### PR TITLE
Add logs subcommand for taskrun

### DIFF
--- a/pkg/cmd/pipelinerun/log_test.go
+++ b/pkg/cmd/pipelinerun/log_test.go
@@ -112,6 +112,9 @@ func Test_print_pipelinerun_logs(t *testing.T) {
 					tb.StateTerminated(0),
 				),
 			),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef(task1Name),
+			),
 		),
 		tb.TaskRun(tr2Name, ns,
 			tb.TaskRunStatus(
@@ -129,6 +132,9 @@ func Test_print_pipelinerun_logs(t *testing.T) {
 					cb.StepName(nopStep),
 					tb.StateTerminated(0),
 				),
+			),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef(task2Name),
 			),
 		),
 	}
@@ -309,6 +315,9 @@ func Test_print_valid_taskrun_logs(t *testing.T) {
 					cb.StepName("nop"),
 					tb.StateTerminated(0),
 				),
+			),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef(task1Name),
 			),
 		),
 	}

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -205,8 +205,8 @@ func filterBy(ts []string, trs []taskRun) []taskRun {
 	return filtered
 }
 
-func (t taskRun) toTaskRunLogs(namespae string, clientSet *cli.Clients) *taskrun.TaskRunLogs {
-	return &taskrun.TaskRunLogs{
+func (t taskRun) toTaskRunLogs(namespae string, clientSet *cli.Clients) *taskrun.Logs {
+	return &taskrun.Logs{
 		Run:     t.name,
 		Task:    t.task,
 		Ns:      namespae,

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,46 +16,93 @@ package taskrun
 
 import (
 	"fmt"
+
+	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/logs"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/taskrun/resources"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	msgTRNotFoundErr = "Error in retrieving Taskrun : "
+	msgTRNotFoundErr = "Error in retrieving Taskrun"
 )
 
-type TaskRunLogs struct {
+// Logs fetches logs of a taskrun
+type Logs struct {
 	Task    string
 	Run     string
 	Ns      string
 	Clients *cli.Clients
 }
 
+// LogOptions provides options on what logs to fetch. An empty LogOptions
+// implies fetching all logs including init steps
 type LogOptions struct {
 	AllSteps bool
+}
+
+func logCommand(p cli.Params) *cobra.Command {
+	opts := LogOptions{}
+	eg := `
+# show the logs of TaskRun named "foo" from the namespace "bar"
+tkn taskrun logs foo -n bar
+`
+
+	c := &cobra.Command{
+		Use:          "logs",
+		Short:        "Show taskruns logs",
+		Example:      eg,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			cs, err := p.Clients()
+			if err != nil {
+				return err
+			}
+
+			trl := &Logs{
+				Run:     args[0],
+				Ns:      p.Namespace(),
+				Clients: cs,
+			}
+
+			s := logs.Streams{
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			trl.Fetch(opts, s, logs.DefaultLogFetcher(cs.Kube))
+			return nil
+		},
+	}
+
+	c.Flags().BoolVarP(
+		&opts.AllSteps,
+		"all", "a", false,
+		"show all logs including init steps injected by tekton")
+	return c
 }
 
 //Fetch To fetch the TaskRun's logs.
 //Stream provides output and error stream to print the logs and error messages.
 //LogOptions provide way to print all(init) steps
-func (trl *TaskRunLogs) Fetch(flags LogOptions, stream logs.Streams, reader *logs.LogFetcher) {
+func (trl *Logs) Fetch(opts LogOptions, stream logs.Streams, reader *logs.LogFetcher) {
 	var (
 		kube   = trl.Clients.Kube
 		tekton = trl.Clients.Tekton
 	)
 
-	tr, err := tekton.TektonV1alpha1().
-		TaskRuns(trl.Ns).
-		Get(trl.Run, v1.GetOptions{})
+	tr, err := tekton.TektonV1alpha1().TaskRuns(trl.Ns).Get(trl.Run, metav1.GetOptions{})
 	if err != nil {
 		fmt.Fprintf(stream.Err, "%s : %s \n", msgTRNotFoundErr, err)
 		return
 	}
 
+	trl.Task = tr.Spec.TaskRef.Name
 	trStatus := tr.Status
 	if !taskRunHasStarted(trStatus) {
 		fmt.Fprintf(stream.Out, "Task %s has not started yet \n", trl.Task)
@@ -64,7 +111,7 @@ func (trl *TaskRunLogs) Fetch(flags LogOptions, stream logs.Streams, reader *log
 
 	pod, err := kube.CoreV1().
 		Pods(trl.Ns).
-		Get(trStatus.PodName, v1.GetOptions{})
+		Get(trStatus.PodName, metav1.GetOptions{})
 	if err != nil {
 		fmt.Fprintf(stream.Err, "Error in getting pod: %s \n", err)
 		return
@@ -75,7 +122,7 @@ func (trl *TaskRunLogs) Fetch(flags LogOptions, stream logs.Streams, reader *log
 		return
 	}
 
-	steps := filterSteps(trStatus, pod, flags.AllSteps)
+	steps := filterSteps(trStatus, pod, opts.AllSteps)
 
 	for _, step := range steps {
 		if !stepHasStarted(step) {

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -1,0 +1,253 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskrun
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
+	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/logs"
+	tu "github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestLog_no_taskrun_arg(t *testing.T) {
+	c := Command(&tu.Params{})
+
+	_, err := tu.ExecuteCommand(c, "logs", "-n", "ns")
+	if err == nil {
+		t.Error("Expecting an error but it's empty")
+	}
+}
+
+func TestLog_missing_taskrun(t *testing.T) {
+	tr := []*v1alpha1.TaskRun{
+		tb.TaskRun("output-taskrun-1", "ns"),
+	}
+	cs, _ := test.SeedTestData(test.Data{TaskRuns: tr})
+	p := &tu.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	c := Command(p)
+	got, _ := tu.ExecuteCommand(c, "logs", "output-taskrun-2", "-n", "ns")
+	expected := msgTRNotFoundErr + " : taskruns.tekton.dev \"output-taskrun-2\" not found \n"
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("Unexpected output mismatch: \n%s\n", d)
+	}
+}
+
+func TestLog_valid_taskrun_logs(t *testing.T) {
+	var (
+		ns          = "namespace"
+		taskName    = "output-task"
+		trName      = "output-task-1"
+		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trPod       = "output-task-pod-123456"
+		trStep1Name = "writefile-step"
+	)
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun(trName, ns,
+			tb.TaskRunStatus(
+				tb.PodName(trPod),
+				tb.TaskRunStartTime(trStartTime),
+				tb.Condition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}),
+				tb.StepState(
+					cb.StepName(trStep1Name),
+					tb.StateTerminated(0),
+				),
+				tb.StepState(
+					cb.StepName("nop"),
+					tb.StateTerminated(0),
+				),
+			),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef(taskName),
+			),
+		),
+	}
+	pods := []*corev1.Pod{
+		tb.Pod(trPod, ns,
+			tb.PodSpec(
+				tb.PodContainer(ContainerNameForStep(trStep1Name), trStep1Name+":latest"),
+				tb.PodContainer("nop", "override-with-nop:latest"),
+			),
+		),
+	}
+	fakeLogStream := logs.TaskRun(
+		logs.Task(taskName, trPod,
+			logs.Step(trStep1Name, ContainerNameForStep(trStep1Name),
+				"written a file",
+			),
+			logs.Step("nop", "nop",
+				"Build successful",
+			),
+		),
+	)
+
+	cs, _ := test.SeedTestData(test.Data{TaskRuns: trs, Pods: pods})
+	tr := fakeLogs(trName, ns, cs)
+
+	output := fetchLogs(LogOptions{}, tr, logs.FakeLogFetcher(cs.Kube, fakeLogStream))
+	expectedLogs := []string{
+		"[output-task : writefile-step] written a file",
+		"[output-task : nop] Build successful",
+	}
+
+	expected := strings.Join(expectedLogs, "\n") + "\n"
+
+	if d := cmp.Diff(output, expected); d != "" {
+		t.Errorf("Unexpected output mismatch: \n%s\n", d)
+	}
+}
+
+func TestLog_taskrun_logs(t *testing.T) {
+	var (
+		prstart     = clockwork.NewFakeClock()
+		ns          = "namespace"
+		taskName    = "output-task"
+		trName      = "output-task-run"
+		trStartTime = prstart.Now().Add(20 * time.Second)
+		trPod       = "output-task-pod-123456"
+		trStep1Name = "writefile-step"
+		trInitStep1 = "credential-initializer-mdzbr"
+		trInitStep2 = "place-tools"
+		nopStep     = "nop"
+	)
+
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun(trName, ns,
+			tb.TaskRunStatus(
+				tb.PodName(trPod),
+				tb.TaskRunStartTime(trStartTime),
+				tb.Condition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}),
+				tb.StepState(
+					cb.StepName(trStep1Name),
+					tb.StateTerminated(0),
+				),
+				tb.StepState(
+					cb.StepName(nopStep),
+					tb.StateTerminated(0),
+				),
+			),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef(taskName),
+			),
+		),
+	}
+
+	pods := []*corev1.Pod{
+		tb.Pod(trPod, ns,
+			tb.PodSpec(
+				tb.PodInitContainer(ContainerNameForStep(trInitStep1), "override-with-creds:latest"),
+				tb.PodInitContainer(ContainerNameForStep(trInitStep2), "override-with-tools:latest"),
+				tb.PodContainer(ContainerNameForStep(trStep1Name), trStep1Name+":latest"),
+				tb.PodContainer(nopStep, "override-with-nop:latest"),
+			),
+			cb.PodStatus(
+				cb.PodInitContainerStatus(ContainerNameForStep(trInitStep1), "override-with-creds:latest"),
+				cb.PodInitContainerStatus(ContainerNameForStep(trInitStep2), "override-with-tools:latest"),
+			),
+		),
+	}
+
+	fakeLogStream := logs.TaskRun(
+		logs.Task(taskName, trPod,
+			logs.Step(trInitStep1, ContainerNameForStep(trInitStep1),
+				"initialized the credentials",
+			),
+			logs.Step(trInitStep2, ContainerNameForStep(trInitStep2),
+				"place tools log",
+			),
+			logs.Step(trStep1Name, ContainerNameForStep(trStep1Name),
+				"written a file",
+			),
+			logs.Step(nopStep, nopStep,
+				"Build successful",
+			),
+		),
+	)
+
+	scenarios := []struct {
+		name         string
+		allSteps     bool
+		expectedLogs []string
+	}{
+		{
+			name:     "task logs only",
+			allSteps: false,
+			expectedLogs: []string{
+				"[output-task : writefile-step] written a file",
+				"[output-task : nop] Build successful",
+			},
+		}, {
+			name:     "all steps logs",
+			allSteps: true,
+			expectedLogs: []string{
+				"[output-task : credential-initializer-mdzbr] initialized the credentials",
+				"[output-task : place-tools] place tools log",
+				"[output-task : writefile-step] written a file",
+				"[output-task : nop] Build successful",
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			cs, _ := test.SeedTestData(test.Data{TaskRuns: trs, Pods: pods})
+
+			trl := fakeLogs(trName, ns, cs)
+			opts := LogOptions{AllSteps: s.allSteps}
+			output := fetchLogs(opts, trl, logs.FakeLogFetcher(cs.Kube, fakeLogStream))
+			expected := strings.Join(s.expectedLogs, "\n") + "\n"
+
+			if d := cmp.Diff(output, expected); d != "" {
+				t.Errorf("Unexpected output mismatch: \n%s\n", d)
+			}
+		})
+	}
+}
+
+func fakeLogs(run, ns string, cs test.Clients) *Logs {
+	return &Logs{
+		Run: run,
+		Ns:  ns,
+		Clients: &cli.Clients{
+			Tekton: cs.Pipeline,
+			Kube:   cs.Kube,
+		},
+	}
+}
+
+func fetchLogs(opt LogOptions, trl *Logs, fetcher *logs.LogFetcher) string {
+	out := new(bytes.Buffer)
+	trl.Fetch(opt, logs.Streams{Out: out, Err: out}, fetcher)
+	return out.String()
+}

--- a/pkg/cmd/taskrun/taskrun.go
+++ b/pkg/cmd/taskrun/taskrun.go
@@ -41,6 +41,9 @@ func Command(p cli.Params) *cobra.Command {
 	}
 
 	flags.AddTektonOptions(cmd)
-	cmd.AddCommand(listCommand(p))
+	cmd.AddCommand(
+		listCommand(p),
+		logCommand(p),
+	)
 	return cmd
 }

--- a/pkg/logs/fakelog.go
+++ b/pkg/logs/fakelog.go
@@ -98,3 +98,15 @@ func Step(name string, container string, logs ...string) step {
 		logs:      logs,
 	}
 }
+
+func TaskRun(ts ...task) FakePodStream {
+	logs := logs{}
+
+	for _, t := range ts {
+		logs = append(logs, t)
+	}
+
+	return FakePodStream{
+		logs: logs,
+	}
+}


### PR DESCRIPTION
This add a subcommand logs for taskrun, which shows logs of a
given taskrun in a given namespace

Eg- tkn taskrun logs task-run-name

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
