### PR TITLE
Removes azure-container flag ref from docs

### DIFF
--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -28,12 +28,6 @@ start       Start pipelines by creating a pipelinerun in a namespace
 -n, --namespace string    namespace to use (default: from $KUBECONFIG)
 ```
 
-### Options inherited from parent commands
-
-```
---azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
-```
-
 ### SEE ALSO
 
 * [tkn pipeline list](tkn_pipeline_list.md)	 - Lists all `pipelines` in a given namespace.

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -28,7 +28,7 @@ describe, desc
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string        Path to the file containing Azure container registry configuration information.
+container registry configuration information.
  -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
  -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -28,7 +28,6 @@ list, ls
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string         Path to the file containing Azure container registry configuration information.
   -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -28,7 +28,7 @@ start, trigger
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string        Path to the file containing Azure container registry configuration information.
+container registry configuration information.
  -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
  -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -29,12 +29,6 @@ logs        Display pipelinerun logs
 -n, --namespace string    namespace to use (default: from $KUBECONFIG)
 ```
 
-### Options inherited from parent commands
-
-```
---azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
-```
-
 ### SEE ALSO
 
 * [tkn pipelinerun list](tkn_pipelinerun_list.md)	 - Lists all the pipelineruns in a given namespace.

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -28,7 +28,6 @@ describe, desc
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string        Path to the file containing Azure container registry configuration information.
  -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
  -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -30,7 +30,6 @@ list, ls
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string        Path to the file containing Azure container registry configuration information.
  -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
  -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -22,7 +22,6 @@ tkn pipelinerun logs NAME [flags]
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string        Path to the file containing Azure container registry configuration information.
  -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
  -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -26,12 +26,6 @@ list        Lists pipelineresources in a namespace
 -n, --namespace string    namespace to use (default: from $KUBECONFIG)
 ```
 
-### Options inherited from parent commands
-
-```
---azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
-```
-
 ### SEE ALSO
 
 * [tkn resource list](tkn_resource_list.md)	 - Lists all `pipelineresources` in a given namespace.

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -28,7 +28,6 @@ list, ls
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string         Path to the file containing Azure container registry configuration information.
   -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -26,12 +26,6 @@ list        Lists tasks in a namespace
 -n, --namespace string    namespace to use (default: from $KUBECONFIG)
 ```
 
-### Options inherited from parent commands
-
-```
---azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
-```
-
 ### SEE ALSO
 
 * [tkn task list](tkn_task_list.md)	 - Lists all the `tasks` in a given namespace.

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -28,7 +28,6 @@ list, ls
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string         Path to the file containing Azure container registry configuration information.
   -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -27,12 +27,6 @@ logs        Displays taskrun logs
 -n, --namespace string    namespace to use (default: from $KUBECONFIG)
 ```
 
-### Options inherited from parent commands
-
-```
---azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
-```
-
 ### SEE ALSO
 
 * [tkn taskrun list](tkn_taskrun_list.md)	 - Lists all `taskruns` in a given namespace.

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -28,7 +28,6 @@ list, ls
 ### Options inherited from parent commands
 
 ```
---azure-container-registry-config string         Path to the file containing Azure container registry configuration information.
   -k, --kubeconfig string                        kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string                         namespace to use (default: from $KUBECONFIG)
 ```


### PR DESCRIPTION
# Changes

Remove the Azure container refs from the doc.

Fixes#146

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

