### PR TITLE
Add Limit Option for PipelineRuns

### DIFF
--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -29,6 +29,7 @@ tkn pr list -n foo",
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
+  -l, --limit int                     limit pipelineruns listed (default: return all pipelineruns)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"fmt"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
@@ -112,6 +113,42 @@ func TestListPipelineRuns(t *testing.T) {
 				"pr1-1",
 				"pr2-2",
 				"pr2-1",
+				"",
+			},
+		},
+		{
+			name:    "limit pipelineruns returned to 1",
+			command: command(t, prs, clock.Now()),
+			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", 1)},
+			expected: []string{
+				"NAME    STARTED          DURATION   STATUS      ",
+				"pr1-1   59 minutes ago   1 minute   Succeeded   ",
+				"",
+			},
+		},
+		{
+			name:    "limit pipelineruns negative case",
+			command: command(t, prs, clock.Now()),
+			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", -1)},
+			expected: []string{
+				"",
+			},
+		},
+		{
+			name:    "limit pipelineruns greater than maximum case",
+			command: command(t, prs, clock.Now()),
+			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", 4)},
+			expected: []string{
+				"",
+			},
+		},
+		{
+			name:    "limit pipelineruns with output flag set",
+			command: command(t, prs, clock.Now()),
+			args:    []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "-l", fmt.Sprintf("%d", 2)},
+			expected: []string{
+				"pr1-1",
+				"pr2-2",
 				"",
 			},
 		},

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -75,5 +75,6 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 	if ns != "" {
 		p.SetNamespace(ns)
 	}
+
 	return nil
 }


### PR DESCRIPTION
This pull request partially addresses #163. It adds a local flag for `--limit` for `pipelineruns`. The `--limit` flag will allow a user to specify how many `pipelineruns` are returned from `tkn pr ls`. 

If this pull request is accepted, I can implement this same approach for other list commands where `--limit` would be a good use case. 

### Usage

**Returns 5 pipelineruns with most recent start time**

`tkn pr ls --limit 5`

### Acceptable Input

`--limit` must be less than the total number of `pipelineruns` for a particular namespace and also greater than 0

### Default Case

The default case will return all `pipelineruns` for a particular namespace

### Local Results

![image](https://user-images.githubusercontent.com/34258252/61839568-1095fc80-ae5c-11e9-824d-66c0d0a91dc7.png)

# Changes

* A `Limit` field was added to the cli interface
* `Limit` added as flag under `flags.go`
* Logic was implemented under `pipelinerun/list.go` to slice the list of `pipelineruns` returned if `--limit` is passed in by user
* Tests were added to validate `--limit` logic

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds a limit flag to limit the amount of pipelineruns returned by the pipelinerun list command
```
