### PR TITLE
Closes #59: Sort pipelineruns by Start Time

### DIFF
--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"sort"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
@@ -125,6 +126,8 @@ func printFormatted(s *cli.Stream, prs *v1alpha1.PipelineRunList, c clockwork.Cl
 		return nil
 	}
 
+	sort.Sort(byStartTime(prs.Items))
+	
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "NAME\tSTARTED\tDURATION\tSTATUS\t")
 	for _, pr := range prs.Items {
@@ -138,3 +141,9 @@ func printFormatted(s *cli.Stream, prs *v1alpha1.PipelineRunList, c clockwork.Cl
 
 	return w.Flush()
 }
+
+type byStartTime []v1alpha1.PipelineRun
+
+func (s byStartTime) Len() int           { return len(s) }
+func (s byStartTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byStartTime) Less(i, j int) bool { return s[j].Status.StartTime.Before(s[i].Status.StartTime) }


### PR DESCRIPTION
Closes #59 

This pull request adds sorting to the `printFormatted` function in `list.go` for `pipelineruns`. This will sort `pipelineruns` by their start times.

Any guidance on testing to be added would be appreciated. 

# Changes

The following is called from `printFormatted`:

```
type byStartTime []v1alpha1.PipelineRun

func (s byStartTime) Len() int           { return len(s) }
func (s byStartTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
func (s byStartTime) Less(i, j int) bool { return s[j].Status.StartTime.Before(s[i].Status.StartTime) }
```

Output for the new functionality can be seen below:

![image](https://user-images.githubusercontent.com/34258252/61095563-edae2600-a421-11e9-874f-01c130c05cbf.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
tkn pr ls now sorts pipelineruns by their start times
```
