### PR TITLE
fixes completion command help formatting

### DIFF
--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -18,28 +18,31 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/tektoncd/cli/pkg/cli"
 )
 
-func Command(cli.Params) *cobra.Command {
-	var cmd = &cobra.Command{
-		Use:   "completion SHELL",
-		Short: "Prints shell completion scripts",
-		Long: `
-	This command prints shell completion code which must be evaluated to provide interactive completion
+const(
+	desc = `
+This command prints shell completion code which must be evaluatedto provide 
+interactive completion
 
-	Supported Shells:
-		- bash
-	`,
+Supported Shells:
+	- bash
+`
+	eg = `
+  # generate completion code for bash
+  tkn completion bash > bash_completion.sh
+  source bash_completion.sh
+`
+)
+func Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:       "completion SHELL",
+		Short:     "Prints shell completion scripts",
+		Long:      desc,
 		Args:      exactValidArgs(1),
 		ValidArgs: []string{"bash"},
-		Example: `
-		# generate completion code for bash
-		tkn completion bash > bash_completion.sh
-		source bash_completion.sh
-		`,
+		Example:   eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			switch args[0] {
 			case "bash":
 				return cmd.Root().GenBashCompletion(os.Stdout)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -33,7 +33,7 @@ func Root(p cli.Params) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		completion.Command(p),
+		completion.Command(),
 		pipeline.Command(p),
 		pipelinerun.Command(p),
 		task.Command(p),


### PR DESCRIPTION
# Changes

There is a minor issue with completion
command help message indentation.

This patch fixes the indentation as well as
removes the unwanted validation  messages.

fixes https://github.com/tektoncd/cli/issues/32

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

