### PR TITLE
Fix #112 brew formula pedantic warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,16 +52,13 @@ brews:
       name: homebrew-tektoncd-cli
     folder: Formula
     homepage: "https://github.com/tektoncd/cli"
-    description: A CLI for interacting with Tekton!
+    description: Tekton CLI - The command line interface for interacting with Tekton
     test: |
-      system "#{bin}/tkn --version"
+      system "#{bin}/tkn", "--version"
     install: |
       bin.install "tkn" => "tkn"
-
       output = Utils.popen_read("SHELL=bash #{bin}/tkn completion bash")
       (bash_completion/"tkn").write output
-
       output = Utils.popen_read("SHELL=zsh #{bin}/tkn completion zsh")
       (zsh_completion/"_tkn").write output
-
       prefix.install_metafiles


### PR DESCRIPTION
I am not really sure I fully agree with those rules but whatever roll the brew
boat I am in,

Fixes #112 

tested with :

```bash
% brew audit --strict tektoncd-cli
```