### PR TITLE
Fixes segfaults for taskrun list

### DIFF
--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -17,8 +17,8 @@ package taskrun
 import (
 	"fmt"
 	"os"
-	"text/tabwriter"
 	"sort"
+	"text/tabwriter"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
@@ -131,6 +131,10 @@ func printFormatted(s *cli.Stream, trs *v1alpha1.TaskRunList, c clockwork.Clock)
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "NAME\tSTARTED\tDURATION\tSTATUS\t")
 	for _, tr := range trs.Items {
+		if len(tr.Status.Conditions) == 0 {
+			tr.Status.InitializeConditions()
+		}
+
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t\n",
 			tr.Name,
 			formatted.Age(*tr.Status.StartTime, c),


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
At present list command safely assumes that TaskRun.Status
has some condition. However, it may be the case that TaskRun.Status.Conditions
would be empty. Which cause segmentation faults while printing status
column.

This patch fixes the segfaults by initializing the condition, in case its
absent.

Fixes https://github.com/tektoncd/cli/issues/168
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

