### PR TITLE
Fix file headers to use Tekton instead of Knative in copyright

### DIFF
--- a/cmd/tkn/main.go
+++ b/cmd/tkn/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/dummy_test.go
+++ b/pkg/dummy_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 The Knative Authors
+// Copyright © 2018 The Tekton Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Knative Authors.
+// Copyright © 2019 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/dummy_test.go
+++ b/test/dummy_test.go
@@ -1,6 +1,6 @@
 // +build e2e
 
-// Copyright © 2018 The Knative Authors
+// Copyright © 2018 The Tekton Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 The Knative Authors
+# Copyright 2018 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 The Knative Authors
+# Copyright 2018 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 The Knative Authors
+# Copyright 2018 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Changes

Those files were created on Tekton not Knative, so it's safe to change this.

cc @chmouel 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
