### PR TITLE
Make sure we get only the latest release.yaml

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -124,7 +124,9 @@ function run_yaml_tests() {
 
 function install_pipeline_crd() {
   echo ">> Deploying Tekton Pipelines"
-  kubectl apply -f https://github.com/tektoncd/pipeline/releases/download/v0.4.0/release.yaml ||
+  local latestreleaseyaml=$(curl -s https://api.github.com/repos/tektoncd/pipeline/releases|python -c "import sys, json;x=json.load(sys.stdin);ass=x[0]['assets'];print([ x['browser_download_url'] for x in ass if x['name'] == 'release.yaml'][0])")
+  [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
+  kubectl apply -f ${latestreleaseyaml} ||
     fail_test "Build pipeline installation failed"
 
   # Make sure thateveything is cleaned up in the current namespace.


### PR DESCRIPTION
When setupping the (Currently unused) pipeline environment for e2e tests we were
using a static version, let's make sure we use only latest with a bit of magic
with python which should be available everywhere.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

