### PR TITLE
Make the resource and param input interactively

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -38,8 +38,8 @@ two parameters (foo and bar)
 ```
   -h, --help                          help for start
   -l, --last                          re-run the pipeline using last pipelinerun values
-  -p, --param strings                 pass the param
-  -r, --resource strings              pass the resource name and ref
+  -p, --param strings                 pass the param as key=value
+  -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name
       --task-serviceaccount strings   pass the service account corresponding to the task
 ```

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -37,11 +37,11 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param
+    pass the param as key=value
 
 .PP
 \fB\-r\fP, \fB\-\-resource\fP=[]
-    pass the resource name and ref
+    pass the resource name and ref as name=ref
 
 .PP
 \fB\-s\fP, \fB\-\-serviceaccount\fP=""

--- a/pkg/cmd/pipeline/logs_testutil.go
+++ b/pkg/cmd/pipeline/logs_testutil.go
@@ -24,6 +24,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/require"
+	"github.com/tektoncd/cli/pkg/cli"
 )
 
 type promptTest struct {
@@ -38,6 +39,24 @@ func (opts *logOptions) RunPromptTest(t *testing.T, test promptTest) {
 		var err error
 		opts.askOpts = WithStdio(stdio)
 		err = opts.run(test.cmdArgs)
+		if err != nil {
+			return err
+		}
+
+		return err
+	})
+}
+
+func (opts *startOptions) RunPromptTest(t *testing.T, test promptTest) {
+
+	test.runTest(t, test.procedure, func(stdio terminal.Stdio) error {
+		var err error
+		opts.askOpts = WithStdio(stdio)
+		opts.stream = &cli.Stream{
+			Out: stdio.Out,
+			Err: stdio.Err,
+		}
+		err = opts.run(test.cmdArgs[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/Netflix/go-expect"
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
@@ -31,6 +33,7 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,6 +93,7 @@ func Test_start_has_pipeline_arg(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting an error but it's empty")
 	}
+	test.AssertOutput(t, "missing pipeline name", err.Error())
 }
 
 func Test_start_pipeline_not_found(t *testing.T) {
@@ -147,7 +151,7 @@ func Test_start_pipeline(t *testing.T) {
 		"-serviceaccounts=task1=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerune logs  -f\\n"
+	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerune logs  -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns("ns").List(v1.ListOptions{})
@@ -158,6 +162,122 @@ func Test_start_pipeline(t *testing.T) {
 	if pr.Items[0].ObjectMeta.GenerateName != (pipelineName + "-run-") {
 		t.Errorf("Error pipelinerun generated is different %+v", pr)
 	}
+}
+
+func Test_start_pipeline_interactive(t *testing.T) {
+
+	pipelineName := "test-pipeline"
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		Pipelines: []*v1alpha1.Pipeline{
+			tb.Pipeline(pipelineName, "ns",
+				tb.PipelineSpec(
+					tb.PipelineDeclaredResource("git-repo", "git"),
+					tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
+					tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
+					tb.PipelineTask("unit-test-1", "unit-test-task",
+						tb.PipelineTaskInputResource("workspace", "git-repo"),
+						tb.PipelineTaskOutputResource("image-to-use", "best-image"),
+						tb.PipelineTaskOutputResource("workspace", "git-repo"),
+					),
+				),
+			),
+		},
+
+		PipelineResources: []*v1alpha1.PipelineResource{
+			tb.PipelineResource("scaffold-git", "ns",
+				tb.PipelineResourceSpec("git",
+					tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
+				),
+			),
+		},
+	})
+
+	tests := []promptTest{
+		{
+			name:    "basic interaction",
+			cmdArgs: []string{pipelineName},
+
+			procedure: func(c *expect.Console) error {
+				if _, err := c.ExpectString("Which git resource to use for git-repo ?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyArrowDown)); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("scaffold-git (git@github.com:tektoncd/cli.git)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Value of param `pipeline-param` ?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("test"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Value of param `rev-param` ?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("test2"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Pipelinerun started:"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectEOF(); err != nil {
+					return err
+				}
+
+				c.Close()
+				return nil
+			},
+		},
+	}
+	opts := startOpts("ns", cs, false, "svc1", []string{"task1=svc1"})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts.RunPromptTest(t, test)
+		})
+	}
+}
+
+func Test_start_pipeline_no_resource(t *testing.T) {
+
+	pipelineName := "test-pipeline"
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		Pipelines: []*v1alpha1.Pipeline{
+			tb.Pipeline(pipelineName, "ns",
+				tb.PipelineSpec(
+					tb.PipelineDeclaredResource("git-repo", "git"),
+					tb.PipelineTask("unit-test-1", "unit-test-task",
+						tb.PipelineTaskInputResource("workspace", "git-repo"),
+						tb.PipelineTaskOutputResource("image-to-use", "best-image"),
+						tb.PipelineTaskOutputResource("workspace", "git-repo"),
+					),
+				),
+			),
+		},
+	})
+
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	pipeline := Command(p)
+	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName, "-n", "ns")
+	expected := "Error: " + "no pipeline resource of type git found in namespace: ns\n"
+	test.AssertOutput(t, expected, got)
 }
 
 func Test_start_pipeline_last(t *testing.T) {
@@ -206,9 +326,14 @@ func Test_start_pipeline_last(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
+		"-r=git-repo=scaffold-git",
+		"-p=rev-param=revision2",
+		"-s=svc1",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
 		"-nns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerune logs random -f\\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerune logs random -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})
@@ -219,16 +344,16 @@ func Test_start_pipeline_last(t *testing.T) {
 
 	for _, v := range pr.Spec.Resources {
 		if v.Name == "git-repo" {
-			test.AssertOutput(t, "some-repo", v.ResourceRef.Name)
+			test.AssertOutput(t, "scaffold-git", v.ResourceRef.Name)
 		}
 	}
 
 	for _, v := range pr.Spec.Params {
 		if v.Name == "rev-param" {
-			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: "revision1"}, v.Value)
+			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: "revision2"}, v.Value)
 		}
 	}
