### PR TITLE
Dont show empty serviceAccount

### DIFF
--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -89,7 +89,9 @@ func printPipelineRunMetadata(w *tabwriter.Writer, pr *v1alpha1.PipelineRun) {
 	fmt.Fprintf(w, "Name:\t%s\n", pr.Name)
 	fmt.Fprintf(w, "Namespace:\t%s\n", pr.Namespace)
 	fmt.Fprintf(w, "Pipeline Ref:\t%s\n", pr.Spec.PipelineRef.Name)
-	fmt.Fprintf(w, "Service Account:\t%s\n", pr.Spec.ServiceAccount)
+	if pr.Spec.ServiceAccount != "" {
+		fmt.Fprintf(w, "Service Account:\t%s\n", pr.Spec.ServiceAccount)
+	}
 }
 
 func printPipelineRunStatus(w *tabwriter.Writer, pr *v1alpha1.PipelineRun, p cli.Params) {

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -66,9 +66,7 @@ func TestPipelineRunDescribe_only_taskrun(t *testing.T) {
 			tb.PipelineRun("pipeline-run", "ns",
 				cb.PipelineRunCreationTimestamp(clock.Now()),
 				tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-				tb.PipelineRunSpec("pipeline",
-					tb.PipelineRunServiceAccount("test-sa"),
-				),
+				tb.PipelineRunSpec("pipeline"),
 				tb.PipelineRunStatus(
 					tb.PipelineRunTaskRunsStatus(map[string]*v1alpha1.PipelineRunTaskRunStatus{
 						"tr-1": {
@@ -95,10 +93,9 @@ func TestPipelineRunDescribe_only_taskrun(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	expected := `Name:              pipeline-run
-Namespace:         ns
-Pipeline Ref:      pipeline
-Service Account:   test-sa
+	expected := `Name:           pipeline-run
+Namespace:      ns
+Pipeline Ref:   pipeline
 
 Status
 STARTED          DURATION    STATUS


### PR DESCRIPTION
# Changes

This will fix showing empty serviceaccount in
pipelinerun description in case if it is not
set.

Fixes https://github.com/tektoncd/cli/issues/80

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

```
release-note
```
