### PR TITLE
Print message also in case of pipelinerun failure

### DIFF
--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/logs"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -133,7 +132,7 @@ func (p *PipelineRunLogs) Fetch(s logs.Streams, opts LogOptions, r *logs.LogFetc
 		return
 	}
 
-	if failed, msg := pipelineRunFailed(pr.Status); failed {
+	if failed, msg := hasFailed(pr); failed {
 		fmt.Fprintf(s.Out, "PipelineRun is failed: %s \n", msg)
 	}
 
@@ -154,15 +153,6 @@ func (p *PipelineRunLogs) Fetch(s logs.Streams, opts LogOptions, r *logs.LogFetc
 		trl := tr.toTaskRunLogs(p.Ns, p.Clients)
 		trl.Fetch(opts.LogOptions, s, r)
 	}
-}
-
-func pipelineRunFailed(status v1alpha1.PipelineRunStatus) (bool, string) {
-	c := status.Conditions[0]
-	if c.Status == corev1.ConditionFalse {
-		return true, c.Message
-	}
-
-	return false, ""
 }
 
 func orderBy(pipelineTasks []v1alpha1.PipelineTask, pipelinesTaskRuns taskRunMap) []taskRun {


### PR DESCRIPTION
# Changes

While describing a pipeline run also print a message
so that user can see details about the failure in case
of pipeline run failure

Add case for empty message probability

Refactor the function so that
we can leverage the function at multiple places

Fixes #64

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
