### PR TITLE
fixes log command links in the doc

### DIFF
--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -38,4 +38,5 @@ logs        Display pipelinerun logs
 ### SEE ALSO
 
 * [tkn pipelinerun list](tkn_pipelinerun_list.md)	 - Lists all the pipelineruns in a given namespace.
-* [tkn pipelinerun describe](tkn_pipelinerun_describe.md)	 - Describe given pipelinerun.
+* [tkn pipelinerun describe](tkn_pipelinerun_describe.md)	 - Describe given `pipelinerun`.
+* [tkn pipelinerun logs](tkn_pipelinerun_logs.md)	 - Show logs for the  given `pipelinerun`.

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -15,7 +15,7 @@ tkn pipelinerun logs NAME [flags]
 ```
 -a, --all                  show all logs including init steps injected by tekton
 -h, --help                 help for logs
--f  --follow               stream the live logs 
+-f  --follow               stream live logs 
 -t, --only-tasks strings   show the logs for mentioned task only
 ```
 

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -15,6 +15,7 @@ tkn pipelinerun logs NAME [flags]
 ```
 -a, --all                  show all logs including init steps injected by tekton
 -h, --help                 help for logs
+-f  --follow               stream the live logs 
 -t, --only-tasks strings   show the logs for mentioned task only
 ```
 

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -36,3 +36,4 @@ logs        Displays taskrun logs
 ### SEE ALSO
 
 * [tkn taskrun list](tkn_taskrun_list.md)	 - Lists all the `taskruns` in a given namespace.
+* [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show logs for the  given `taskrun`.

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -35,5 +35,5 @@ logs        Displays taskrun logs
 
 ### SEE ALSO
 
-* [tkn taskrun list](tkn_taskrun_list.md)	 - Lists all the `taskruns` in a given namespace.
-* [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show logs for the  given `taskrun`.
+* [tkn taskrun list](tkn_taskrun_list.md)	 - Lists all `taskruns` in a given namespace.
+* [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show logs for the given `taskrun`.

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -14,7 +14,7 @@ tkn taskrun logs NAME [flags]
 
 ```
   -a, --all      show all logs including init steps injected by tekton
-  -f, --follow   stream the live logs
+  -f, --follow   stream live logs
   -h, --help     help for logs
 
 ```

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -13,18 +13,18 @@ tkn taskrun logs NAME [flags]
 ### Options
 
 ```
--a, --all                  show all logs including init steps injected by tekton
--h, --help                 help for logs
+  -a, --all      show all logs including init steps injected by tekton
+  -f, --follow   stream the live logs
+  -h, --help     help for logs
+
 ```
 
 ### Options inherited from parent commands
 
 ```
 Flags:
---allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
- -h, --help                          help for list
- -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file.
-      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+  -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
+  -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```
 
 ### SEE ALSO

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -71,7 +71,7 @@ func logCommand(p cli.Params) *cobra.Command {
 	}
 
 	c.Flags().BoolVarP(&opts.allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
-	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream the live logs")
+	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream live logs")
 	c.Flags().StringSliceVarP(&opts.tasks, "only-tasks", "t", []string{}, "show logs for mentioned tasks only")
 
 	return c

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -66,7 +66,7 @@ tkn taskrun logs -f foo -n bar
 	}
 
 	c.Flags().BoolVarP(&opts.allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
-	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "follow live logs")
+	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream live logs")
 
 	return c
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The links for `logs` commands in the doc are absent.

So this patch updates the links for `logs` command

Fixes https://github.com/tektoncd/cli/issues/89

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
