### PR TITLE
Symlink kubectl-tkn to tkn in brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,7 @@ brews:
     test: |
       system "#{bin}/tkn", "--version"
     install: |
+      bin.install_symlink "tkn" => "kubectl-tkn"
       bin.install "tkn" => "tkn"
       output = Utils.popen_read("SHELL=bash #{bin}/tkn completion bash")
       (bash_completion/"tkn").write output


### PR DESCRIPTION
So we can do `kubectl tkn` ....

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
