### PR TITLE
Add support for a `--build-cross-tests` flag in presubmit

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -33,9 +33,11 @@ function pre_build_tests() {
 
 function post_build_tests() {
     golangci-lint run
-    make cross
 }
 
 # We use the default build, unit and integration test runners.
-
-main $@
+if [[ "$1" == "--build-cross-tests" ]]; then
+    make cross
+else
+    main $@
+fi


### PR DESCRIPTION
# Changes

This will be used by the prow job responsible for doing the cross
build job.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
