### PR TITLE
Sort PipelineRuns for Pipeline Logs by Start Time and Add Limit Flag

### DIFF
--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -26,16 +26,17 @@ Show pipeline logs
 
   # show logs for given pipeline and pipelinerun
     tkn pipeline logs pipeline run -n namespace
-  
+
    
 
 ### Options
 
 ```
-  -a, --all      show all logs including init steps injected by tekton
-  -f, --follow   stream live logs
-  -h, --help     help for logs
-  -l, --last     show logs for last run
+  -a, --all         show all logs including init steps injected by tekton
+  -f, --follow      stream live logs
+  -h, --help        help for logs
+  -l, --last        show logs for last run
+  -L, --limit int   lists number of pipelineruns (default 5)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -21,7 +21,7 @@ Show the logs of PipelineRun
   # show the logs of PipelineRun named "microservice-1" for task "build" only, from the namespace "bar"
     tkn pr logs microservice-1 -t build -n bar
 
-  # show the logs of PipelineRun named "microservice-1" for all tasks and steps (including init steps), 
+  # show the logs of PipelineRun named "microservice-1" for all tasks and steps (including init steps),
     from the namespace "foo"
     tkn pr logs microservice-1 -a -n foo
    

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -18,7 +18,7 @@ Show taskruns logs
 # show the logs of TaskRun named "foo" from the namespace "bar"
 tkn taskrun logs foo -n bar
 
-# show the live logs of TaskRun named "foo" from the namespace "bar" 
+# show the live logs of TaskRun named "foo" from the namespace "bar"
 tkn taskrun logs -f foo -n bar
 
 

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -35,6 +35,10 @@ Show pipeline logs
 \fB\-l\fP, \fB\-\-last\fP[=false]
     show logs for last run
 
+.PP
+\fB\-L\fP, \fB\-\-limit\fP=5
+    lists number of pipelineruns
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -17,6 +17,7 @@ package pipeline
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -38,6 +39,7 @@ type logOptions struct {
 	follow       bool
 	pipelineName string
 	runName      string
+	limit        int
 }
 
 func nameArg(args []string, p cli.Params) error {
@@ -100,6 +102,7 @@ func logCommand(p cli.Params) *cobra.Command {
 	c.Flags().BoolVarP(&opts.last, "last", "l", false, "show logs for last run")
 	c.Flags().BoolVarP(&opts.allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream live logs")
+	c.Flags().IntVarP(&opts.limit, "limit", "L", 5, "lists number of pipelineruns")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 	return c
@@ -154,6 +157,12 @@ func (opts *logOptions) init(args []string) error {
 }
 
 func (opts *logOptions) getAllInputs() error {
+	err := validate(opts)
+
+	if err != nil {
+		return err
+	}
+
 	ps, err := allPipelines(opts)
 	if err != nil {
 		return err
@@ -182,9 +191,14 @@ func (opts *logOptions) getAllInputs() error {
 }
 
 func (opts *logOptions) askRunName() error {
+	err := validate(opts)
+	if err != nil {
+		return err
+	}
+
 	var ans string
 
-	prs, err := allRuns(opts.params, opts.pipelineName)
+	prs, err := allRuns(opts.params, opts.pipelineName, opts.limit)
 	if err != nil {
 		return err
 	}
@@ -243,7 +257,7 @@ func allPipelines(opts *logOptions) ([]string, error) {
 	return ret, nil
 }
 
-func allRuns(p cli.Params, pName string) ([]string, error) {
+func allRuns(p cli.Params, pName string, limit int) ([]string, error) {
 	cs, err := p.Clients()
 	if err != nil {
 		return nil, err
@@ -257,9 +271,19 @@ func allRuns(p cli.Params, pName string) ([]string, error) {
 		return nil, err
 	}
 
+	runslen := len(runs.Items)
+
+	if runslen > 1 {
+		sort.Sort(byStartTime(runs.Items))
+	}
+
+	if limit > runslen {
+		limit = runslen
+	}
+
 	ret := []string{}
 	for i, run := range runs.Items {
-		if i < 5 {
+		if i < limit {
 			ret = append(ret, run.ObjectMeta.Name+" started "+formatted.Age(run.Status.StartTime, p.Time()))
 		}
 	}
@@ -287,4 +311,29 @@ func lastRun(cs *cli.Clients, ns, pName string) (string, error) {
 		}
 	}
 	return latest.ObjectMeta.Name, nil
+}
+
+type byStartTime []v1alpha1.PipelineRun
+
+func (s byStartTime) Len() int      { return len(s) }
+func (s byStartTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s byStartTime) Less(i, j int) bool {
+	if s[j].Status.StartTime == nil {
+		return false
+	}
+
+	if s[i].Status.StartTime == nil {
+		return true
+	}
+
+	return s[j].Status.StartTime.Before(s[i].Status.StartTime)
+}
+
+func validate(opts *logOptions) error {
+
+	if opts.limit <= 0 {
+		return fmt.Errorf("limit was %d but must be a positive number", opts.limit)
+	}
+
+	return nil
 }

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -180,7 +180,9 @@ func (s byStartTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s byStartTime) Less(i, j int) bool {
 	if s[j].Status.StartTime == nil {
 		return false
-	} else if s[i].Status.StartTime == nil {
+	}
+
+	if s[i].Status.StartTime == nil {
 		return true
 	}
 

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -181,7 +181,9 @@ func (s byStartTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s byStartTime) Less(i, j int) bool {
 	if s[j].Status.StartTime == nil {
 		return false
-	} else if s[i].Status.StartTime == nil {
+	}
+
+	if s[i].Status.StartTime == nil {
 		return true
 	}
 


### PR DESCRIPTION
Closes #224 

# Changes

This pull request adds sorting of `pipelineruns` by their start times. It also adds a `limit` flag that allows more or less than 5 `pipelineruns` to be returned. The current implementation only allows a hard coded 5 `pipelineruns` to be returned.

### Local Testing

Start times of some `pipelineruns`:

![image](https://user-images.githubusercontent.com/34258252/63462427-ec144c80-c428-11e9-98ec-5caa2c41dd60.png)

Correct order of `pipelineruns` with default of 5 `pipelineruns`:

![image](https://user-images.githubusercontent.com/34258252/63462517-1e25ae80-c429-11e9-9fd9-93bb6eba2474.png)

Limit flag with `L` set to 2:

![image](https://user-images.githubusercontent.com/34258252/63462628-55945b00-c429-11e9-93e8-4666519fbbcc.png)

Error messaging for negative number:

![image](https://user-images.githubusercontent.com/34258252/63462714-883e5380-c429-11e9-99df-099e0806efef.png)

Specify greater number than 5 for `pipelineruns`:

![image](https://user-images.githubusercontent.com/34258252/63462781-af952080-c429-11e9-8717-9649ce76bc39.png)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Sort pipelineruns by start time for tkn pipeline logs command and add limit flag to limit pipelineruns returned from tkn pipeline logs
```
