### PR TITLE
Makefile: add a FORCE target before bin/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 all: bin/tkn test
 
-bin/%: cmd/%
+FORCE:
+
+bin/%: cmd/% FORCE
 	@go build -v -o $@$(EXEC_EXT) ./$<
 
 check: lint test


### PR DESCRIPTION
# Changes

This will force the target to always execute, letting go do its
optimization when compiling (aka only recompiling what changed).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
