### PR TITLE
Improve flags design

### DIFF
--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -27,11 +27,6 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "pipeline",
 		Aliases: []string{"p", "pipelines"},
 		Short:   "Manage pipelines",
-
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("pipeline requires a subcommand; see help")
@@ -40,7 +35,12 @@ func Command(p cli.Params) *cobra.Command {
 		},
 	}
 
-	flags.AddTektonOptions(cmd)
+	cmd.PersistentPreRunE = flags.InitParams(
+		p,
+		flags.FromKubeConfig(cmd),
+		flags.FromNamespace(cmd, flags.Options{Required: true}),
+	)
+
 	cmd.AddCommand(listCommand(p))
 	return cmd
 }

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -24,13 +24,10 @@ import (
 
 //Command instantiates the pipelinerun command
 func Command(p cli.Params) *cobra.Command {
-	c := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "pipelineruns",
 		Aliases: []string{"pr", "pipelinerun"},
 		Short:   "Manage pipelineruns",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("pipelinerun requires a subcommand; see help and examples")
@@ -40,7 +37,12 @@ func Command(p cli.Params) *cobra.Command {
 		},
 	}
 
-	flags.AddTektonOptions(c)
-	c.AddCommand(listCommand(p))
-	return c
+	cmd.PersistentPreRunE = flags.InitParams(
+		p,
+		flags.FromKubeConfig(cmd),
+		flags.FromNamespace(cmd, flags.Options{Required: true}),
+	)
+
+	cmd.AddCommand(listCommand(p))
+	return cmd
 }

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -28,10 +28,6 @@ func Command(p cli.Params) *cobra.Command {
 		Aliases: []string{"t", "tasks"},
 		Short:   "Manage tasks",
 
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("task requires a subcommand; see help")
@@ -40,7 +36,12 @@ func Command(p cli.Params) *cobra.Command {
 		},
 	}
 
-	flags.AddTektonOptions(cmd)
+	cmd.PersistentPreRunE = flags.InitParams(
+		p,
+		flags.FromKubeConfig(cmd),
+		flags.FromNamespace(cmd, flags.Options{Required: true}),
+	)
+
 	cmd.AddCommand(listCommand(p))
 	return cmd
 }

--- a/pkg/cmd/taskrun/taskrun.go
+++ b/pkg/cmd/taskrun/taskrun.go
@@ -28,10 +28,6 @@ func Command(p cli.Params) *cobra.Command {
 		Aliases: []string{"tr", "taskruns"},
 		Short:   "Manage taskruns",
 
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("taskrun requires a subcommand; see help")
@@ -40,7 +36,12 @@ func Command(p cli.Params) *cobra.Command {
 		},
 	}
 
-	flags.AddTektonOptions(cmd)
+	cmd.PersistentPreRunE = flags.InitParams(
+		p,
+		flags.FromKubeConfig(cmd),
+		flags.FromNamespace(cmd, flags.Options{Required: true}),
+	)
+
 	cmd.AddCommand(listCommand(p))
 	return cmd
 }


### PR DESCRIPTION
# Changes

Previously, to use `pkg/flags` to initialize `cli.Params`
from `cobra.Command.Flags()` the pattern used to that the
caller uses `AddTektonOptions` that added the flags to the `cmd`
and in the PersistentPreRun, the caller had to invoke `flags.InitParams()`

There were 2 things that stood out about this pattern
  1. The caller had to know the implementation details
     of `AddTektonOptions`
  2. There was a disconnect between adding flags and initializing
     `cli.Params`

This is improved in the current design where both the points are
addressed by having it done in a single place. e.g.

```go

cmd.PersistentPreRunE = flags.InitParams(
  p,
  flags.FromKubeConfig(cmd, opts),
  flags.FromNamespace(cmd, opts),
)
```

This also allows only certain flags to be added to a command.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [:no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [:no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
release-note
```
