### PR TITLE
Use a name_template for archive names.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,8 @@ builds:
   - arm
   - arm64
 archives:
-- replacements:
+- name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  replacements:
     darwin: Darwin
     linux: Linux
     windows: Windows


### PR DESCRIPTION
# Changes

The current archive names is a bit weird: "cli_0.1.0_Linux_arm64.tar.gz". This uses the `name_template` feature for `archives` to generate something like `tkn_0.1.0_Linux_arm64.tar.gz`

/cc @hrishin @chmouel @sthaha 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
