### PR TITLE
Proper OS exit status when a failure occures when listing

### DIFF
--- a/cmd/tkn/main.go
+++ b/cmd/tkn/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/tektoncd/cli/pkg/cli"
@@ -29,7 +28,6 @@ func main() {
 	tkn := cmd.Root(tp)
 
 	if err := tkn.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -42,10 +42,11 @@ func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 
 	c := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "Lists pipelines in a namespace",
-		Long:    ``,
+		Use:          "list",
+		Aliases:      []string{"ls"},
+		Short:        "Lists pipelines in a namespace",
+		Long:         ``,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
@@ -80,8 +81,7 @@ func printPipelineDetails(out io.Writer, p cli.Params) error {
 	}
 
 	if len(ps.Items) == 0 {
-		fmt.Fprintln(out, emptyMsg)
-		return nil
+		return fmt.Errorf(emptyMsg)
 	}
 
 	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/cmd/pipeline/list_test.go
+++ b/pkg/cmd/pipeline/list_test.go
@@ -24,12 +24,12 @@ func TestPipelinesList_empty(t *testing.T) {
 	p := &test.Params{Tekton: cs.Pipeline}
 
 	pipeline := Command(p)
-	output, err := test.ExecuteCommand(pipeline, "list", "-n", "foo")
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+	_, err := test.ExecuteCommand(pipeline, "list", "-n", "foo")
+	if err == nil {
+		t.Errorf("No errors was defined")
 	}
-	expected := emptyMsg + "\n"
-	if d := cmp.Diff(expected, output); d != "" {
+
+	if d := cmp.Diff(emptyMsg, err.Error()); d != "" {
 		t.Errorf("Unexpected output mismatch: %s", d)
 	}
 }

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -78,8 +78,7 @@ func printTaskDetails(out io.Writer, p cli.Params) error {
 	}
 
 	if len(tasks.Items) == 0 {
-		fmt.Fprintln(out, emptyMsg)
-		return nil
+		return fmt.Errorf(emptyMsg)
 	}
 
 	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -33,12 +33,11 @@ func TestTaskListEmpty(t *testing.T) {
 	p := &test.Params{Tekton: cs.Pipeline}
 
 	task := Command(p)
-	output, err := test.ExecuteCommand(task, "list", "-n", "foo")
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+	_, err := test.ExecuteCommand(task, "list", "-n", "foo")
+	if err == nil {
+		t.Errorf("No errors was defined")
 	}
-	expected := emptyMsg + "\n"
-	if d := cmp.Diff(expected, output); d != "" {
+	if d := cmp.Diff(emptyMsg, err.Error()); d != "" {
 		t.Errorf("Unexpected output mismatch: %s", d)
 	}
 }


### PR DESCRIPTION
# Changes

We were just fprintFing when there was a failure but not returning
properly as error to cobra which would fail OS exit return codes

The problem with this was that cobra would print the whole command usage and our message
would get lost along the way, so we use the SilenceUsage flag to silence
it.

cobra takes care of printing error message so we don't have to do it twice in
main.go too

Errors would still get printed when the user doesn't provide the right/needed
flags.

There is still other subcommands to transform like pipeline/describe but I believe it's been worked on atm by @pgarg and can be updated along the way.

# Submitter Checklist

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ - ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
