### PR TITLE
Add Limit Option for TaskRuns

### DIFF
--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -19,6 +19,7 @@ Lists tasks in a namespace
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
+  -l, --limit int                     limit taskruns listed (default: return all taskruns)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -131,10 +131,9 @@ func list(p cli.Params, pipeline string, limit int) (*v1alpha1.PipelineRunList, 
 		sort.Sort(byStartTime(prs.Items))
 	}
 
-	// Limit after sort since pipelineruns are not in correct order until sorted
+	// If greater than maximum amount of pipelineruns, return all pipelineruns by setting limit to default
 	if limit > prslen {
-		fmt.Fprintf(os.Stderr, "Limit was %d but cannot be greater than %d\n", limit, prslen)
-		return nil, err
+		limit = 0
 	}
 
 	// Return all pipelineruns if limit is 0 or is same as prslen

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -150,6 +150,12 @@ func TestListPipelineRuns(t *testing.T) {
 			command: command(t, prs, clock.Now()),
 			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", 7)},
 			expected: []string{
+				"NAME    STARTED          DURATION   STATUS               ",
+				"pr0-1   ---              ---        ---                  ",
+				"pr3-1   ---              ---        ---                  ",
+				"pr1-1   59 minutes ago   1 minute   Succeeded            ",
+				"pr2-2   2 hours ago      1 minute   Failed               ",
+				"pr2-1   3 hours ago      ---        Succeeded(Running)   ",
 				"",
 			},
 		},

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -35,7 +35,13 @@ const (
 	emptyMsg = "No taskruns found"
 )
 
+type ListOptions struct {
+	Limit int
+}
+
 func listCommand(p cli.Params) *cobra.Command {
+
+	opts := &ListOptions{Limit: 0}
 	f := cliopts.NewPrintFlags("list")
 	eg := `
 # List all TaskRuns of Task name 'foo'
@@ -57,7 +63,12 @@ tkn pr list -n foo \n",
 				task = args[0]
 			}
 
-			trs, err := list(p, task)
+			if opts.Limit < 0 {
+				fmt.Fprintf(os.Stderr, "Limit was %d but must be a positive number\n", opts.Limit)
+				return nil
+			}
+
+			trs, err := list(p, task, opts.Limit)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to list taskruns from %s namespace \n", p.Namespace())
 				return err
@@ -69,28 +80,35 @@ tkn pr list -n foo \n",
 				return err
 			}
 
-			if output != "" {
+			if output != "" && trs != nil {
 				return printer.PrintObject(cmd.OutOrStdout(), trs, f)
 			}
+
 			stream := &cli.Stream{
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
-			err = printFormatted(stream, trs, p.Time())
+
+			if trs != nil {
+				err = printFormatted(stream, trs, p.Time())
+			}
+
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Failed to print Taskruns \n")
+				fmt.Fprint(os.Stderr, "Failed to print taskruns \n")
 				return err
 			}
+
 			return nil
 		},
 	}
 
 	f.AddFlags(c)
+	c.Flags().IntVarP(&opts.Limit, "limit", "l", 0, "limit taskruns listed (default: return all taskruns)")
 
 	return c
 }
 
-func list(p cli.Params, task string) (*v1alpha1.TaskRunList, error) {
+func list(p cli.Params, task string, limit int) (*v1alpha1.TaskRunList, error) {
 	cs, err := p.Clients()
 	if err != nil {
 		return nil, err
@@ -109,8 +127,20 @@ func list(p cli.Params, task string) (*v1alpha1.TaskRunList, error) {
 		return nil, err
 	}
 
-	if len(trs.Items) != 0 {
+	trslen := len(trs.Items)
+
+	if trslen != 0 {
 		sort.Sort(byStartTime(trs.Items))
+	}
+
+	// If greater than maximum amount of taskruns, return all taskruns by setting limit to default
+	if limit > trslen {
+		limit = 0
+	}
+
+	// Return all taskruns if limit is 0 or is same as trslen
+	if limit != 0 && trslen > limit {
+		trs.Items = trs.Items[0:limit]
 	}
 
 	// NOTE: this is required for -o json|yaml to work properly since

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -15,6 +15,7 @@
 package taskrun
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -142,6 +143,48 @@ func TestListTaskRuns(t *testing.T) {
 			command:  command(t, trs, now),
 			args:     []string{"list", "-n", "random"},
 			expected: []string{emptyMsg, ""},
+		},
+		{
+			name:    "limit taskruns returned to 1",
+			command: command(t, trs, now),
+			args:    []string{"list", "-n", "foo", "-l", fmt.Sprintf("%d", 1)},
+			expected: []string{
+				"NAME    STARTED   DURATION   STATUS      ",
+				"tr0-1   ---       ---        Succeeded   ",
+				"",
+			},
+		},
+		{
+			name:    "limit taskruns negative case",
+			command: command(t, trs, now),
+			args:    []string{"list", "-n", "foo", "-l", fmt.Sprintf("%d", -1)},
+			expected: []string{
+				"",
+			},
+		},
+		{
+			name:    "limit taskruns greater than maximum case",
+			command: command(t, trs, now),
+			args:    []string{"list", "-n", "foo", "-l", fmt.Sprintf("%d", 7)},
+			expected: []string{
+				"NAME    STARTED          DURATION   STATUS      ",
+				"tr0-1   ---              ---        Succeeded   ",
+				"tr3-1   ---              ---        Failed      ",
+				"tr2-2   59 minutes ago   1 minute   Failed      ",
+				"tr1-1   1 hour ago       1 minute   Succeeded   ",
+				"tr2-1   1 hour ago       ---        Running     ",
+				"",
+			},
+		},
+		{
+			name:    "limit taskruns with output flag set",
+			command: command(t, trs, now),
+			args:    []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "-l", fmt.Sprintf("%d", 2)},
+			expected: []string{
+				"tr0-1",
+				"tr3-1",
+				"",
+			},
 		},
 	}
 


### PR DESCRIPTION
Closes #163. 

This pull request adds a local flag (`--limit`) for `taskruns`. The `--limit` flag will allow a user to specify how many `taskruns` are returned from `tkn tr ls`. 

It follows the same pattern used in #185 for `pipelineruns`, but also changes the behavior for this feature for `pipelineruns`. Now, instead of returning an error when `limit` is greater than the max amount of `pipelineruns`, it will return all `pipelineruns` available.

### Usage

**Returns 5 taskruns with most recent start time**

`tkn tr ls --limit 5`

### Acceptable Input

`--limit` must be less than the total number of `taskruns` for a particular namespace and also greater than 0

### Default Case

The default case will return all `taskruns` for a particular namespace

### Local Results

![image](https://user-images.githubusercontent.com/34258252/62877976-2f1e4380-bcf6-11e9-834b-64d0d4d8b79f.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds a limit flag to limit the amount of taskruns returned by the taskrun list command
```
