### PR TITLE
InitParams before arg validation in pipeline start

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -82,9 +82,9 @@ tkn pipeline start foo --param NAME=VALUE --resource source=scaffold-git  -s Ser
 `,
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
-			initResult := flags.InitParams(p, cmd)
-			if initResult != nil {
-				return initResult
+			err := flags.InitParams(p, cmd)
+			if err != nil {
+				return err
 			}
 			return NameArg(args, p)
 		},

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -56,7 +56,6 @@ func NameArg(args []string, p cli.Params) error {
 	}
 
 	name, ns := args[0], p.Namespace()
-  fmt.Println("Namespace is: ", ns)
 	_, err = c.Tekton.TektonV1alpha1().Pipelines(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return errInvalidPipeline

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -45,7 +45,7 @@ type startOptions struct {
 }
 
 // NameArg validates that the first argument is a valid pipeline name
-func NameArg(cmd *cobra.Command, args []string, p cli.Params) error {
+func NameArg(args []string, p cli.Params) error {
 	if len(args) == 0 {
 		return errNoPipeline
 	}
@@ -56,6 +56,7 @@ func NameArg(cmd *cobra.Command, args []string, p cli.Params) error {
 	}
 
 	name, ns := args[0], p.Namespace()
+  fmt.Println("Namespace is: ", ns)
 	_, err = c.Tekton.TektonV1alpha1().Pipelines(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return errInvalidPipeline
@@ -86,7 +87,7 @@ tkn pipeline start foo --param NAME=VALUE --resource source=scaffold-git  -s Ser
 			if initResult != nil {
 				return initResult
 			}
-			return NameArg(cmd, args, p)
+			return NameArg(args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -384,7 +384,7 @@ func Test_start_pipeline_client_error(t *testing.T) {
 	pipelineName := "test-pipeline"
 
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline(pipelineName, "foo",
+		tb.Pipeline(pipelineName, "namespace",
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineParam("pipeline-param", tb.PipelineParamDefault("somethingdifferent")),
@@ -410,7 +410,7 @@ func Test_start_pipeline_client_error(t *testing.T) {
 		"-r=source=scaffold-git",
 		"-p=key1=value1",
 		"-s=svc1",
-		"-n=ns")
+		"-n=namespace")
 
 	expected := "Error: mock error\n"
 	tu.AssertOutput(t, expected, got)
@@ -421,7 +421,7 @@ func Test_start_pipeline_resource_error(t *testing.T) {
 	pipelineName := "test-pipeline"
 
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline(pipelineName, "foo",
+		tb.Pipeline(pipelineName, "namespace",
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineParam("pipeline-param", tb.PipelineParamDefault("somethingdifferent")),
@@ -443,7 +443,7 @@ func Test_start_pipeline_resource_error(t *testing.T) {
 		"-r scaffold-git",
 		"-p=key1=value1",
 		"-s=svc1",
-		"-n=ns")
+		"-n=namespace")
 	expected := "Error: invalid resource parameter:  scaffold-git\n Please pass resource as -p ResourceName=ResourceRef\n"
 
 	tu.AssertOutput(t, expected, got)
@@ -454,7 +454,7 @@ func Test_start_pipeline_param_error(t *testing.T) {
 	pipelineName := "test-pipeline"
 
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline(pipelineName, "foo",
+		tb.Pipeline(pipelineName, "namespace",
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineParam("pipeline-param", tb.PipelineParamDefault("somethingdifferent")),
@@ -477,7 +477,7 @@ func Test_start_pipeline_param_error(t *testing.T) {
 		"-r=source=scaffold-git",
 		"-p value1",
 		"-s=svc1",
-		"-n=ns")
+		"-n=namespace")
 	expected := "Error: invalid param parameter:  value1\n Please pass resource as -r ParamName=ParamValue\n"
 
 	tu.AssertOutput(t, expected, got)


### PR DESCRIPTION
Fixes https://github.com/tektoncd/cli/issues/195

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Invoke `InitParams` so that the namespace will get set before trying to
validate the pipeline exists. Without this the `default` namespace will
be used even if `--namespace` is set and cause confusion for users in a
fresh cli environment that does not have a namespace set for the current
context.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Ensure namespace flag is honored when detecting pipelines when using pipeline start.
```
