### PR TITLE
Add type flag to resource list

### DIFF
--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -28,6 +28,7 @@ tkn pre list -n foo",
   -h, --help                          help for list
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+  -t, --type string                   Pipeline resource type
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_version.md
+++ b/docs/cmd/tkn_version.md
@@ -15,7 +15,8 @@ Prints version information
 ### Options
 
 ```
-  -h, --help   help for version
+  -c, --check   check if a newer version is available
+  -h, --help    help for version
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-resource-list.1
+++ b/docs/man/man1/tkn-resource-list.1
@@ -36,6 +36,10 @@ Lists pipeline resources in a namespace
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].
 
+.PP
+\fB\-t\fP, \fB\-\-type\fP=""
+    Pipeline resource type
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/tkn-version.1
+++ b/docs/man/man1/tkn-version.1
@@ -20,6 +20,10 @@ Prints version information
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-check\fP[=false]
+    check if a newer version is available
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for version
 


### PR DESCRIPTION
This will add a flag type to resource list command
which will list the resources filter by the given
type
It will show error in case of invalid type

Add docs and tests

Fix https://github.com/tektoncd/cli/issues/147

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)