### PR TITLE
grouped commands into logical groups for cli usage and help

### DIFF
--- a/pkg/cmd/clustertask/clustertask.go
+++ b/pkg/cmd/clustertask/clustertask.go
@@ -25,6 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "clustertask",
 		Aliases: []string{"ct", "clustertasks"},
 		Short:   "Manage clustertasks",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -46,6 +46,9 @@ func Command() *cobra.Command {
 		Long:      desc,
 		ValidArgs: []string{"bash", "zsh"},
 		Example:   eg,
+		Annotations: map[string]string{
+			"commandType": "utility",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -25,6 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "pipeline",
 		Aliases: []string{"p", "pipelines"},
 		Short:   "Manage pipelines",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},

--- a/pkg/cmd/pipelineresource/pipelineresource.go
+++ b/pkg/cmd/pipelineresource/pipelineresource.go
@@ -25,6 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "resource",
 		Aliases: []string{"res", "resources"},
 		Short:   "Manage pipeline resources",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -26,6 +26,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "pipelinerun",
 		Aliases: []string{"pr", "pipelineruns"},
 		Short:   "Manage pipelineruns",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -42,7 +42,8 @@ Examples:
 
 Available Commands:{{range .Commands}}{{if (eq .Annotations.commandType "main")}}
 {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
-{{range .Commands}}{{if or (eq .Annotations.commandType "utility") (eq .Name "help")}}
+
+Other Commands:{{range .Commands}}{{if or (eq .Annotations.commandType "utility") (eq .Name "help")}}
 {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,6 +30,33 @@ import (
 	"github.com/tektoncd/cli/pkg/cmd/version"
 )
 
+const usageTemplate = `Usage:{{if .Runnable}}
+{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+{{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (eq .Annotations.commandType "main")}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+{{range .Commands}}{{if or (eq .Annotations.commandType "utility") (eq .Name "help")}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
 func Root(p cli.Params) *cobra.Command {
 	// Reset CommandLine so we don't get the flags from the libraries, i.e:
 	// azure library adding --azure-container-registry-config
@@ -41,6 +68,7 @@ func Root(p cli.Params) *cobra.Command {
 		Long:                   ``,
 		BashCompletionFunction: completion.BashCompletionFunc,
 	}
+	cmd.SetUsageTemplate(usageTemplate)
 
 	cmd.AddCommand(
 		completion.Command(),

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,19 +32,19 @@ import (
 
 const usageTemplate = `Usage:{{if .Runnable}}
 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
-{{.NameAndAliases}}{{end}}{{if .HasExample}}
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (eq .Annotations.commandType "main")}}
-{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
 
 Other Commands:{{range .Commands}}{{if (eq .Annotations.commandType "utility")}}
-{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,7 +32,7 @@ import (
 
 const usageTemplate = `Usage:{{if .Runnable}}
 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-{{.CommandPath}} [command] [options]{{end}}{{if gt (len .Aliases) 0}}
+{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
 {{.NameAndAliases}}{{end}}{{if .HasExample}}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,7 +32,7 @@ import (
 
 const usageTemplate = `Usage:{{if .Runnable}}
 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+{{.CommandPath}} [command] [options]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
 {{.NameAndAliases}}{{end}}{{if .HasExample}}
@@ -43,7 +43,7 @@ Examples:
 Available Commands:{{range .Commands}}{{if (eq .Annotations.commandType "main")}}
 {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
 
-Other Commands:{{range .Commands}}{{if or (eq .Annotations.commandType "utility") (eq .Name "help")}}
+Other Commands:{{range .Commands}}{{if (eq .Annotations.commandType "utility")}}
 {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -25,6 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "task",
 		Aliases: []string{"t", "tasks"},
 		Short:   "Manage tasks",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},

--- a/pkg/cmd/taskrun/taskrun.go
+++ b/pkg/cmd/taskrun/taskrun.go
@@ -25,6 +25,9 @@ func Command(p cli.Params) *cobra.Command {
 		Use:     "taskrun",
 		Aliases: []string{"tr", "taskruns"},
 		Short:   "Manage taskruns",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.InitParams(p, cmd)
 		},

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -41,6 +41,9 @@ func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "version",
 		Short: "Prints version information",
+		Annotations: map[string]string{
+			"commandType": "utility",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Created two groups - "main" and "utility" using annotation (key: "commandType"). Used the annotation in the usage template to format accordingly.
Fixes #179 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
The cli help and usage now have logical grouping of commands
```