-	test.AssertOutput(t, "test-sa", pr.Spec.ServiceAccount)
+	test.AssertOutput(t, "svc1", pr.Spec.ServiceAccount)
 }
 
 func Test_start_pipeline_last_merge(t *testing.T) {
@@ -240,7 +365,7 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineDeclaredResource("build-image", "image"),
-				tb.PipelineParamSpec("", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
+				tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
 				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
 				tb.PipelineTask("unit-test-1", "unit-test-task",
 					tb.PipelineTaskInputResource("workspace", "git-repo"),
@@ -279,14 +404,14 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
+		"-s=svc1",
 		"-r=git-repo=scaffold-git",
 		"-p=rev-param=revision2",
-		"-s=svc1",
 		"--task-serviceaccount=task3=task3svc3",
 		"--task-serviceaccount=task5=task3svc5",
 		"-n=ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerune logs random -f\\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerune logs random -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})
@@ -349,9 +474,14 @@ func Test_start_pipeline_last_no_pipelineruns(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
+		"-s=svc1",
+		"-r=git-repo=scaffold-git",
+		"-p=rev-param=revision2",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
 		"-nns")
 
-	expected := "Error: No pipelineruns found in namespace: ns\n"
+	expected := "Error: no pipelineruns found in namespace: ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -385,6 +515,11 @@ func Test_start_pipeline_last_list_err(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
+		"-s=svc1",
+		"-r=git-repo=scaffold-git",
+		"-p=rev-param=revision2",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
 		"-nns")
 
 	expected := "Error: test generated error\n"
@@ -398,9 +533,6 @@ func Test_start_pipeline_client_error(t *testing.T) {
 	ps := []*v1alpha1.Pipeline{
 		tb.Pipeline(pipelineName, "namespace",
 			tb.PipelineSpec(
-				tb.PipelineDeclaredResource("git-repo", "git"),
-				tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
-				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
 				tb.PipelineTask("unit-test-1", "unit-test-task",
 					tb.PipelineTaskInputResource("workspace", "git-repo"),
 					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
@@ -419,8 +551,6 @@ func Test_start_pipeline_client_error(t *testing.T) {
 
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
-		"-r=source=scaffold-git",
-		"-p=key1=value1",
 		"-s=svc1",
 		"-n=namespace")
 
@@ -428,72 +558,75 @@ func Test_start_pipeline_client_error(t *testing.T) {
 	test.AssertOutput(t, expected, got)
 }
 
-func Test_start_pipeline_resource_error(t *testing.T) {
+func Test_start_pipeline_res_err(t *testing.T) {
 
 	pipelineName := "test-pipeline"
 
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline(pipelineName, "namespace",
+		tb.Pipeline(pipelineName, "ns",
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
-				tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
+				tb.PipelineDeclaredResource("build-image", "image"),
+				tb.PipelineParamSpec("pipeline-param-1", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
 				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
 				tb.PipelineTask("unit-test-1", "unit-test-task",
 					tb.PipelineTaskInputResource("workspace", "git-repo"),
 					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
 					tb.PipelineTaskOutputResource("workspace", "git-repo"),
 				),
-			),
-		),
+			), // spec
+		), // pipeline
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Pipelines: ps})
-
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
-		"-r scaffold-git",
-		"-p=key1=value1",
 		"-s=svc1",
-		"-n=namespace")
+		"-r=git-reposcaffold-git",
+		"-p=rev-param=revision2",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
+		"-nns")
 
-	expected := "Error: invalid resource parameter:  scaffold-git\nPlease pass resource as -r ResourceName=ResourceRef\n"
-
+	expected := "Error: invalid input format for resource parameter : git-reposcaffold-git\n"
 	test.AssertOutput(t, expected, got)
 }
 
-func Test_start_pipeline_param_error(t *testing.T) {
+func Test_start_pipeline_param_err(t *testing.T) {
 
 	pipelineName := "test-pipeline"
 
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline(pipelineName, "namespace",
+		tb.Pipeline(pipelineName, "ns",
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
-				tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
+				tb.PipelineDeclaredResource("build-image", "image"),
+				tb.PipelineParamSpec("pipeline-param-1", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
 				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
 				tb.PipelineTask("unit-test-1", "unit-test-task",
 					tb.PipelineTaskInputResource("workspace", "git-repo"),
 					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
 					tb.PipelineTaskOutputResource("workspace", "git-repo"),
 				),
-			),
-		),
+			), // spec
+		), // pipeline
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Pipelines: ps})
-
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
-		"-r=source=scaffold-git",
-		"-p value1",
 		"-s=svc1",
-		"-n=namespace")
+		"-r=git-repo=scaffold-git",
+		"-p=rev-paramrevision2",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
+		"-nns")
 
