### PR TITLE
Fix docs links from tektoncd/pipeline to tektoncd/cli

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ review them:
 - [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
 - [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
 
-_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
+_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
 for more details._
 
 # Release Notes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ Then you can [iterate](#iterating) (including
 ### Checkout your fork
 
 The Go tools require that you clone the repository to the
-`src/github.com/tektoncd/pipeline` directory in your
+`src/github.com/tektoncd/cli` directory in your
 [`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
 
 To check out this repository:
@@ -112,7 +112,7 @@ You can stand up a version of this controller on-cluster (to your
 `kubectl config current-context`):
 
 - using a `release.yaml` file from the Tekton pipelines
-  [releases](https://github.com/tektoncd/pipeline/releases) 
-- using [tektoncd/pipeline](https://github.com/tektoncd/pipeline)
+  [releases](https://github.com/tektoncd/cli/releases)
+- using [tektoncd/cli](https://github.com/tektoncd/cli)
   sources, following
-  [DEVELOPMENT.md](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md).
+  [DEVELOPMENT.md](https://github.com/tektoncd/cli/blob/master/DEVELOPMENT.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tekton Pipelines cli
 
-[![Go Report Card](https://goreportcard.com/badge/tektoncd/pipeline)](https://goreportcard.com/report/tektoncd/pipeline)
+[![Go Report Card](https://goreportcard.com/badge/tektoncd/cli)](https://goreportcard.com/report/tektoncd/cli)
 
 The Tekton Pipelines cli project provides a CLI for interacting with
 Tekton !
@@ -13,7 +13,6 @@ We are so excited to have you!
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview of our processes
 - See [DEVELOPMENT.md](DEVELOPMENT.md) for how to get started
 - Look at our
-  [good first issues](https://github.com/tektoncd/pipeline/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+  [good first issues](https://github.com/tektoncd/cli/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
   and our
-  [help wanted issues](https://github.com/tektoncd/pipeline/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-
+  [help wanted issues](https://github.com/tektoncd/cli/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)


### PR DESCRIPTION
# Changes

OCD mode kicked in and felt this was the right thing to do.

# Submitter Checklist

- [ ✓ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ✓ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)