### PR TITLE
Fix Typos and Change go install Instructions in Development Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tags
 
 # VSCode specific
 .vscode
+
+#Mac
+.DS_Store

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,7 +97,7 @@ If you want this `tkn` binary in your `$PATH`, a couple options are:
 
 
 1. Use `go install ./cmd/...` to install the binary into your `$GOBIN`. Rerun
-   `go install` when you want to update the binary:
+   `go install ./cmd/...` when you want to update the binary:
 
    ```bash
    go install ./cmd/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,9 +116,9 @@ If you want this `tkn` binary on your `$PATH`, a couple options are:
    ```
 3. After it finishes, you can run the following to execute the binary to verify it works:
 
-  ```sh
-  ./tkn
-  ```
+   ```sh
+   ./tkn
+   ```
 
 Whether you have added the `tkn` binary to your current directory or added it to
 your `$PATH`, you are should now be ready to make changes to `tkn`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,7 +121,7 @@ If you want this `tkn` binary on your `$PATH`, a couple options are:
    ```
 
 Whether you have added the `tkn` binary to your current directory or added it to
-your `$PATH`, you are should now be ready to make changes to `tkn`.
+your `$PATH`, you are now be ready to make changes to `tkn`.
 
 **Notes:**
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,32 +84,44 @@ While iterating on the project, you may need to:
 
 [go mod](https://github.com/golang/go/wiki/Modules#quick-start) is used and required for dependencies.
 
-**Building:**
+**Building In Local Directory:**
+
+The following command builds the `tkn` binary in your current directory:
 
 ```sh
-go build ./cmd/...
+go build ./cmd/tkn
 ```
 
-It builds `tkn` binary in your current directory. You can start playing with
-it.
+After it finishes, you can run the following to execute the binary to
+verify it works:
 
-If you want this `tkn` binary in your `$PATH`, a couple options are:
+```sh
+./tkn
+```
+
+**Building and Adding to $PATH:**
+
+If you want this `tkn` binary on your `$PATH`, a couple options are:
 
 
-1. Use `go install ./cmd/...` to install the binary into your `$GOBIN`. Rerun
-   `go install ./cmd/...` when you want to update the binary:
-
-   ```bash
-   go install ./cmd/
-   ```
+1. Use `go install ./cmd/tkn` to install the binary into your `$GOBIN`. Rerun
+`go install ./cmd/tkn` when you want to update the binary.
 
 2. Add a soft link to the binary into your `$PATH`. Rerun `go build` when
    you want to update the binary.
 
    ```bash
-   go build ./cmd/...
+   go build ./cmd/tkn
    ln -s $PWD/tkn $GOPATH/bin/tkn
    ```
+3. After it finishes, you can run the following to execute the binary to verify it works:
+
+  ```sh
+  ./tkn
+  ```
+
+Whether you have added the `tkn` binary to your current directory or added it to
+your `$PATH`, you are should now be ready to make changes to `tkn`.
 
 **Notes:**
 
@@ -118,7 +130,7 @@ If you want this `tkn` binary in your `$PATH`, a couple options are:
 
 ```sh
 # if you are building in your $GOPATH
-GO111MODULE=on go build ./cmd/...
+GO111MODULE=on go build ./cmd/tkn
 ```
 
 You can now try updating code for client and test out the changes by building the `tkn` binary.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,8 +66,8 @@ registry, you can add `storage-full` to your `--scopes` arg.
 
 ## Environment Setup
 
-To build the Tekton pipelines cli you'll need to set `GO111MODULE=on`
-enviroment variable to force `go` to use [go
+To build the Tekton pipelines cli, you'll need to set `GO111MODULE=on`
+environment variable to force `go` to use [go
 modules](https://github.com/golang/go/wiki/Modules#quick-start).
 
 ## Iterating
@@ -75,7 +75,7 @@ modules](https://github.com/golang/go/wiki/Modules#quick-start).
 While iterating on the project, you may need to:
 
 1. [Install Tekton pipeline](#install-pipeline)
-2. [Buildking Tekton client](#building-tekton-client)
+2. [Building Tekton client](#building-tekton-client)
 1. [Add and run tests](./test/README.md#tests)
 
 ## Building Tekton client
@@ -96,7 +96,7 @@ it.
 If you want this `tkn` binary in your `$PATH`, a couple options are:
 
 
-1. Use `go install ./cmd/` to install the binary into your `$GOBIN`. Rerun
+1. Use `go install ./cmd/...` to install the binary into your `$GOBIN`. Rerun
    `go install` when you want to update the binary:
 
    ```bash


### PR DESCRIPTION
# Changes

This pull request touches up the Development Guide to address the following:
* Typos under the `Environment Setup` and `Iterating` sections
* Changes `go install ./cmd/` to `go install ./cmd/tkn` under the `Building` section
* Changes `go build ./cmd/...` to `go build ./cmd/tkn` under the `Building` section
* Adds `.DS_Store` to the `.gitignore`

**Why make these changes?**

The main issue I ran into in setting up my local dev environment with the CLI was getting the `go install ./cmd/` to save the binary to my `$GOBIN`. Running `go install ./cmd/tkn` in the root directory of where I cloned tektoncd/cli locally helped me successfully save the binaries to my `$GOBIN`. Additionally, adding changes required another run of `go install ./cmd/tkn`.

I also updated `go build ./cmd/...` references to `go build ./cmd/tkn`.

Adding `.DS_Store` to the `gitignore` will help those working on a Mac.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

It faces users in the sense that this is documentation that will help developers make contributions to the Tekton CLI. 

```
Edited go build and install commands in Development Guide from go install ./cmd/ to go install ./cmd/tkn and go build ./cmd/... to go build ./cmd/tkn
```
