### PR TITLE
Shows pipelinerun logs

### DIFF
--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -17,14 +17,20 @@ package cli
 import (
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	k8s "k8s.io/client-go/kubernetes"
 )
+
+type Clients struct {
+	Tekton versioned.Interface
+	Kube   k8s.Interface
+}
 
 // Params interface provides
 type Params interface {
-	// SetKubeConfigPath uses the kubeconfig path to instantiate clientset
+	// SetKubeConfigPath uses the kubeconfig path to instantiate tekton
 	// returned by Clientset function
 	SetKubeConfigPath(string)
-	Clientset() (versioned.Interface, error)
+	Clients() (*Clients, error)
 
 	// SetNamespace can be used to store the namespace parameter that is needed
 	// by most commands

--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -67,12 +67,12 @@ func listCommand(p cli.Params) *cobra.Command {
 
 func printPipelineDetails(out io.Writer, p cli.Params) error {
 
-	cs, err := p.Clientset()
+	cs, err := p.Clients()
 	if err != nil {
 		return err
 	}
 
-	ps, prs, err := listPipelineDetails(cs, p.Namespace())
+	ps, prs, err := listPipelineDetails(cs.Tekton, p.Namespace())
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to list pipelines from %s namespace\n", p.Namespace())
@@ -115,12 +115,12 @@ func printPipelineDetails(out io.Writer, p cli.Params) error {
 }
 
 func printPipelineListObj(w io.Writer, p cli.Params, f *cliopts.PrintFlags) error {
-	cs, err := p.Clientset()
+	cs, err := p.Clients()
 	if err != nil {
 		return err
 	}
 
-	ps, err := listAllPipelines(cs, p.Namespace())
+	ps, err := listAllPipelines(cs.Tekton, p.Namespace())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pipeline/list_test.go
+++ b/pkg/cmd/pipeline/list_test.go
@@ -21,7 +21,7 @@ import (
 func TestPipelinesList_empty(t *testing.T) {
 
 	cs, _ := pipelinetest.SeedTestData(pipelinetest.Data{})
-	p := &test.Params{Client: cs.Pipeline}
+	p := &test.Params{Tekton: cs.Pipeline}
 
 	pipeline := Command(p)
 	output, err := test.ExecuteCommand(pipeline, "list", "-n", "foo")
@@ -43,7 +43,7 @@ func TestPipelineList_only_pipelines(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	cs, _ := seedPipelines(clock, pipelines, "namespace")
-	p := &test.Params{Client: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 
 	pipeline := Command(p)
 	output, err := test.ExecuteCommand(pipeline, "list", "-n", "namespace")
@@ -95,7 +95,7 @@ func TestPipelinesList_with_single_run(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Client: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 	pipeline := Command(p)
 
 	// -5 : pipeline created
@@ -182,7 +182,7 @@ func TestPipelinesList_latest_run(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Client: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 	pipeline := Command(p)
 
 	clock.Advance(30 * time.Minute)

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -88,7 +88,7 @@ tkn pr list -n foo \n",
 }
 
 func list(p cli.Params, pipeline string) (*v1alpha1.PipelineRunList, error) {
-	cs, err := p.Clientset()
+	cs, err := p.Clients()
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func list(p cli.Params, pipeline string) (*v1alpha1.PipelineRunList, error) {
 		}
 	}
 
-	prc := cs.TektonV1alpha1().PipelineRuns(p.Namespace())
+	prc := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace())
 	prs, err := prc.List(options)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The tektoncd Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pipelinerun
 
 import (
@@ -132,7 +133,7 @@ func TestListPipelineRuns(t *testing.T) {
 
 func TestListPipeline_empty(t *testing.T) {
 	cs, _ := pipelinetest.SeedTestData(pipelinetest.Data{})
-	p := &tu.Params{Client: cs.Pipeline}
+	p := &tu.Params{Tekton: cs.Pipeline}
 
 	pipeline := Command(p)
 	output, err := tu.ExecuteCommand(pipeline, "list", "-n", "ns")
@@ -153,7 +154,7 @@ func command(prs []*v1alpha1.PipelineRun, now time.Time) *cobra.Command {
 
 	cs, _ := pipelinetest.SeedTestData(pipelinetest.Data{PipelineRuns: prs})
 
-	p := &test.Params{Client: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 
 	return Command(p)
 }

--- a/pkg/cmd/pipelinerun/log_test.go
+++ b/pkg/cmd/pipelinerun/log_test.go
@@ -1,0 +1,409 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"bytes"
+	"github.com/tektoncd/cli/pkg/cmd/taskrun"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
+	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/logs"
+	tu "github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
+	"github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_command_has_pipelinerun_arg(t *testing.T) {
+	c := Command(&tu.Params{})
+
+	_, err := tu.ExecuteCommand(c, "logs", "-n", "ns")
+
+	if err == nil {
+		t.Error("Expecting an error but it's empty")
+	}
+}
+
+func Test_pipelinerun_not_found(t *testing.T) {
+	pr := []*v1alpha1.PipelineRun{
+		tb.PipelineRun("output-pipeline-1", "ns",
+			tb.PipelineRunLabel("tekton.dev/pipeline", "output-pipeline-1"),
+			tb.PipelineRunStatus(
+				tb.PipelineRunStatusCondition(apis.Condition{
+					Status: corev1.ConditionFalse,
+					Reason: resources.ReasonFailed,
+				}),
+			),
+		),
+	}
+	cs, _ := test.SeedTestData(test.Data{PipelineRuns: pr})
+	p := &tu.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	c := Command(p)
+	got, _ := tu.ExecuteCommand(c, "logs", "output-pipeline-2", "-n", "ns")
+	expected := msgPRNotFoundErr + " : pipelineruns.tekton.dev \"output-pipeline-2\" not found \n"
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("Unexpected output mismatch: \n%s\n", d)
+	}
+}
+
+func Test_print_pipelinerun_logs(t *testing.T) {
+	var (
+		pipelineName = "output-pipeline"
+		prName       = "output-pipeline-1"
+		prstart      = clockwork.NewFakeClock()
+		ns           = "namespace"
+
+		task1Name    = "output-task"
+		tr1Name      = "output-task-1"
+		tr1StartTime = prstart.Now().Add(20 * time.Second)
+		tr1Pod       = "output-task-pod-123456"
+		tr1Step1Name = "writefile-step"
+		tr1InitStep1 = "credential-initializer-mdzbr"
+		pr2InitStep2 = "place-tools"
+
+		task2Name    = "read-task"
+		tr2Name      = "read-task-1"
+		tr2StartTime = prstart.Now().Add(2 * time.Minute)
+		tr2Pod       = "read-task-pod-123456"
+		tr2Step1Name = "readfile-step"
+
+		nopStep = "nop"
+	)
+
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun(tr1Name, ns,
+			tb.TaskRunStatus(
+				tb.PodName(tr1Pod),
+				tb.TaskRunStartTime(tr1StartTime),
+				tb.Condition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}),
+				tb.StepState(
+					cb.StepName(tr1Step1Name),
+					tb.StateTerminated(0),
+				),
+				tb.StepState(
+					cb.StepName(nopStep),
+					tb.StateTerminated(0),
+				),
+			),
+		),
+		tb.TaskRun(tr2Name, ns,
+			tb.TaskRunStatus(
+				tb.PodName(tr2Pod),
+				tb.TaskRunStartTime(tr2StartTime),
+				tb.Condition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}),
+				tb.StepState(
+					cb.StepName(tr2Step1Name),
+					tb.StateTerminated(0),
+				),
+				tb.StepState(
+					cb.StepName(nopStep),
+					tb.StateTerminated(0),
+				),
+			),
+		),
+	}
+
+	prtrs := map[string]*v1alpha1.PipelineRunTaskRunStatus{
+		tr1Name: {
+			PipelineTaskName: task1Name,
+			Status:           &trs[0].Status,
+		},
+		tr2Name: {
+			PipelineTaskName: task2Name,
+			Status:           &trs[1].Status,
+		},
+	}
+
+	prs := []*v1alpha1.PipelineRun{
+		tb.PipelineRun(prName, ns,
+			tb.PipelineRunLabel("tekton.dev/pipeline", prName),
+			tb.PipelineRunStatus(
+				tb.PipelineRunStatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+				tb.PipelineRunTaskRunsStatus(
+					prtrs,
+				),
+			),
+		),
+	}
+
+	pps := []*v1alpha1.Pipeline{
+		tb.Pipeline(pipelineName, ns,
+			tb.PipelineSpec(
+				tb.PipelineTask(task1Name, task1Name),
+				tb.PipelineTask(task2Name, task2Name),
+			),
+		),
+	}
+
+	pods := []*corev1.Pod{
+		tb.Pod(tr1Pod, ns,
+			tb.PodLabel("tekton.dev/task", pipelineName),
+			tb.PodSpec(
+				tb.PodInitContainer(taskrun.ContainerNameForStep(tr1InitStep1), "override-with-creds:latest"),
+				tb.PodInitContainer(taskrun.ContainerNameForStep(pr2InitStep2), "override-with-tools:latest"),
+				tb.PodContainer(taskrun.ContainerNameForStep(tr1Step1Name), tr1Step1Name+":latest"),
+				tb.PodContainer(nopStep, "override-with-nop:latest"),
+			),
+			cb.PodStatus(
+				cb.PodInitContainerStatus(taskrun.ContainerNameForStep(tr1InitStep1), "override-with-creds:latest"),
+				cb.PodInitContainerStatus(taskrun.ContainerNameForStep(pr2InitStep2), "override-with-tools:latest"),
+			),
+		),
+		tb.Pod(tr2Pod, ns,
+			tb.PodLabel("tekton.dev/task", pipelineName),
+			tb.PodSpec(
+				tb.PodContainer(taskrun.ContainerNameForStep(tr2Step1Name), tr1Step1Name+":latest"),
+				tb.PodContainer(nopStep, "override-with-nop:latest"),
+			),
+		),
+	}
+
+	fakeLogStream := logs.Pipeline(
+		logs.Task(task1Name, tr1Pod,
+			logs.Step(tr1InitStep1, taskrun.ContainerNameForStep(tr1InitStep1),
+				"initialized the credentials",
+			),
+			logs.Step(pr2InitStep2, taskrun.ContainerNameForStep(pr2InitStep2),
+				"place tools log",
+			),
+			logs.Step(tr1Step1Name, taskrun.ContainerNameForStep(tr1Step1Name),
+				"written a file",
+			),
+			logs.Step(nopStep, nopStep,
+				"Build successful",
+			),
+		),
+		logs.Task(task2Name, tr2Pod,
+			logs.Step(tr2Step1Name, taskrun.ContainerNameForStep(tr2Step1Name),
+				"able to read a file",
+			),
+			logs.Step(nopStep, nopStep,
+				"Build successful",
+			),
+		),
+	)
+
+	scenarios := []struct {
+		name         string
+		allSteps     bool
+		tasks        []string
+		expectedLogs []string
+	}{
+		{
+			name:     "all task logs",
+			allSteps: false,
+			expectedLogs: []string{
+				"[output-task : writefile-step] written a file",
+				"[output-task : nop] Build successful",
+				"[read-task : readfile-step] able to read a file",
+				"[read-task : nop] Build successful",
+			},
+		}, {
+			name:     "task1 logs only",
+			allSteps: false,
+			tasks:    []string{task1Name},
+			expectedLogs: []string{
+				"[output-task : writefile-step] written a file",
+				"[output-task : nop] Build successful",
+			},
+		}, {
+			name:     "all steps logs",
+			allSteps: true,
+			expectedLogs: []string{
+				"[output-task : credential-initializer-mdzbr] initialized the credentials",
+				"[output-task : place-tools] place tools log",
+				"[output-task : writefile-step] written a file",
+				"[output-task : nop] Build successful",
+				"[read-task : readfile-step] able to read a file",
+				"[read-task : nop] Build successful",
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			cs, _ := test.SeedTestData(test.Data{PipelineRuns: prs, Pipelines: pps, TaskRuns: trs, Pods: pods})
+
+			plr := fakePipelineRunLogs(prName, ns, cs)
+			output := fetchLogs(plr, LogOpts(s.allSteps, s.tasks...), logs.FakeLogFetcher(cs.Kube, fakeLogStream))
+
+			expected := strings.Join(s.expectedLogs, "\n") + "\n"
+
+			if d := cmp.Diff(output, expected); d != "" {
+				t.Errorf("Unexpected output mismatch: \n%s\n", d)
+			}
+		})
+	}
+}
+
+// scenario, print logs for 1 completed taskruns out of 4 pipeline tasks
+func Test_print_valid_taskrun_logs(t *testing.T) {
+	var (
+		pipelineName = "output-pipeline"
+		prName       = "output-pipeline-1"
+		prstart      = clockwork.NewFakeClock()
+		ns           = "namespace"
+
+		task1Name    = "output-task"
+		tr1Name      = "output-task-1"
+		tr1StartTime = prstart.Now().Add(20 * time.Second)
+		tr1Pod       = "output-task-pod-123456"
+		tr1Step1Name = "writefile-step"
+
+		// these are pipeline tasks for which pipeline has not
+		// scheduled any taskrun
+		task2Name = "read-task"
+
+		task3Name = "notify"
+
+		task4Name = "teardown"
+	)
+
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun(tr1Name, ns,
+			tb.TaskRunStatus(
+				tb.PodName(tr1Pod),
+				tb.TaskRunStartTime(tr1StartTime),
+				tb.Condition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}),
+				tb.StepState(
+					cb.StepName(tr1Step1Name),
+					tb.StateTerminated(0),
+				),
+				tb.StepState(
+					cb.StepName("nop"),
+					tb.StateTerminated(0),
+				),
+			),
+		),
+	}
+
+	prtrs := map[string]*v1alpha1.PipelineRunTaskRunStatus{
+		tr1Name: {
+			PipelineTaskName: task1Name,
+			Status:           &trs[0].Status,
+		},
+	}
+
+	prs := []*v1alpha1.PipelineRun{
+		tb.PipelineRun(prName, ns,
+			tb.PipelineRunLabel("tekton.dev/pipeline", prName),
+			tb.PipelineRunStatus(
+				tb.PipelineRunStatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonRunning,
+				}),
+				tb.PipelineRunTaskRunsStatus(
+					prtrs,
+				),
+			),
+		),
+	}
+
+	pps := []*v1alpha1.Pipeline{
+		tb.Pipeline(pipelineName, ns,
+			tb.PipelineSpec(
+				tb.PipelineTask(task1Name, task1Name),
+				tb.PipelineTask(task2Name, task2Name),
+				tb.PipelineTask(task3Name, task3Name),
+				tb.PipelineTask(task4Name, task4Name),
+			),
+		),
+	}
+
+	pods := []*corev1.Pod{
+		tb.Pod(tr1Pod, ns,
+			tb.PodLabel("tekton.dev/task", pipelineName),
+			tb.PodSpec(
+				tb.PodContainer(taskrun.ContainerNameForStep(tr1Step1Name), tr1Step1Name+":latest"),
+				tb.PodContainer("nop", "override-with-nop:latest"),
+			),
+		),
+	}
+
+	fakeLogStream := logs.Pipeline(
+		logs.Task(task1Name, tr1Pod,
+			logs.Step(tr1Step1Name, taskrun.ContainerNameForStep(tr1Step1Name),
+				"written a file",
+			),
+			logs.Step("nop", "nop",
+				"Build successful",
+			),
+		),
+	)
+
+	cs, _ := test.SeedTestData(test.Data{PipelineRuns: prs, Pipelines: pps, TaskRuns: trs, Pods: pods})
+	plr := fakePipelineRunLogs(prName, ns, cs)
+
+	output := fetchLogs(plr, LogOpts(false), logs.FakeLogFetcher(cs.Kube, fakeLogStream))
+	expectedLogs := []string{
+		"[output-task : writefile-step] written a file",
+		"[output-task : nop] Build successful",
+	}
+
+	expected := strings.Join(expectedLogs, "\n") + "\n"
+
+	if d := cmp.Diff(output, expected); d != "" {
+		t.Errorf("Unexpected output mismatch: \n%s\n", d)
+	}
+
+}
+
+func LogOpts(allSteps bool, tasks ...string) LogOptions {
+	return LogOptions{
+		LogOptions: taskrun.LogOptions{
+			AllSteps: allSteps,
+		},
+		Tasks: tasks,
+	}
+}
+
+func fakePipelineRunLogs(name string, ns string, cs test.Clients) *PipelineRunLogs {
+	return NewPipelineRunLogs(name, ns,
+		&cli.Clients{
+			Tekton: cs.Pipeline,
+			Kube:   cs.Kube,
+		})
+}
+
+func fetchLogs(plr *PipelineRunLogs, opt LogOptions, fetcher *logs.LogFetcher) string {
+	out := new(bytes.Buffer)
+
+	plr.Fetch(logs.Streams{out, out}, opt, fetcher)
+
+	return out.String()
+}

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -1,0 +1,216 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cmd/taskrun"
+	"github.com/tektoncd/cli/pkg/logs"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	msgPipelineNotFoundErr = "Error in retrieving Pipeline"
+	msgPRNotFoundErr       = "Error in retrieving PipelineRun"
+)
+
+type taskRunMap map[string]*v1alpha1.PipelineRunTaskRunStatus
+
+type PipelineRunLogs struct {
+	Name    string
+	Ns      string
+	Clients *cli.Clients
+}
+
+type taskRun struct {
+	name string
+	task string
+}
+
+type LogOptions struct {
+	taskrun.LogOptions
+	Tasks []string
+}
+
+func logCommand(p cli.Params) *cobra.Command {
+	var (
+		allSteps  bool
+		onlyTasks []string
+		eg        = `
+  # show the logs of PipelineRun named "foo" from the namesspace "bar"
+    tkn pipelinerun logs foo -n bar
+
+  # show the logs of PipelineRun named "microservice-1" for task "build" only, from the namespace "bar"
+    tkn pr logs microservice-1 -t build -n bar
+
+  # show the logs of PipelineRun named "microservice-1" for all tasks and steps (including init steps), 
+    from the namespace "foo"
+    tkn pr logs microservice-1 -a -n foo
+   `
+	)
+
+	c := &cobra.Command{
+		Use:                   "logs",
+		DisableFlagsInUseLine: true,
+		Short:                 "Show the logs of PipelineRun",
+		Example:               eg,
+		Args:                  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prName := args[0]
+
+			cs, err := p.Clients()
+			if err != nil {
+				return err
+			}
+
+			prLogs := NewPipelineRunLogs(prName, p.Namespace(), cs)
+
+			opt := LogOptions{
+				LogOptions: taskrun.LogOptions{
+					AllSteps: allSteps,
+				},
+				Tasks: onlyTasks,
+			}
+
+			s := logs.Streams{
+				Out: cmd.OutOrStderr(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			//TODO: put log fetcher as pipelinerun dependency
+			prLogs.Fetch(s, opt, logs.DefaultLogFetcher(cs.Kube))
+
+			return nil
+		},
+	}
+
+	c.Flags().BoolVarP(&allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
+	c.Flags().StringSliceVarP(&onlyTasks, "only-tasks", "t", []string{}, "show the logs for mentioned task only")
+
+	return c
+}
+
+//NewPipelineRunLogs create a new instance of PipelineRunLogs.
+func NewPipelineRunLogs(pipelineRunName string, namespace string, clients *cli.Clients) *PipelineRunLogs {
+	return &PipelineRunLogs{
+		Name:    pipelineRunName,
+		Ns:      namespace,
+		Clients: clients,
+	}
+}
+
+//Fetch To fetch the PipelineRun's logs.
+//Stream provides output and error stream to print the logs and error messages.
+//LogOptions provide way to print all(init) steps or specified task logs
+func (p *PipelineRunLogs) Fetch(s logs.Streams, opts LogOptions, r *logs.LogFetcher) {
+	var (
+		tkn = p.Clients.Tekton
+	)
+
+	pr, err := tkn.TektonV1alpha1().
+		PipelineRuns(p.Ns).
+		Get(p.Name, metav1.GetOptions{})
+
+	if err != nil {
+		fmt.Fprintf(s.Err, "%s : %s \n", msgPRNotFoundErr, err)
+		return
+	}
+
+	if r, msg := pipelineRunFailed(pr.Status); r == true {
+		fmt.Fprintf(s.Out, "PipelineRun is failed: %s \n", msg)
+	}
+
+	pl, err := tkn.TektonV1alpha1().
+		Pipelines(p.Ns).
+		Get(pr.Spec.PipelineRef.Name, metav1.GetOptions{})
+
+	if err != nil {
+		fmt.Fprintf(s.Err, "%s : %s \n", msgPipelineNotFoundErr, err)
+		return
+	}
+
+	//Sort taskruns, to display the taskrun logs as per pipeline tasks order
+	ordered := orderBy(pl.Spec.Tasks, pr.Status.TaskRuns)
+	taskRuns := filterBy(opts.Tasks, ordered)
+
+	for _, tr := range taskRuns {
+		trl := tr.toTaskRunLogs(p.Ns, p.Clients)
+		trl.Fetch(opts.LogOptions, s, r)
+	}
+
+	return
+}
+
+func pipelineRunFailed(status v1alpha1.PipelineRunStatus) (bool, string) {
+	c := status.Conditions[0]
+	if c.Status == corev1.ConditionFalse {
+		return true, c.Message
+	}
+
+	return false, ""
+}
+
+func orderBy(pipelineTasks []v1alpha1.PipelineTask, pipelinesTaskRuns taskRunMap) []taskRun {
+	trNames := map[string]string{}
+
+	for name, t := range pipelinesTaskRuns {
+		trNames[t.PipelineTaskName] = name
+	}
+
+	trs := []taskRun{}
+	for _, ts := range pipelineTasks {
+		if n, ok := trNames[ts.Name]; ok {
+			trs = append(trs, taskRun{
+				task: ts.Name,
+				name: n,
+			})
+		}
+	}
+
+	return trs
+}
+
+func filterBy(ts []string, trs []taskRun) []taskRun {
+	if len(ts) == 0 {
+		return trs
+	}
+
+	filter := map[string]bool{}
+	for _, t := range ts {
+		filter[t] = true
+	}
+
+	filtered := []taskRun{}
+	for _, tr := range trs {
+		if filter[tr.task] {
+			filtered = append(filtered, tr)
+		}
+	}
+
+	return filtered
+}
+
+func (t taskRun) toTaskRunLogs(namespae string, clientSet *cli.Clients) *taskrun.TaskRunLogs {
+	return &taskrun.TaskRunLogs{
+		Run:     t.name,
+		Task:    t.task,
+		Ns:      namespae,
+		Clients: clientSet,
+	}
+}

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -25,9 +25,10 @@ import (
 //Command instantiates the pipelinerun command
 func Command(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
-		Use:     "pipelineruns",
-		Aliases: []string{"pr", "pipelinerun"},
-		Short:   "Manage pipelineruns",
+		Use:                   "pipelineruns",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"pr", "pipelinerun"},
+		Short:                 "Manage pipelineruns",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},
@@ -42,5 +43,7 @@ func Command(p cli.Params) *cobra.Command {
 
 	flags.AddTektonOptions(c)
 	c.AddCommand(listCommand(p))
+	c.AddCommand(logCommand(p))
+
 	return c
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,8 +28,7 @@ func Root(p cli.Params) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "tkn",
 		Short: "CLI for tekton pipelines",
-		Long: `
-	`,
+		Long:  ``,
 	}
 
 	cmd.AddCommand(

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -35,7 +35,6 @@ const (
 	emptyMsg = "No tasks found"
 	header   = "NAME\tAGE"
 	body     = "%s\t%s\n"
-	blank    = "---"
 )
 
 func listCommand(p cli.Params) *cobra.Command {
@@ -67,12 +66,12 @@ func listCommand(p cli.Params) *cobra.Command {
 
 func printTaskDetails(out io.Writer, p cli.Params) error {
 
-	cs, err := p.Clientset()
+	cs, err := p.Clients()
 	if err != nil {
 		return err
 	}
 
-	tasks, err := listTaskDetails(cs, p.Namespace())
+	tasks, err := listTaskDetails(cs.Tekton, p.Namespace())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to list tasks from %s namespace\n", p.Namespace())
 		return err
@@ -97,12 +96,12 @@ func printTaskDetails(out io.Writer, p cli.Params) error {
 }
 
 func printTaskListObj(w io.Writer, p cli.Params, f *cliopts.PrintFlags) error {
-	cs, err := p.Clientset()
+	cs, err := p.Clients()
 	if err != nil {
 		return err
 	}
 
-	tasks, err := listAllTasks(cs, p.Namespace())
+	tasks, err := listAllTasks(cs.Tekton, p.Namespace())
 
 	if err != nil {
 		return err

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestTaskListEmpty(t *testing.T) {
 	cs, _ := pipelinetest.SeedTestData(pipelinetest.Data{})
-	p := &test.Params{Client: cs.Pipeline}
+	p := &test.Params{Tekton: cs.Pipeline}
 
 	task := Command(p)
 	output, err := test.ExecuteCommand(task, "list", "-n", "foo")
@@ -52,7 +52,7 @@ func TestTaskListOnlyTasks(t *testing.T) {
 	}
 
 	cs, _ := pipelinetest.SeedTestData(pipelinetest.Data{Tasks: tasks})
-	p := &test.Params{Client: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 
 	task := Command(p)
 	output, err := test.ExecuteCommand(task, "list", "-n", "namespace")

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -88,7 +88,7 @@ tkn pr list -n foo \n",
 }
 
 func list(p cli.Params, task string) (*v1alpha1.TaskRunList, error) {
-	cs, err := p.Clientset()
+	cs, err := p.Clients()
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func list(p cli.Params, task string) (*v1alpha1.TaskRunList, error) {
 		}
 	}
 
-	trc := cs.TektonV1alpha1().TaskRuns(p.Namespace())
+	trc := cs.Tekton.TektonV1alpha1().TaskRuns(p.Namespace())
 	trs, err := trc.List(options)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package taskrun
 
 import (
@@ -141,7 +142,7 @@ func command(trs []*v1alpha1.TaskRun, now time.Time) *cobra.Command {
 
 	cs, _ := pipelinetest.SeedTestData(pipelinetest.Data{TaskRuns: trs})
 
-	p := &test.Params{Client: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 
 	return Command(p)
 }

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -1,0 +1,137 @@
+// Copyright © 2019 The Knative Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskrun
+
+import (
+	"fmt"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/logs"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/taskrun/resources"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	msgTRNotFoundErr = "Error in retrieving Taskrun : "
+)
+
+type TaskRunLogs struct {
+	Task    string
+	Run     string
+	Ns      string
+	Clients *cli.Clients
+}
+
+type LogOptions struct {
+	AllSteps bool
+}
+
+//Fetch To fetch the TaskRun's logs.
+//Stream provides output and error stream to print the logs and error messages.
+//LogOptions provide way to print all(init) steps
+func (trl *TaskRunLogs) Fetch(flags LogOptions, stream logs.Streams, reader *logs.LogFetcher) {
+	var (
+		kube   = trl.Clients.Kube
+		tekton = trl.Clients.Tekton
+	)
+
+	tr, err := tekton.TektonV1alpha1().
+		TaskRuns(trl.Ns).
+		Get(trl.Run, v1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(stream.Err, "%s : %s \n", msgTRNotFoundErr, err)
+		return
+	}
+
+	trStatus := tr.Status
+	if !taskRunHasStarted(trStatus) {
+		fmt.Fprintf(stream.Out, "Task %s has not started yet \n", trl.Task)
+		return
+	}
+
+	pod, err := kube.CoreV1().
+		Pods(trl.Ns).
+		Get(trStatus.PodName, v1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(stream.Err, "Error in getting pod: %s \n", err)
+		return
+	}
+
+	if !podHasStarted(pod) {
+		fmt.Fprintf(stream.Out, "Task %s pod %s has not started yet \n", trl.Task, trStatus.PodName)
+		return
+	}
+
+	steps := filterSteps(trStatus, pod, flags.AllSteps)
+
+	for _, step := range steps {
+		if !stepHasStarted(step) {
+			fmt.Fprintf(stream.Out, "Step %s has not started yet \n", trl.Task)
+			continue
+		}
+
+		pl := logs.NewPodLogs(trStatus.PodName, trl.Ns, reader)
+		err := pl.Fetch(stream, ContainerNameForStep(step.Name), func(s string) string {
+			return fmt.Sprintf("[%s : %s] %s", trl.Task, step.Name, s)
+		})
+
+		if err != nil {
+			fmt.Fprintf(stream.Err, "Error in printing logs for the %s : %s \n", step.Name, err)
+		}
+
+		fmt.Fprint(stream.Out, "\n")
+	}
+}
+
+func podHasStarted(pod *corev1.Pod) bool {
+	return !(pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodUnknown)
+}
+
+func taskRunHasStarted(trStatus v1alpha1.TaskRunStatus) bool {
+	return trStatus.StartTime != nil && !trStatus.StartTime.IsZero()
+}
+
+func filterSteps(trStatus v1alpha1.TaskRunStatus, pod *corev1.Pod, allSteps bool) []v1alpha1.StepState {
+	if !allSteps {
+		return trStatus.Steps
+	}
+
+	initSteps := []v1alpha1.StepState{}
+	for _, ics := range pod.Status.InitContainerStatuses {
+		initSteps = append(initSteps, v1alpha1.StepState{
+			ContainerState: *ics.State.DeepCopy(),
+			Name:           resources.TrimContainerNamePrefix(ics.Name),
+		})
+	}
+	//append normal steps to preserve the order
+	initSteps = append(initSteps, trStatus.Steps...)
+
+	return initSteps
+}
+
+func stepHasStarted(stepState v1alpha1.StepState) bool {
+	return stepState.ContainerState.Waiting == nil
+}
+
+//TODO: anonymous steps?
+func ContainerNameForStep(name string) string {
+	switch name {
+	case "nop":
+		return "nop"
+	default:
+		return "build-step-" + name
+	}
+}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -50,7 +50,7 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 	p.SetKubeConfigPath(kcPath)
 
 	// ensure that the config is valid by creating a client
-	if _, err := p.Clientset(); err != nil {
+	if _, err := p.Clients(); err != nil {
 		return err
 	}
 

--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -5,7 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Condition returns a human readable text based on the Status of the Condition
+// Condition returns a human readable text based on the status of the Condition
 func Condition(c apis.Condition) string {
 	var status string
 	switch c.Status {

--- a/pkg/logs/fakelog.go
+++ b/pkg/logs/fakelog.go
@@ -1,0 +1,100 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type logs []task
+
+type step struct {
+	name      string
+	container string
+	logs      []string
+}
+
+type task struct {
+	name  string
+	pod   string
+	steps []step
+}
+
+type FakePodStream struct {
+	logs logs
+	pods typedv1.PodInterface
+}
+
+func FakeLogFetcher(kubeClient k8s.Interface, fakeStreamer FakePodStream) *LogFetcher {
+	return &LogFetcher{
+		kube: kubeClient,
+		streamer: func(pods typedv1.PodInterface) PodLogStreamer {
+			fakeStreamer.pods = pods
+			return &fakeStreamer
+		},
+	}
+}
+
+func (p *FakePodStream) Stream(name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+	for _, t := range p.logs {
+		if t.pod != name {
+			continue
+		}
+
+		for _, s := range t.steps {
+			if s.container == opts.Container {
+				log := strings.Join(s.logs, "\n")
+				return ioutil.NopCloser(strings.NewReader(log)), nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("Failed to stream container logs \n")
+}
+
+func Pipeline(pl ...task) FakePodStream {
+	logs := logs{}
+
+	for _, t := range pl {
+		logs = append(logs, t)
+	}
+
+	return FakePodStream{
+		logs: logs,
+	}
+}
+
+func Task(name string, podName string, steps ...step) task {
+	return task{
+		name:  name,
+		pod:   podName,
+		steps: steps,
+	}
+}
+
+func Step(name string, container string, logs ...string) step {
+	return step{
+		name:      name,
+		container: container,
+		logs:      logs,
+	}
+}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -1,0 +1,132 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type PodLogStreamer interface {
+	Stream(name string, opts *corev1.PodLogOptions) (io.ReadCloser, error)
+}
+
+type LogStreamFunc func(pods typedv1.PodInterface) PodLogStreamer
+
+type PodsStream struct {
+	pods typedv1.PodInterface
+}
+
+type LogFetcher struct {
+	kube     k8s.Interface
+	streamer LogStreamFunc
+}
+
+type PodLogs struct {
+	pod     string
+	ns      string
+	fetcher *LogFetcher
+}
+
+type Streams struct {
+	Out io.Writer
+	Err io.Writer
+}
+
+//Stream Creates a stream object which allows reading the logs
+func (p *PodsStream) Stream(name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+	return p.pods.GetLogs(name, opts).Stream()
+}
+
+func defaultStreamer(pods typedv1.PodInterface) PodLogStreamer {
+	return &PodsStream{pods}
+}
+
+//DefaultLogFetcher Returns a new instance of LogFetcher
+func DefaultLogFetcher(kubeClient k8s.Interface) *LogFetcher {
+	return &LogFetcher{
+		kube:     kubeClient,
+		streamer: defaultStreamer,
+	}
+}
+
+//NewPodLogs Returns a new instance of PodLog
+func NewPodLogs(podName string, namespace string, logfetcher *LogFetcher) *PodLogs {
+	return &PodLogs{
+		pod:     podName,
+		ns:      namespace,
+		fetcher: logfetcher,
+	}
+}
+
+//Fetch streams the logs for given pod container.
+//Format callback function allows an API consumer to format the log statement.
+// e.g. prefix some string before log statement
+func (p *PodLogs) Fetch(s Streams, container string, format func(s string) string) error {
+	var (
+		kube     = p.fetcher.kube
+		streamer = p.fetcher.streamer
+		pod      = p.pod
+	)
+
+	pods := kube.CoreV1().
+		Pods(p.ns)
+
+	if pods == nil {
+		return fmt.Errorf("Error in getting pods \n")
+	}
+
+	opts := corev1.PodLogOptions{
+		Follow:    false,
+		Container: container,
+	}
+
+	logStream, err := streamer(pods).
+		Stream(pod, &opts)
+	if err != nil {
+		return fmt.Errorf("Error in getting logs for the %s : %s \n", pod, err)
+	}
+	defer logStream.Close()
+
+	if format == nil {
+		format = func(s string) string {
+			return s
+		}
+	}
+
+	r := bufio.NewReader(logStream)
+	for {
+		line, err := r.ReadString('\n')
+		if err == io.EOF {
+			if len(line) > 0 {
+				fmt.Fprint(s.Out, format(line))
+			}
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprint(s.Out, format(line))
+	}
+
+	return nil
+}

--- a/pkg/test/builder/pod.go
+++ b/pkg/test/builder/pod.go
@@ -1,0 +1,45 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type PodStatusOp func(*corev1.PodStatus)
+
+// PodStatus creates a Status with default values.
+// Any number of PodStatus modifiers can be passed to transform it.
+func PodStatus(ops ...PodStatusOp) tb.PodOp {
+	return func(pod *corev1.Pod) {
+		podStatus := &pod.Status
+		for _, op := range ops {
+			op(podStatus)
+		}
+		pod.Status = *podStatus
+	}
+}
+
+// PodInitContainerStatus creates new ContainerStatus
+func PodInitContainerStatus(name, image string) PodStatusOp {
+	return func(status *corev1.PodStatus) {
+		cs := corev1.ContainerStatus{
+			Name:  name,
+			Image: image,
+		}
+		status.InitContainerStatuses = append(status.InitContainerStatuses, cs)
+	}
+}

--- a/pkg/test/builder/taskrun.go
+++ b/pkg/test/builder/taskrun.go
@@ -14,3 +14,10 @@ func TaskRunCompletionTime(ct time.Time) tb.TaskRunStatusOp {
 		s.CompletionTime = &metav1.Time{Time: ct}
 	}
 }
+
+// StepName adds a state to stepstate of TaskRunStatus.
+func StepName(name string) tb.StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.Name = name
+	}
+}

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -18,12 +18,15 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
 type Params struct {
 	ns, kc string
-	Client versioned.Interface
+	Tekton versioned.Interface
+	Kube   k8s.Interface
 	Clock  clockwork.Clock
+	Cls    *cli.Clients
 }
 
 var _ cli.Params = &Params{}
@@ -43,8 +46,35 @@ func (p *Params) KubeConfigPath() string {
 	return p.kc
 }
 
-func (p *Params) Clientset() (versioned.Interface, error) {
-	return p.Client, nil
+func (p *Params) tektonClient() (versioned.Interface, error) {
+	return p.Tekton, nil
+}
+
+func (p *Params) kubeClient() (k8s.Interface, error) {
+	return p.Kube, nil
+}
+
+func (p *Params) Clients() (*cli.Clients, error) {
+	if p.Cls != nil {
+		return p.Cls, nil
+	}
+
+	tekton, err := p.tektonClient()
+	if err != nil {
+		return nil, err
+	}
+
+	kube, err := p.kubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	p.Cls = &cli.Clients{
+		Tekton: tekton,
+		Kube:   kube,
+	}
+
+	return p.Cls, nil
 }
 
 func (p *Params) Time() clockwork.Clock {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Adds subcommand, to show the pipelinerun logs

```
09:26 $ ./tkn pr logs output-pipeline-run -n test
[first-create-file : git-source-skaffold-git-qn42p] {"level":"warn","ts":1557744960.2213447,"logger":"fallback-logger","caller":"logging/config.go:65","msg":"Fetch GitHub commit ID from kodata failed: \"ref: refs/heads/master\" is not a valid GitHub commit ID"}
[first-create-file : git-source-skaffold-git-qn42p] {"level":"info","ts":1557744966.9072747,"logger":"fallback-logger","caller":"git/git.go:105","msg":"Successfully cloned https://github.com/GoogleContainerTools/skaffold @ master in path /workspace/damnworkspace"}

.....................
```

- pipelinerun log command refactoring:
  * extract logging pieces into pipelinerun, taskrun and pod
    packages
- param interface refactoring:
  * Clientset()(Clients()) returns both tekton and kubernets
    in one object
  * Replaces clientset() usage accross all commands

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
To fetch the logs from pipelinerun "foo-pipelinerun-1" from the namespace "bar"
./tkn pr logs <pipeline-run-name> -n <namepsace>
```
