### PR TITLE
fixes nil ptr errors

### DIFF
--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -90,7 +90,7 @@ func printClusterTaskDetails(s *cli.Stream, p cli.Params) error {
 	for _, clustertask := range clustertasks.Items {
 		fmt.Fprintf(w, body,
 			clustertask.Name,
-			formatted.Age(clustertask.CreationTimestamp, p.Time()),
+			formatted.Age(&clustertask.CreationTimestamp, p.Time()),
 		)
 	}
 	return w.Flush()

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -233,7 +233,7 @@ func allRuns(p cli.Params, pName string) ([]string, error) {
 	ret := []string{}
 	for i, run := range runs.Items {
 		if i < 5 {
-			ret = append(ret, run.ObjectMeta.Name+" started "+formatted.Age(*run.Status.StartTime, p.Time()))
+			ret = append(ret, run.ObjectMeta.Name+" started "+formatted.Age(run.Status.StartTime, p.Time()))
 		}
 	}
 	return ret, nil

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -39,6 +39,7 @@ Service Account:	{{ .PipelineRun.Spec.ServiceAccount }}
 Status
 STARTED	DURATION	STATUS
 {{ formatAge .PipelineRun.Status.StartTime  .Params.Time }}	{{ formatDuration .PipelineRun.Status.StartTime .PipelineRun.Status.CompletionTime }}	{{ index .PipelineRun.Status.Conditions 0 | formatCondition }}
+
 {{- $msg := hasFailed .PipelineRun -}}
 {{-  if ne $msg "" }}
 

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/knative/pkg/apis"
 	"github.com/tektoncd/cli/pkg/test"
@@ -110,10 +109,7 @@ Taskruns
 NAME   TASK NAME   STARTED         DURATION    STATUS
 tr-1   t-1         8 minutes ago   3 minutes   Succeeded
 `
-	if d := cmp.Diff(expected, actual); d != "" {
-		t.Errorf("Unexpected output mismatch: %s", d)
-	}
-
+	tu.AssertOutput(t, expected, actual)
 }
 
 func TestPipelineRunDescribe_failed(t *testing.T) {
@@ -190,10 +186,7 @@ Taskruns
 NAME   TASK NAME   STARTED         DURATION    STATUS
 tr-1   t-1         8 minutes ago   3 minutes   Failed
 `
-	if d := cmp.Diff(expected, actual); d != "" {
-		t.Errorf("Unexpected output mismatch: %s", d)
-	}
-
+	tu.AssertOutput(t, expected, actual)
 }
 
 func TestPipelineRunDescribe_with_resources_taskrun(t *testing.T) {
@@ -271,8 +264,52 @@ Taskruns
 NAME   TASK NAME   STARTED         DURATION    STATUS
 tr-1   t-1         8 minutes ago   3 minutes   Succeeded
 `
-	if d := cmp.Diff(expected, actual); d != "" {
-		t.Errorf("Unexpected output mismatch: %s", d)
-	}
+	tu.AssertOutput(t, expected, actual)
+}
 
+func TestPipelineRunDescribe_without_start_time(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	cs, _ := pipelinetest.SeedTestData(t, pipelinetest.Data{
+		PipelineRuns: []*v1alpha1.PipelineRun{
+			tb.PipelineRun("pipeline-run", "ns",
+				cb.PipelineRunCreationTimestamp(clock.Now()),
+				tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
+				tb.PipelineRunSpec("pipeline"),
+				tb.PipelineRunStatus(
+					tb.PipelineRunStatusCondition(apis.Condition{
+						Status: corev1.ConditionUnknown,
+						Reason: resources.ReasonRunning,
+					}),
+				),
+			),
+		},
+	})
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+
+	pipelinerun := Command(p)
+	clock.Advance(10 * time.Minute)
+	actual, err := test.ExecuteCommand(pipelinerun, "desc", "pipeline-run", "-n", "ns")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected := `Name:           pipeline-run
+Namespace:      ns
+Pipeline Ref:   pipeline
+
+Status
+STARTED   DURATION   STATUS
+---       ---        Running
+
+Resources
+No resources
+
+Params
+No params
+
+Taskruns
+No taskruns
+`
+	tu.AssertOutput(t, expected, actual)
 }

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -164,7 +164,7 @@ func printFormatted(s *cli.Stream, prs *v1alpha1.PipelineRunList, c clockwork.Cl
 	for _, pr := range prs.Items {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t\n",
 			pr.Name,
-			formatted.Age(*pr.Status.StartTime, c),
+			formatted.Age(pr.Status.StartTime, c),
 			formatted.Duration(pr.Status.StartTime, pr.Status.CompletionTime),
 			formatted.Condition(pr.Status.Conditions[0]),
 		)

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -90,7 +90,7 @@ func printTaskDetails(s *cli.Stream, p cli.Params) error {
 	for _, task := range tasks.Items {
 		fmt.Fprintf(w, body,
 			task.Name,
-			formatted.Age(task.CreationTimestamp, p.Time()),
+			formatted.Age(&task.CreationTimestamp, p.Time()),
 		)
 	}
 	return w.Flush()

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -139,7 +139,7 @@ func printFormatted(s *cli.Stream, trs *v1alpha1.TaskRunList, c clockwork.Clock)
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t\n",
 			tr.Name,
-			formatted.Age(*tr.Status.StartTime, c),
+			formatted.Age(tr.Status.StartTime, c),
 			formatted.Duration(tr.Status.StartTime, tr.Status.CompletionTime),
 			formatted.Condition(tr.Status.Conditions[0]),
 		)

--- a/pkg/formatted/time.go
+++ b/pkg/formatted/time.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Age(t metav1.Time, c clockwork.Clock) string {
+func Age(t *metav1.Time, c clockwork.Clock) string {
 	if t.IsZero() {
 		return "---"
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Earlier, if any command try to use `age` formatting
function, then it causes the segfaults becasue
function is accepting the value type. While dereferencig
nil pointer type in `status` field is throwing segfaults

This patch fixes the `age` function to accept the
pointer type.

Fixes #202

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
