### PR TITLE
goreleaser: add the version ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,8 @@ builds:
   - amd64
   - arm
   - arm64
+  ldflags:
+  - -s -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}
 archives:
 - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   replacements:


### PR DESCRIPTION
# Changes

The v0.1.0 release miss those flags and thus display the version as dev
instead of v0.1.0.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix the tkn version output
```
