### PR TITLE
fixes pipeline logs command with --last flag

### DIFF
--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -144,9 +144,6 @@ func (opts *logOptions) init(args []string) error {
 
 	case 1: // pipeline name provided
 		opts.pipelineName = args[0]
-		if opts.last {
-			return opts.initLastRunName()
-		}
 		return opts.askRunName()
 
 	case 2: // both pipeline and run provided
@@ -197,6 +194,10 @@ func (opts *logOptions) askRunName() error {
 	err := validate(opts)
 	if err != nil {
 		return err
+	}
+
+	if opts.last {
+		return opts.initLastRunName()
 	}
 
 	var ans string

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -26,7 +26,6 @@ import (
 type LogOptions struct {
 	AllSteps        bool
 	Follow          bool
-	Last            bool
 	Params          cli.Params
 	PipelineName    string
 	PipelineRunName string


### PR DESCRIPTION
tkn pipeline logs command without a given pipeline name does not
respect --last flag, pipeline name given or not given in either
case with --last flag should be respected and last run's log
should be rendered

Fixed : #232

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
