### PR TITLE
Add a release pipeline ⛏

### DIFF
--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -235,6 +235,7 @@ __tkn_bash_source <(__tkn_convert_bash_to_zsh)
 _complete tkn 2>/dev/null
 `
 	if _, err := out.Write([]byte(zsh_tail)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,0 +1,67 @@
+# Tekton cli Repo CI/CD
+
+We dogfood our project by using Tekton Pipelines to build, test and
+release the Tekton Pipelines cli!
+
+This directory contains the
+[`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md) and
+[`Pipelines`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md)
+that we (will) use for the release and the pull-requests.
+
+TODO(tektoncd/pipeline#538): In tektoncd/pipeline#538 or tektoncd/pipeline#537 we will update
+[Prow](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#pull-request-process)
+to invoke these `Pipelines` automatically, but for now we will have to invoke
+them manually.
+
+## Release Pipeline
+
+The release pipeline uses the
+[`golang`](https://github.com/tektoncd/catalog/tree/master/golang)
+Tasks from the
+[`tektoncd/catalog`](https://github.com/tektoncd/catalog). To add them
+to your cluster:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/lint.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/build.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/tests.yaml
+```
+
+It also uses the [`goreleaser`](./goreleaser.yml) Task from this
+repository.
+
+```
+kubectl apply -f ./goreleaser.yml
+```
+
+Next is the actual release pipeline. It is defined in
+[`release-pipeline.yml`](./release-pipeline.yml).
+
+```
+kubectl apply -f ./release-pipeline.yml
+```
+
+Note that the [`goreleaser.yml`](./goreleaser.yml) `Task` needs a
+secret for the GitHub token, named `bot-token-github`.
+
+TODO(vdemeester): It is hardcoded for now as Tekton Pipeline doesn't
+support variable interpolation in the environment. This needs to be
+fixed upstream.
+
+```
+kubectl create secret generic bot-token-github --from-literal=bot-token=${GITHUB_TOKEN}
+```
+
+
+### Running
+
+To run these `Pipelines` and `Tasks`, you must have Tekton Pipelines installed
+(in your own kubernetes cluster) either via
+[an official release](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+or
+[from `HEAD`](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#install-pipeline).
+
+- [`release-pipeline-run.yml`](./release-pipeline-run.yml) — this
+  runs the `ci-release-pipeline` on `tektoncd/cli` master branch. The
+  way [`goreleaser`](https://goreleaser.com) works, it will build the
+  latest tag.

--- a/tekton/goreleaser.yml
+++ b/tekton/goreleaser.yml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: goreleaser
+spec:
+  inputs:
+    params:
+    - name: package
+      description: base package to build in
+    # FIXME(vdemeester): this is not yet used (see below)
+    - name: github-token-secret
+      description: name of the secret holding the github-token
+      default: github-token
+    - name: flags
+      description: flags to use for the test command
+      default: --timeout=30m
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  steps:
+  - name: pull
+    image: goreleaser/goreleaser
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - /bin/bash
+    args:
+    - -c
+    - "git status; git fetch -p --all"
+  - name: release
+    image: goreleaser/goreleaser
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - /bin/bash
+    args:
+    - -c
+    - "goreleaser release ${inputs.params.flags}"
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          # FIXME(vdemeester): this need to be fixed upstream, template should work there
+          #name: ${inputs.params.github-token-secret}
+          name: bot-token-github
+          key: bot-token

--- a/tekton/release-pipeline-run.yml
+++ b/tekton/release-pipeline-run.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: tektoncd-cli-git
+spec:
+  type: git
+  params:
+  - name: revision
+    value: master
+  - name: url
+    value: https://github.com/tektoncd/cli
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: cli-release-pipeline-run
+spec:
+  pipelineRef:
+    name: cli-release-pipeline
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: tektoncd-cli-git

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -1,0 +1,65 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: cli-release-pipeline
+spec:
+  params:
+  - name: package
+    description: package to release
+    default: github.com/tektoncd/cli
+  # FIXME(vdemeester): this is not yet used and need to be fixed upstream
+  - name: github-token-secret
+    description: name of the secret holding the github-token
+    default: bot-token-github
+  resources:
+  - name: source-repo
+    type: git
+  tasks:
+    - name: lint
+      taskRef:
+        name: golangci-lint
+      params:
+        - name: package
+          value: ${params.package}
+        - name: flags
+          value: -v --issues-exit-code=0
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo
+    - name: unit-tests
+      runAfter: [lint]
+      taskRef:
+        name: golang-test
+      params:
+        - name: package
+          value: ${params.package}
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo
+    - name: build
+      runAfter: [lint]
+      taskRef:
+        name: golang-build
+      params:
+        - name: package
+          value: ${params.package}
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo
+    - name: release
+      runAfter: [build, unit-tests]
+      taskRef:
+        name: goreleaser
+      params:
+        - name: package
+          value: ${params.package}
+        - name: github-token-secret
+          value: ${params.github-token-secret}
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo    

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -23,7 +23,7 @@ spec:
         - name: package
           value: ${params.package}
         - name: flags
-          value: -v --issues-exit-code=0
+          value: -v
       resources:
         inputs:
           - name: source


### PR DESCRIPTION
# Changes

This will need to be run manually for the first(s) releases, but it
sets pieces in place and help the dogfooding effort for Tekton
Pipelines.

It reuses golang tasks from the tektoncd/catalog *and* adds a
`goreleaser` Task (using goreleaser).

The pipeline runs the lint, then build the command and run the unit
tests. It finaly cross build the binary for all targeted architecture
and system and publish a draft release.

Although this should be considered still a work in progress, it is
still usable and will be run to make the v0.1.0 release of
tektoncd/cli.

/cc @sthaha @chmouel 

This is *slightly* blocked by #77 (although both can be merged asynchronously)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
