### PR TITLE
Error out if invalid subcommands are passed root comamnds

### DIFF
--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -15,8 +15,6 @@
 package pipeline
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/flags"
@@ -27,16 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "pipeline",
 		Aliases: []string{"p", "pipelines"},
 		Short:   "Manage pipelines",
-
+		Args:    cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
-		},
-
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return fmt.Errorf("pipeline requires a subcommand; see help")
-			}
-			return nil
 		},
 	}
 

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -15,8 +15,6 @@
 package pipelinerun
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/flags"
@@ -25,19 +23,12 @@ import (
 //Command instantiates the pipelinerun command
 func Command(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "pipelinerun",
-		DisableFlagsInUseLine: true,
-		Aliases:               []string{"pr", "pipelineruns"},
-		Short:                 "Manage pipelineruns",
+		Use:     "pipelinerun",
+		Aliases: []string{"pr", "pipelineruns"},
+		Short:   "Manage pipelineruns",
+		Args:    cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return fmt.Errorf("pipelinerun requires a subcommand; see help and examples")
-			}
-
-			return nil
 		},
 	}
 

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -15,8 +15,6 @@
 package task
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/flags"
@@ -27,16 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "task",
 		Aliases: []string{"t", "tasks"},
 		Short:   "Manage tasks",
-
+		Args:    cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
-		},
-
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return fmt.Errorf("task requires a subcommand; see help")
-			}
-			return nil
 		},
 	}
 

--- a/pkg/cmd/taskrun/taskrun.go
+++ b/pkg/cmd/taskrun/taskrun.go
@@ -15,8 +15,6 @@
 package taskrun
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/flags"
@@ -27,16 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "taskrun",
 		Aliases: []string{"tr", "taskruns"},
 		Short:   "Manage taskruns",
-
+		Args:    cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
-		},
-
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return fmt.Errorf("taskrun requires a subcommand; see help")
-			}
-			return nil
 		},
 	}
 


### PR DESCRIPTION
# Changes

Before this change, you can pass non declared sub-commands and it
would not fail. By putting `NoArgs` on those "root" commands, we
disallow any argument that is not a declared sub-commands.

Fixes #22 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
