### PR TITLE
Reset the flags before adding to it

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,7 +15,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/completion"
 	"github.com/tektoncd/cli/pkg/cmd/pipeline"
@@ -26,6 +29,10 @@ import (
 )
 
 func Root(p cli.Params) *cobra.Command {
+	// Reset CommandLine so we don't get the flags from the libraries, i.e:
+	// azure library adding --azure-container-registry-config
+	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
 	var cmd = &cobra.Command{
 		Use:   "tkn",
 		Short: "CLI for tekton pipelines",

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -1,11 +1,29 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/pflag"
 	"github.com/tektoncd/cli/pkg/test"
 )
+
+func TestCommand_no_global_flags(t *testing.T) {
+	unwantedflag := "OPTION-SHOULD-NOT-BE-HERE"
+	pflag.String(unwantedflag, "", "An option that we really don't want to show")
+
+	p := &test.Params{}
+	pipelinerun := Root(p)
+	out, err := test.ExecuteCommand(pipelinerun)
+	if err != nil {
+		t.Errorf("An error has occured. Output: %s", out)
+	}
+
+	if strings.Contains(out, unwantedflag) {
+		t.Errorf("The Flag: %s, should not have been added to the global flags", unwantedflag)
+	}
+}
 
 func TestCommand_suggest(t *testing.T) {
 	p := &test.Params{}
@@ -17,6 +35,5 @@ func TestCommand_suggest(t *testing.T) {
 	expected := "unknown command \"pi\" for \"tkn\"\n\nDid you mean this?\n\tpipeline\n\tpipelinerun\n"
 	if d := cmp.Diff(expected, err.Error()); d != "" {
 		t.Errorf("Unexpected output mismatch: %s", d)
-
 	}
 }


### PR DESCRIPTION
We had flags coming from the libraries showing up in the help messages (i.e:
--azure-container-registry-config).

Let's reset them and if we really need it we can add them manually.

Closes #65 

/cc @hrishin 