### PR TITLE
Fix double spacing in the pipelinerun description

### DIFF
--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -42,7 +42,7 @@ func listCommand(p cli.Params) *cobra.Command {
 tkn pipelinerun list foo -n bar
 
 # List all pipelineruns in a namespaces 'foo'
-tkn pr list -n foo \n",
+tkn pr list -n foo",
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -39,7 +39,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 	eg := `
 # List all PipelineRuns of Pipeline name 'foo'
-tkn pipelinerun list  foo -n bar
+tkn pipelinerun list foo -n bar
 
 # List all pipelineruns in a namespaces 'foo'
 tkn pr list -n foo \n",


### PR DESCRIPTION
It's all vdemeester's OCD fault

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

# Changes

Just a trivial double spacing

# Submitter Checklist


- [🤷🏼‍♂️ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ 🤷🏼‍♂️ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ 👍  ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Fix descriptions for OCD maniacs
```
