### PR TITLE
Improve sort feature in tr and pr list

### DIFF
--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -17,8 +17,8 @@ package pipelinerun
 import (
 	"fmt"
 	"os"
-	"text/tabwriter"
 	"sort"
+	"text/tabwriter"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
@@ -109,6 +109,10 @@ func list(p cli.Params, pipeline string) (*v1alpha1.PipelineRunList, error) {
 		return nil, err
 	}
 
+	if len(prs.Items) != 0 {
+		sort.Sort(byStartTime(prs.Items))
+	}
+
 	// NOTE: this is required for -o json|yaml to work properly since
 	// tektoncd go client fails to set these; probably a bug
 	prs.GetObjectKind().SetGroupVersionKind(
@@ -126,8 +130,6 @@ func printFormatted(s *cli.Stream, prs *v1alpha1.PipelineRunList, c clockwork.Cl
 		return nil
 	}
 
-	sort.Sort(byStartTime(prs.Items))
-	
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "NAME\tSTARTED\tDURATION\tSTATUS\t")
 	for _, pr := range prs.Items {

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -39,7 +39,7 @@ func TestListPipelineRuns(t *testing.T) {
 
 	pr1Started := clock.Now().Add(10 * time.Second)
 	pr2Started := clock.Now().Add(-2 * time.Hour)
-	pr3Started := clock.Now().Add(-450 * time.Hour)
+	pr3Started := clock.Now().Add(-1 * time.Hour)
 
 	prs := []*v1alpha1.PipelineRun{
 		tb.PipelineRun("pr1-1", "namespace",
@@ -99,8 +99,8 @@ func TestListPipelineRuns(t *testing.T) {
 			expected: []string{
 				"NAME    STARTED          DURATION   STATUS               ",
 				"pr1-1   59 minutes ago   1 minute   Succeeded            ",
+				"pr2-2   2 hours ago      1 minute   Failed               ",
 				"pr2-1   3 hours ago      ---        Succeeded(Running)   ",
-				"pr2-2   2 weeks ago      1 minute   Failed               ",
 				"",
 			},
 		},
@@ -110,8 +110,8 @@ func TestListPipelineRuns(t *testing.T) {
 			args:    []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			expected: []string{
 				"pr1-1",
-				"pr2-1",
 				"pr2-2",
+				"pr2-1",
 				"",
 			},
 		},

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -126,5 +126,3 @@ func listAllTasks(cs versioned.Interface, ns string) (*v1alpha1.TaskList, error)
 		})
 	return tasks, nil
 }
-
-

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -109,6 +109,10 @@ func list(p cli.Params, task string) (*v1alpha1.TaskRunList, error) {
 		return nil, err
 	}
 
+	if len(trs.Items) != 0 {
+		sort.Sort(byStartTime(trs.Items))
+	}
+
 	// NOTE: this is required for -o json|yaml to work properly since
 	// tektoncd go client fails to set these; probably a bug
 	trs.GetObjectKind().SetGroupVersionKind(
@@ -125,8 +129,6 @@ func printFormatted(s *cli.Stream, trs *v1alpha1.TaskRunList, c clockwork.Clock)
 		fmt.Fprintln(s.Err, emptyMsg)
 		return nil
 	}
-
-	sort.Sort(byStartTime(trs.Items))
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "NAME\tSTARTED\tDURATION\tSTATUS\t")

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -35,6 +35,7 @@ import (
 func TestListTaskRuns(t *testing.T) {
 	now := time.Now()
 	aMinute, _ := time.ParseDuration("1m")
+	twoMinute, _ := time.ParseDuration("2m")
 
 	trs := []*v1alpha1.TaskRun{
 		tb.TaskRun("tr1-1", "foo",
@@ -68,8 +69,8 @@ func TestListTaskRuns(t *testing.T) {
 					Status: corev1.ConditionFalse,
 					Reason: resources.ReasonFailed,
 				}),
-				tb.TaskRunStartTime(now),
-				taskRunCompletionTime(now.Add(aMinute)),
+				tb.TaskRunStartTime(now.Add(aMinute)),
+				taskRunCompletionTime(now.Add(twoMinute)),
 			),
 		),
 	}
@@ -95,10 +96,10 @@ func TestListTaskRuns(t *testing.T) {
 			command: command(t, trs, now),
 			args:    []string{"list", "-n", "foo"},
 			expected: []string{
-				"NAME    STARTED      DURATION   STATUS      ",
-				"tr1-1   1 hour ago   1 minute   Succeeded   ",
-				"tr2-1   1 hour ago   ---        Running     ",
-				"tr2-2   1 hour ago   1 minute   Failed      ",
+				"NAME    STARTED          DURATION   STATUS      ",
+				"tr2-2   59 minutes ago   1 minute   Failed      ",
+				"tr1-1   1 hour ago       1 minute   Succeeded   ",
+				"tr2-1   1 hour ago       ---        Running     ",
 				"",
 			},
 		},
@@ -107,9 +108,9 @@ func TestListTaskRuns(t *testing.T) {
 			command: command(t, trs, now),
 			args:    []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			expected: []string{
+				"tr2-2",
 				"tr1-1",
 				"tr2-1",
-				"tr2-2",
 				"",
 			},
 		},


### PR DESCRIPTION
This will improve the output experience for user in case of
tr and pr list

Now it shows tr and pr in sorted order in case of tr or pr ls
in standard format but in case of output in json or yaml
format or others it shows different order

It should be consistent for all