### PR TITLE
Correct Mac OS X Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tekton !
 
 Download the latest binary executable for your operating system:
 
-* [Max OS X](https://github.com/tektoncd/cli/releases/download/v0.1.2/tkn_0.1.2_Darwin_x86_64.tar.gz)
+* [Mac OS X](https://github.com/tektoncd/cli/releases/download/v0.1.2/tkn_0.1.2_Darwin_x86_64.tar.gz)
 
   ```shell
   # Get the tar.xz
@@ -46,11 +46,11 @@ Download the latest binary executable for your operating system:
   sudo tar xvzf tkn_0.1.2_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
   ```
 
-If you have [go](https://golang.org/) installed `GO111MODULE="on" go get github.com/tektoncd/cli@v0.1.2` is all you need!
+If you have [go](https://golang.org/) installed, `GO111MODULE="on" go get github.com/tektoncd/cli@v0.1.2` is all you need!
 
 ### Useful Commands
 
-The following commands help you understand and effectively use Tekton CLI:
+The following commands help you understand and effectively use the Tekton CLI:
 
  * `tkn help:` Displays a list of the commands with helpful information.
  * [`tkn completion:`](docs/cmd/tkn_completion.md) Outputs a BASH completion script for `tkn` to allow command completion with Tab.
@@ -60,9 +60,7 @@ The following commands help you understand and effectively use Tekton CLI:
  * [`tkn task:`](docs/cmd/tkn_task.md) Parent command of the Task command group.
  * [`tkn taskrun:`](docs/cmd/tkn_taskrun.md) Parent command of the Taskrun command group.
 
-For every tkn command you can use `-h` or `--help` flags to display specific help for that command.
-
-
+For every `tkn` command, you can use `-h` or `--help` flags to display specific help for that command.
 
 ## Want to contribute
 


### PR DESCRIPTION
This pull request fixes the the `Max OS X` typo in the main `README`. Should be `Mac OS X`. It also makes minor edits to the rest of the README.

# Changes

* Changed `Max OS X` to `Mac OS X`
* Added comma after `If you have go installed,` and `For every tkn command,`
* Added `the` in the following sentence: `The following commands help you understand and effectively use the Tekton CLI:`
* Added `` around `tkn` in the sentence in the bullet point above

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

No release note necessary.
