### PR TITLE
Implement --tail for logs

### DIFF
--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -33,6 +33,7 @@ type LogOptions struct {
 	taskrunName string
 	allSteps    bool
 	follow      bool
+	taillines   int64
 	stream      *cli.Stream
 	params      cli.Params
 	streamer    stream.NewStreamerFunc
@@ -44,7 +45,7 @@ func logCommand(p cli.Params) *cobra.Command {
 # show the logs of TaskRun named "foo" from the namespace "bar"
 tkn taskrun logs foo -n bar
 
-# show the live logs of TaskRun named "foo" from the namespace "bar" 
+# show the live logs of TaskRun named "foo" from the namespace "bar"
 tkn taskrun logs -f foo -n bar
 `
 	c := &cobra.Command{
@@ -67,6 +68,7 @@ tkn taskrun logs -f foo -n bar
 
 	c.Flags().BoolVarP(&opts.allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream live logs")
+	c.Flags().Int64VarP(&opts.taillines, "tail", "", -1, "Lines of recent log file to display.")
 
 	return c
 }
@@ -82,12 +84,13 @@ func (lo *LogOptions) run() error {
 	}
 
 	lr := &LogReader{
-		Run:      lo.taskrunName,
-		Ns:       lo.params.Namespace(),
-		Clients:  cs,
-		Streamer: lo.streamer,
-		Follow:   lo.follow,
-		AllSteps: lo.allSteps,
+		Run:       lo.taskrunName,
+		Ns:        lo.params.Namespace(),
+		Clients:   cs,
+		Streamer:  lo.streamer,
+		Follow:    lo.follow,
+		AllSteps:  lo.allSteps,
+		TailLines: lo.taillines,
 	}
 
 	logC, errC, err := lr.Read()

--- a/pkg/helper/pods/container.go
+++ b/pkg/helper/pods/container.go
@@ -17,8 +17,9 @@ package pods
 import (
 	"bufio"
 	"fmt"
-	"github.com/tektoncd/cli/pkg/helper/pods/stream"
 	"io"
+
+	"github.com/tektoncd/cli/pkg/helper/pods/stream"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -78,10 +79,11 @@ type LogReader struct {
 	containerName string
 	pod           *Pod
 	follow        bool
+	taillines     int64
 }
 
-func (c *Container) LogReader(follow bool) *LogReader {
-	return &LogReader{c.name, c.pod, follow}
+func (c *Container) LogReader(follow bool, taillines int64) *LogReader {
+	return &LogReader{c.name, c.pod, follow, taillines}
 }
 
 func (lr *LogReader) Read() (<-chan Log, <-chan error, error) {
@@ -89,6 +91,10 @@ func (lr *LogReader) Read() (<-chan Log, <-chan error, error) {
 	opts := &corev1.PodLogOptions{
 		Follow:    lr.follow,
 		Container: lr.containerName,
+	}
+
+	if lr.taillines > 0 {
+		opts.TailLines = &lr.taillines
 	}
 
 	stream, err := pod.Stream(opts)


### PR DESCRIPTION
Add a --tail as what kubectl does. It's not that accurate because we have other
stuff printed around with the extra labels. But I don't think it really matters.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ 🏗 ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [  🏗 ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [  ✔️  ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

```
Add --tail to logs command
```

Closes #125
