### PR TITLE
Fixes command name and description inconsistency

### DIFF
--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -48,7 +48,7 @@ tkn pr list -n foo \n",
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List the pipelineruns",
+		Short:   "Lists pipelineruns in a namespace",
 		Example: eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var pipeline string

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -25,9 +25,9 @@ import (
 //Command instantiates the pipelinerun command
 func Command(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "pipelineruns",
+		Use:                   "pipelinerun",
 		DisableFlagsInUseLine: true,
-		Aliases:               []string{"pr", "pipelinerun"},
+		Aliases:               []string{"pr", "pipelineruns"},
 		Short:                 "Manage pipelineruns",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -48,7 +48,7 @@ tkn pr list -n foo \n",
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List the taskruns",
+		Short:   "Lists taskruns in a namespace",
 		Example: eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var task string


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Changes
For `pipelinerun` command, the name is displayed as
`pipelineruns` which is a plural form.

This patch fixes the command name and also brings the
the description consistency across other commands

Fixes https://github.com/tektoncd/cli/issues/35
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

