### PR TITLE
Ensure GO111MODULE=on on verify-codegen.sh script

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -23,7 +23,6 @@ source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/library.sh
 cd ${REPO_ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
-export GO111MODULE=on
 go mod tidy
 go mod vendor
 

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
+export GO111MODULE=on
 readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
 
 cleanup() {


### PR DESCRIPTION
# Changes

Otherwise, `go mod vendor` is no-op if it's the default value (aka
`auto`)… Which is the case if the repository is checked out in the
GOPATH, which is the case in the CI…

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
