### PR TITLE
Fixes show sub commands help section

### DIFF
--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -44,6 +44,9 @@ func listCommand(p cli.Params) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Lists clustertasks in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {

--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -65,9 +65,12 @@ func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
 
 	c := &cobra.Command{
-		Use:          "describe",
-		Aliases:      []string{"desc"},
-		Short:        "Describes a pipeline in a namespace",
+		Use:     "describe",
+		Aliases: []string{"desc"},
+		Short:   "Describes a pipeline in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -51,9 +51,12 @@ func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 
 	c := &cobra.Command{
-		Use:          "list",
-		Aliases:      []string{"ls"},
-		Short:        "Lists pipelines in a namespace",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "Lists pipelines in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, err := cmd.LocalFlags().GetString("output")

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -86,6 +86,9 @@ func logCommand(p cli.Params) *cobra.Command {
 		Short:                 "Show pipeline logs",
 		Example:               eg,
 		SilenceUsage:          true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			return nameArg(args, p)
 		},

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -79,6 +79,9 @@ func startCommand(p cli.Params) *cobra.Command {
 		Use:     "start pipeline [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
 		Aliases: []string{"trigger"},
 		Short:   "Start pipelines",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		Example: `
 # start pipeline foo by creating a pipelinerun named "foo-run-xyz123" from the namespace "bar"
 tkn pipeline start foo --param NAME=VALUE --resource source=scaffold-git  -s ServiceAccountName  -n bar

--- a/pkg/cmd/pipelineresource/describe.go
+++ b/pkg/cmd/pipelineresource/describe.go
@@ -67,6 +67,9 @@ tkn res desc foo -n bar",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/pipelineresource/list.go
+++ b/pkg/cmd/pipelineresource/list.go
@@ -54,7 +54,10 @@ tkn pre list -n foo",
 		Short:        "Lists pipeline resources in a namespace",
 		Example:      eg,
 		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(0),
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Args: cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cs, err := p.Clients()
 			if err != nil {

--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -20,7 +20,10 @@ func cancelCommand(p cli.Params) *cobra.Command {
 		Short:        "Cancel the PipelineRun",
 		Example:      eg,
 		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pr := args[0]
 			s := &cli.Stream{

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -94,6 +94,9 @@ tkn pr desc foo -n bar",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -55,6 +55,9 @@ tkn pr list -n foo",
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Lists pipelineruns in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		Example: eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var pipeline string

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -53,8 +53,11 @@ func logCommand(p cli.Params) *cobra.Command {
 		Use:                   "logs",
 		DisableFlagsInUseLine: true,
 		Short:                 "Show the logs of PipelineRun",
-		Example:               eg,
-		Args:                  cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.PipelineRunName = args[0]
 			opts.Stream = &cli.Stream{

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -44,6 +44,9 @@ func listCommand(p cli.Params) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Lists tasks in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -55,6 +55,9 @@ tkn tr list -n foo \n",
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Lists taskruns in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 		Example: eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var task string

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -52,7 +52,10 @@ tkn taskrun logs -f foo -n bar
 		Short:        "Show taskruns logs",
 		Example:      eg,
 		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.taskrunName = args[0]
 			opts.stream = &cli.Stream{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Right now available sub-commands section for `tkn <main-command> -h`
is absent.

This patch fixes the `tkn help` command by adding the right annotations
so that help template can process it correctly.

Fixes https://github.com/tektoncd/cli/issues/225

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
