### PR TITLE
Fix homebrew formula test

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ brews:
     homepage: "https://github.com/tektoncd/cli"
     description: Tekton CLI - The command line interface for interacting with Tekton
     test: |
-      system "#{bin}/tkn", "--version"
+      system "#{bin}/tkn", "version"
     install: |
       bin.install_symlink "tkn" => "kubectl-tkn"
       bin.install "tkn" => "tkn"


### PR DESCRIPTION
We were using --version for test which was wrong, it now exists with 1 so this
would fail (before that would exit 0 which was buggy). Let's use tkn version
properly!
