### PR TITLE
Fix "Did you mean this" for mistyped command

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,9 +15,6 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/completion"
@@ -45,39 +42,5 @@ func Root(p cli.Params) *cobra.Command {
 		version.Command(),
 	)
 
-	visitCommands(cmd, reconfigureCmdWithSubcmd)
-
 	return cmd
-}
-
-// reconfigureCmdWithSubcmd reconfigures each root command with a list of all subcommands and lists them
-// beside the help output
-func reconfigureCmdWithSubcmd(cmd *cobra.Command) {
-	if len(cmd.Commands()) == 0 {
-		return
-	}
-
-	if cmd.Args == nil {
-		cmd.Args = cobra.ArbitraryArgs
-	}
-
-	if cmd.RunE == nil {
-		cmd.RunE = ShowSubcommands
-	}
-}
-
-// ShowSubcommands shows all available subcommands.
-func ShowSubcommands(cmd *cobra.Command, args []string) error {
-	var strs []string
-	for _, subcmd := range cmd.Commands() {
-		strs = append(strs, subcmd.Use)
-	}
-	return fmt.Errorf("Use one of available subcommands: %s", strings.Join(strs, ", "))
-}
-
-func visitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
-	f(cmd)
-	for _, child := range cmd.Commands() {
-		visitCommands(child, f)
-	}
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -1,20 +1,22 @@
 package cmd
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/cli/pkg/test"
-	"testing"
 )
 
-func TestCommand_invalid(t *testing.T) {
+func TestCommand_suggest(t *testing.T) {
 	p := &test.Params{}
 	pipelinerun := Root(p)
-	out, err := test.ExecuteCommand(pipelinerun)
+	out, err := test.ExecuteCommand(pipelinerun, "pi")
 	if err == nil {
 		t.Errorf("No errors was defined. Output: %s", out)
 	}
-	expected := "Use one of available subcommands: completion [SHELL], help [command], pipeline, pipelinerun, task, taskrun, version"
+	expected := "unknown command \"pi\" for \"tkn\"\n\nDid you mean this?\n\tpipeline\n\tpipelinerun\n"
 	if d := cmp.Diff(expected, err.Error()); d != "" {
 		t.Errorf("Unexpected output mismatch: %s", d)
+
 	}
 }


### PR DESCRIPTION
Remove old code and add an explicit test for suggestions.

Fix bug #136

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ✓ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ 🤷‍♂ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ✓] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Suggest command if you misstyped them, i.e: 
````
<img width="695" alt="image" src="https://user-images.githubusercontent.com/98980/60530423-fce1f500-9cf8-11e9-9fa4-2e8f88787a46.png">

