### PR TITLE
sorted taskruns related to pipelinerun for pr describe command

### DIFF
--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -165,7 +165,9 @@ func hasFailed(pr *v1alpha1.PipelineRun) string {
 	return ""
 }
 
-type taskrunList []struct {
+type taskrunList []tkr
+
+type tkr struct {
 	TaskrunName string
 	*v1alpha1.PipelineRunTaskRunStatus
 }
@@ -175,10 +177,7 @@ func newTaskrunListFromMap(statusMap map[string]*v1alpha1.PipelineRunTaskRunStat
 	var trl taskrunList
 
 	for taskrunName, taskrunStatus := range statusMap {
-		trl = append(trl, struct {
-			TaskrunName string
-			*v1alpha1.PipelineRunTaskRunStatus
-		}{
+		trl = append(trl, tkr{
 			taskrunName,
 			taskrunStatus,
 		})

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -68,12 +68,12 @@ NAME	VALUE
 {{- end }}
 
 Taskruns
-{{- $l := len .TaskRunList }}{{ if eq $l 0 }}
+{{- $l := len .TaskrunList }}{{ if eq $l 0 }}
 No taskruns
 {{- else }}
 NAME	TASK NAME	STARTED	DURATION	STATUS
-{{- range $taskrun := .TaskRunList }}
-{{ $taskrun.TaskRunName }}	{{ $taskrun.PipelineTaskName }}	{{ formatAge $taskrun.Status.StartTime $.Params.Time }}	{{ formatDuration $taskrun.Status.StartTime $taskrun.Status.CompletionTime }}	{{ formatCondition $taskrun.Status.Conditions }}
+{{- range $taskrun := .TaskrunList }}
+{{ $taskrun.TaskrunName }}	{{ $taskrun.PipelineTaskName }}	{{ formatAge $taskrun.Status.StartTime $.Params.Time }}	{{ formatDuration $taskrun.Status.StartTime $taskrun.Status.CompletionTime }}	{{ formatCondition $taskrun.Status.Conditions }}
 {{- end }}
 {{- end }}
 `


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Sorted the taskruns by start time for a specific pipelinerun in the `pr describe` command

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
pr desc command now shows taskruns in a sorted order by "start time"
```