-	expected := "Error: invalid param parameter:  value1\nPlease pass param as -p ParamName=ParamValue\n"
-
+	expected := "Error: invalid input format for param parameter : rev-paramrevision2\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -504,8 +637,6 @@ func Test_start_pipeline_task_svc_error(t *testing.T) {
 	ps := []*v1alpha1.Pipeline{
 		tb.Pipeline(pipelineName, "foo",
 			tb.PipelineSpec(
-				tb.PipelineDeclaredResource("git-repo", "git"),
-				tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
 				tb.PipelineTask("unit-test-1", "unit-test-task",
 					tb.PipelineTaskInputResource("workspace", "git-repo"),
 					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
@@ -529,6 +660,165 @@ func Test_start_pipeline_task_svc_error(t *testing.T) {
 		" TaskName=ServiceAccount\n"
 
 	test.AssertOutput(t, expected, got)
+}
+
+func Test_mergeResource(t *testing.T) {
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    "ns",
+			GenerateName: "test-run",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{Name: "test"},
+			Resources: []v1alpha1.PipelineResourceBinding{
+				{
+					Name: "source",
+					ResourceRef: v1alpha1.PipelineResourceRef{
+						Name: "git",
+					},
+				},
+			},
+		},
+	}
+
+	err := mergeRes(pr, []string{"test"})
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	err = mergeRes(pr, []string{"image=test-1"})
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+	test.AssertOutput(t, 2, len(pr.Spec.Resources))
+
+	err = mergeRes(pr, []string{"image=test-new", "image-2=test-2"})
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+	test.AssertOutput(t, 3, len(pr.Spec.Resources))
+}
+
+func Test_mergeParam(t *testing.T) {
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    "ns",
+			GenerateName: "test-run",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{Name: "test"},
+			Params: []v1alpha1.Param{
+				{
+					Name: "key1",
+					Value: v1alpha1.ArrayOrString{
+						Type:      v1alpha1.ParamTypeString,
+						StringVal: "value1",
+					},
+				},
+				{
+					Name: "key2",
+					Value: v1alpha1.ArrayOrString{
+						Type:      v1alpha1.ParamTypeString,
+						StringVal: "value2",
+					},
+				},
+			},
+		},
+	}
+
+	err := mergeParam(pr, []string{"test"})
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	err = mergeParam(pr, []string{"key3=test"})
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+	test.AssertOutput(t, 3, len(pr.Spec.Params))
+
+	err = mergeParam(pr, []string{"key3=test-new", "key4=test-2"})
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+	test.AssertOutput(t, 4, len(pr.Spec.Params))
+}
+
+func Test_getPipelineResourceByFormat(t *testing.T) {
+	pipelineResources := []*v1alpha1.PipelineResource{
+		tb.PipelineResource("scaffold-git", "ns",
+			tb.PipelineResourceSpec("git",
+				tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
+			),
+		),
+		tb.PipelineResource("scaffold-git-fork", "ns",
+			tb.PipelineResourceSpec("git",
+				tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd-fork/cli.git"),
+				tb.PipelineResourceSpecParam("revision", "release"),
+			),
+		),
+		tb.PipelineResource("scaffold-image", "ns",
+			tb.PipelineResourceSpec("image",
+				tb.PipelineResourceSpecParam("url", "docker.io/tektoncd/cli"),
+			),
+		),
+		tb.PipelineResource("scaffold-pull", "ns",
+			tb.PipelineResourceSpec("pullRequest",
+				tb.PipelineResourceSpecParam("url", "https://github.com/tektoncd/cli/pulls/9"),
+			),
+		),
+		tb.PipelineResource("scaffold-cluster", "ns",
+			tb.PipelineResourceSpec("cluster",
+				tb.PipelineResourceSpecParam("url", "https://opemshift.com"),
+				tb.PipelineResourceSpecParam("user", "tektoncd-developer"),
+			),
+		),
+		tb.PipelineResource("scaffold-storage", "ns",
+			tb.PipelineResourceSpec("storage",
+				tb.PipelineResourceSpecParam("location", "/home/tektoncd"),
+			),
+		),
+	}
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineResources: pipelineResources})
+	res, _ := getPipelineResources(cs.Pipeline, "ns")
+	resFormat := getPipelineResourcesByFormat(res.Items)
+
+	output := getOptionsByType(resFormat, "git")
+	expected := []string{"scaffold-git (git@github.com:tektoncd/cli.git)", "scaffold-git-fork (git@github.com:tektoncd-fork/cli.git#release)"}
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("output git = %v, want %v", output, expected)
+	}
+
+	output = getOptionsByType(resFormat, "image")
+	expected = []string{"scaffold-image (docker.io/tektoncd/cli)"}
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("output image = %v, want %v", output, expected)
+	}
+
+	output = getOptionsByType(resFormat, "pullRequest")
+	expected = []string{"scaffold-pull (https://github.com/tektoncd/cli/pulls/9)"}
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("output pullRequest = %v, want %v", output, expected)
+	}
+
+	output = getOptionsByType(resFormat, "cluster")
+	expected = []string{"scaffold-cluster (https://opemshift.com#tektoncd-developer)"}
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("output cluster = %v, want %v", output, expected)
+	}
+
+	output = getOptionsByType(resFormat, "storage")
+	expected = []string{"scaffold-storage (/home/tektoncd)"}
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("output storage = %v, want %v", output, expected)
+	}
+
+	output = getOptionsByType(resFormat, "file")
+	expected = []string{}
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("output error = %v, want %v", output, expected)
+	}
 }
 
 func Test_parseRes(t *testing.T) {
@@ -591,7 +881,7 @@ func Test_parseParam(t *testing.T) {
 	}{{
 		name: "Test_parseParam No Err",
 		args: args{
-			p: []string{"key1=value1", "key2=value2"},
+			p: []string{"key1=value1", "key2=value2", "key3=value3,value4,value5"},
 		},
 		want: map[string]v1alpha1.Param{
 			"key1": {Name: "key1", Value: v1alpha1.ArrayOrString{
@@ -602,6 +892,11 @@ func Test_parseParam(t *testing.T) {
 			"key2": {Name: "key2", Value: v1alpha1.ArrayOrString{
 				Type:      v1alpha1.ParamTypeString,
 				StringVal: "value2",
+			},
+			},
+			"key3": {Name: "key3", Value: v1alpha1.ArrayOrString{
+				Type:     v1alpha1.ParamTypeArray,
+				ArrayVal: []string{"value3", "value4", "value5"},
 			},
 			},
 		},
@@ -764,4 +1059,20 @@ func Test_lastPipelineRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func startOpts(ns string, cs pipelinetest.Clients, last bool, svc string, svcs []string) *startOptions {
+	p := test.Params{
+		Kube:   cs.Kube,
+		Tekton: cs.Pipeline,
+	}
+	p.SetNamespace(ns)
+	startOp := startOptions{
+		cliparams:          &p,
+		Last:               last,
+		ServiceAccountName: svc,
+		ServiceAccounts:    svcs,
+	}
+
+	return &startOp
 }


### PR DESCRIPTION
# Changes

This will add the feature of resource and
param input interactively based on the pipeline
spec.

If user has privded resource or param input
by flag then interactive terminal will not start

Also support param as both array and string

Add respective test and docs

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
