### PR TITLE
Fix case sensitive in resource list

### DIFF
--- a/pkg/cmd/pipelineresource/list.go
+++ b/pkg/cmd/pipelineresource/list.go
@@ -17,6 +17,7 @@ package pipelineresource
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -127,13 +128,13 @@ func printFormatted(s *cli.Stream, pres *v1alpha1.PipelineResourceList) error {
 }
 
 func details(pre v1alpha1.PipelineResource) string {
-	var key = "URL"
+	var key = "url"
 	if pre.Spec.Type == v1alpha1.PipelineResourceTypeStorage {
-		key = "Location"
+		key = "location"
 	}
 
 	for _, p := range pre.Spec.Params {
-		if p.Name == key {
+		if strings.ToLower(p.Name) == key {
 			return p.Name + ": " + p.Value
 		}
 	}

--- a/pkg/cmd/pipelineresource/list_test.go
+++ b/pkg/cmd/pipelineresource/list_test.go
@@ -36,7 +36,7 @@ func TestPipelineResources(t *testing.T) {
 		),
 		tb.PipelineResource("test-2", "test-ns-1",
 			tb.PipelineResourceSpec("git",
-				tb.PipelineResourceSpecParam("URL", "git@github.com:tektoncd/cli.git"),
+				tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
 			),
 		),
 		tb.PipelineResource("test-3", "test-ns-1",
@@ -62,7 +62,7 @@ func TestPipelineResources(t *testing.T) {
 			expected: []string{
 				"NAME     TYPE    DETAILS",
 				"test-1   image   URL: quey.io/tekton/controller",
-				"test-2   git     URL: git@github.com:tektoncd/cli.git",
+				"test-2   git     url: git@github.com:tektoncd/cli.git",
 				"test-3   image   ---",
 				"",
 			},


### PR DESCRIPTION
# Changes

Fix the issue of case sensitive when the key is url or Url,
it only shows when it is URL, also same for location key in
case of storage resource

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
