### PR TITLE
Fix test names

### DIFF
--- a/pkg/cmd/pipelinerun/pipelinerun_test.go
+++ b/pkg/cmd/pipelinerun/pipelinerun_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tektoncd/cli/pkg/test"
 )
 
-func TestPipelines_invalid(t *testing.T) {
+func TestPipelinesRun_invalid(t *testing.T) {
 
 	p := &test.Params{}
 

--- a/pkg/cmd/task/task_test.go
+++ b/pkg/cmd/task/task_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tektoncd/cli/pkg/test"
 )
 
-func TestPipelines_invalid(t *testing.T) {
+func TestTask_invalid(t *testing.T) {
 
 	p := &test.Params{}
 

--- a/pkg/cmd/taskrun/taskrun_test.go
+++ b/pkg/cmd/taskrun/taskrun_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tektoncd/cli/pkg/test"
 )
 
-func TestPipelines_invalid(t *testing.T) {
+func TestTaskRun_invalid(t *testing.T) {
 
 	p := &test.Params{}
 


### PR DESCRIPTION
Following PR #56 the test was all named the same due of a copy and
paste that was too greedy. Fixing it by naming them properly

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
