### PR TITLE
Add command for pipelinerun details

### DIFF
--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -1,0 +1,140 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/formatted"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
+	"text/tabwriter"
+)
+
+const (
+	statusHeader = "STARTED\tDURATION\tSTATUS\n"
+	statusBody = "%s\t%s\t%s\n"
+	resourceHeader = "NAME\tRESOURCE REF\n"
+	resourceBody = "%s\t%s\n"
+	paramHeader = "NAME\tVALUE\n"
+	paramBody = "%s\t%s\n"
+	taskrunHeader = "NAME\tSTARTED\tDURATION\tSTATUS\n"
+	taskrunBody = "%s\t%s\t%s\t%s\n"
+)
+
+func describeCommand(p cli.Params) *cobra.Command {
+	f := cliopts.NewPrintFlags("describe")
+	eg := `
+# Describe a PipelineRun of name 'foo' in namespace 'bar'
+tkn pipelinerun describe foo -n bar
+
+tkn pr desc foo -n bar \n",
+`
+
+	c := &cobra.Command{
+		Use:     "describe",
+		Aliases: []string{"desc"},
+		Short:   "Describe a pipelinerun in a namespace",
+		Example: eg,
+		Args: cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printPipelineRunDescription(cmd.OutOrStdout(), args[0], p)
+		},
+	}
+
+	f.AddFlags(c)
+
+	return c
+}
+
+func printPipelineRunDescription(out io.Writer, prname string, p cli.Params) error {
+	cs, err := p.Clients()
+	if err != nil {
+		return fmt.Errorf("Failed to create tekton client\n")
+	}
+
+	pr, err := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Get(prname, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to find pipelinerun %q", prname)
+	}
+
+	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	printPipelineRunMetadata(w, pr)
+	printPipelineRunStatus(w, pr, p)
+	printPipelineRunResources(w, pr)
+	printPipelineRunParams(w, pr)
+	printPipelineRunTaskruns(w, pr, p)
+	return w.Flush()
+}
+
+func printPipelineRunMetadata(w *tabwriter.Writer, pr *v1alpha1.PipelineRun) {
+	fmt.Fprintf(w, "Name:\t%s\n", pr.Name)
+	fmt.Fprintf(w, "Namespace:\t%s\n", pr.Namespace)
+	fmt.Fprintf(w, "Pipeline Ref:\t%s\n", pr.Spec.PipelineRef.Name)
+	fmt.Fprintf(w, "Service Account:\t%s\n", pr.Spec.ServiceAccount)
+}
+
+func printPipelineRunStatus(w *tabwriter.Writer, pr *v1alpha1.PipelineRun, p cli.Params) {
+	fmt.Fprintln(w, "\nStatus")
+	fmt.Fprintf(w, statusHeader)
+	fmt.Fprintf(w, statusBody, formatted.Age(*pr.Status.StartTime, p.Time()),
+		formatted.Duration(pr.Status.StartTime, pr.Status.CompletionTime),
+		formatted.Condition(pr.Status.Conditions[0]))
+}
+
+func printPipelineRunResources(w *tabwriter.Writer, pr *v1alpha1.PipelineRun) {
+	fmt.Fprintln(w, "\nResources")
+	if len(pr.Spec.Resources) == 0 {
+		fmt.Fprintln(w, "No resources")
+		return
+	}
+
+	fmt.Fprintf(w, resourceHeader)
+	for _, resource := range pr.Spec.Resources {
+		fmt.Fprintf(w, resourceBody, resource.Name, resource.ResourceRef.Name)
+	}
+}
+
+func printPipelineRunParams(w *tabwriter.Writer, pr *v1alpha1.PipelineRun) {
+	fmt.Fprintln(w, "\nParams")
+	if len(pr.Spec.Params) == 0 {
+		fmt.Fprintln(w, "No params")
+		return
+	}
+
+	fmt.Fprintf(w, paramHeader)
+	for _, param := range pr.Spec.Params {
+		fmt.Fprintf(w, paramBody, param.Name, param.Value)
+	}
+}
+
+func printPipelineRunTaskruns(w *tabwriter.Writer, pr *v1alpha1.PipelineRun, p cli.Params) {
+	fmt.Fprintln(w, "\nTaskruns")
+	if len(pr.Status.TaskRuns) == 0 {
+		fmt.Fprintln(w, "No taskruns")
+		return
+	}
+
+	fmt.Fprintf(w, taskrunHeader)
+	for taskrunname, taskrun := range pr.Status.TaskRuns {
+		fmt.Fprintf(w, taskrunBody, taskrunname, formatted.Age(*taskrun.Status.StartTime, p.Time()),
+			formatted.Duration(taskrun.Status.StartTime, taskrun.Status.CompletionTime),
+			formatted.Condition(taskrun.Status.Conditions[0]))
+	}
+}

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -16,11 +16,12 @@ package pipelinerun
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 	"text/tabwriter"
@@ -43,7 +44,7 @@ func describeCommand(p cli.Params) *cobra.Command {
 # Describe a PipelineRun of name 'foo' in namespace 'bar'
 tkn pipelinerun describe foo -n bar
 
-tkn pr desc foo -n bar \n",
+tkn pr desc foo -n bar",
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -94,21 +94,25 @@ func TestPipelineRunDescribe_only_taskrun(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	expected := "" +
-		"Name:              pipeline-run\n" +
-		"Namespace:         ns\n" +
-		"Pipeline Ref:      pipeline\n" +
-		"Service Account:   test-sa\n\n" +
-		"Status\n" +
-		"STARTED          DURATION    STATUS\n" +
-		"10 minutes ago   5 minutes   Succeeded\n\n" +
-		"Resources\n" +
-		"No resources\n\n" +
-		"Params\n" +
-		"No params\n\n" +
-		"Taskruns\n" +
-		"NAME   STARTED         DURATION    STATUS\n" +
-		"tr-1   8 minutes ago   3 minutes   Succeeded\n"
+	expected := `Name:              pipeline-run
+Namespace:         ns
+Pipeline Ref:      pipeline
+Service Account:   test-sa
+
+Status
+STARTED          DURATION    STATUS
+10 minutes ago   5 minutes   Succeeded
+
+Resources
+No resources
+
+Params
+No params
+
+Taskruns
+NAME   STARTED         DURATION    STATUS
+tr-1   8 minutes ago   3 minutes   Succeeded
+`
 	if d := cmp.Diff(expected, actual ); d != "" {
 		t.Errorf("Unexpected output mismatch: %s", d)
 	}
@@ -170,23 +174,27 @@ func TestPipelineRunDescribe_with_resources_taskrun(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	expected := "" +
-		"Name:              pipeline-run\n" +
-		"Namespace:         ns\n" +
-		"Pipeline Ref:      pipeline\n" +
-		"Service Account:   test-sa\n\n" +
-		"Status\n" +
-		"STARTED          DURATION    STATUS\n" +
-		"10 minutes ago   5 minutes   Succeeded\n\n" +
-		"Resources\n" +
-		"NAME            RESOURCE REF\n" +
-		"test-resource   test-resource-ref\n\n" +
-		"Params\n" +
-		"NAME         VALUE\n" +
-		"test-param   param-value\n\n" +
-		"Taskruns\n" +
-		"NAME   STARTED         DURATION    STATUS\n" +
-		"tr-1   8 minutes ago   3 minutes   Succeeded\n"
+	expected := `Name:              pipeline-run
+Namespace:         ns
+Pipeline Ref:      pipeline
+Service Account:   test-sa
+
+Status
+STARTED          DURATION    STATUS
+10 minutes ago   5 minutes   Succeeded
+
+Resources
+NAME            RESOURCE REF
+test-resource   test-resource-ref
+
+Params
+NAME         VALUE
+test-param   param-value
+
+Taskruns
+NAME   STARTED         DURATION    STATUS
+tr-1   8 minutes ago   3 minutes   Succeeded
+`
 	if d := cmp.Diff(expected, actual ); d != "" {
 		t.Errorf("Unexpected output mismatch: %s", d)
 	}

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -15,6 +15,9 @@
 package pipelinerun
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/knative/pkg/apis"
@@ -25,8 +28,6 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
-	"time"
 )
 
 func TestPipelineRunDescribe_not_found(t *testing.T) {

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -44,6 +44,7 @@ func Command(p cli.Params) *cobra.Command {
 	flags.AddTektonOptions(c)
 	c.AddCommand(listCommand(p))
 	c.AddCommand(logCommand(p))
+	c.AddCommand(describeCommand(p))
 
 	return c
 }


### PR DESCRIPTION
This will add the `describe` command for pipelinerun
with an alias `desc` which can be used to get
details of a pipeline run

like `tkn pipelinerun describe name`

or `tkn pr desc name`

Fixes https://github.com/tektoncd/cli/issues/8
