### PR TITLE
Add delete for clustertask command

### DIFF
--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -19,5 +19,6 @@ Manage clustertasks
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
+* [tkn clustertask delete](tkn_clustertask_delete.md)	 - Delete a clustertask resource in a cluster
 * [tkn clustertask list](tkn_clustertask_list.md)	 - Lists clustertasks in a namespace
 

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -1,0 +1,46 @@
+## tkn clustertask delete
+
+Delete a clustertask resource in a cluster
+
+***Aliases**: rm*
+
+### Usage
+
+```
+tkn clustertask delete
+```
+
+### Synopsis
+
+Delete a clustertask resource in a cluster
+
+### Examples
+
+
+# Delete a ClusterTask of name 'foo'
+tkn clustertask delete foo
+
+tkn ct rm foo ",
+
+
+### Options
+
+```
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -f, --force                         Whether to force deletion (default: false)
+  -h, --help                          help for delete
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
+  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+```
+
+### SEE ALSO
+
+* [tkn clustertask](tkn_clustertask.md)	 - Manage clustertasks
+

--- a/pkg/cmd/clustertask/clustertask.go
+++ b/pkg/cmd/clustertask/clustertask.go
@@ -34,6 +34,9 @@ func Command(p cli.Params) *cobra.Command {
 	}
 
 	flags.AddTektonOptions(cmd)
-	cmd.AddCommand(listCommand(p))
+	cmd.AddCommand(
+		listCommand(p),
+		deleteCommand(p),
+	)
 	return cmd
 }

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -1,0 +1,103 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustertask
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type deleteOptions struct {
+	forceDelete bool
+}
+
+func deleteCommand(p cli.Params) *cobra.Command {
+	opts := &deleteOptions{forceDelete: false}
+	f := cliopts.NewPrintFlags("delete")
+	eg := `
+# Delete a ClusterTask of name 'foo'
+tkn clustertask delete foo
+
+tkn ct rm foo ",
+`
+
+	c := &cobra.Command{
+		Use:          "delete",
+		Aliases:      []string{"rm"},
+		Short:        "Delete a clustertask resource in a cluster",
+		Example:      eg,
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s := &cli.Stream{
+				In:  cmd.InOrStdin(),
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			if err := checkOptions(opts, s, p, args[0]); err != nil {
+				return err
+			}
+
+			return deleteClusterTask(s, p, args[0])
+		},
+	}
+	f.AddFlags(c)
+	c.Flags().BoolVarP(&opts.forceDelete, "force", "f", false, "Whether to force deletion (default: false)")
+	return c
+}
+
+func deleteClusterTask(s *cli.Stream, p cli.Params, tName string) error {
+	cs, err := p.Clients()
+	if err != nil {
+		return fmt.Errorf("Failed to create tekton client")
+	}
+
+	if err := cs.Tekton.TektonV1alpha1().ClusterTasks().Delete(tName, &metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("Failed to delete clustertask %q: %s", tName, err)
+	}
+
+	fmt.Fprintf(s.Out, "ClusterTask deleted: %s\n", tName)
+	return nil
+}
+
+func checkOptions(opts *deleteOptions, s *cli.Stream, p cli.Params, tName string) error {
+	if opts.forceDelete {
+		return nil
+	}
+
+	fmt.Fprintf(s.Out, "Make sure you really want to delete clustertask %q (y/n): ", tName)
+	scanner := bufio.NewScanner(s.In)
+	for scanner.Scan() {
+		t := strings.TrimSpace(scanner.Text())
+		if t == "y" {
+			break
+		} else if t == "n" {
+			return fmt.Errorf("Canceled deleting clustertask %q", tName)
+		}
+		fmt.Fprint(s.Out, "Please enter (y/n): ")
+	}
+
+	return nil
+}

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -1,0 +1,116 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustertask
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinetest "github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+)
+
+func TestClusterTaskDelete(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	seeds := make([]pipelinetest.Clients, 0)
+	for i := 0; i < 3; i++ {
+		clustertasks := []*v1alpha1.ClusterTask{
+			tb.ClusterTask("tomatoes", cb.ClusterTaskCreationTime(clock.Now().Add(-1*time.Minute))),
+		}
+		cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks})
+		seeds = append(seeds, cs)
+	}
+
+	testParams := []struct {
+		name        string
+		command     []string
+		input       pipelinetest.Clients
+		inputStream io.Reader
+		wantError   bool
+		want        string
+	}{
+		{
+			name:        "With force delete flag (shorthand)",
+			command:     []string{"rm", "tomatoes", "-f"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   false,
+			want:        "ClusterTask deleted: tomatoes\n",
+		},
+		{
+			name:        "With force delete flag",
+			command:     []string{"rm", "tomatoes", "--force"},
+			input:       seeds[1],
+			inputStream: nil,
+			wantError:   false,
+			want:        "ClusterTask deleted: tomatoes\n",
+		},
+		{
+			name:        "Without force delete flag, reply no",
+			command:     []string{"rm", "tomatoes"},
+			input:       seeds[2],
+			inputStream: strings.NewReader("n"),
+			wantError:   true,
+			want:        "Canceled deleting clustertask \"tomatoes\"",
+		},
+		{
+			name:        "Without force delete flag, reply yes",
+			command:     []string{"rm", "tomatoes"},
+			input:       seeds[2],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Make sure you really want to delete clustertask \"tomatoes\" (y/n): ClusterTask deleted: tomatoes\n",
+		},
+		{
+			name:        "Remove non existent resource",
+			command:     []string{"rm", "nonexistent"},
+			input:       seeds[2],
+			inputStream: strings.NewReader("y"),
+			wantError:   true,
+			want:        "Failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			p := &test.Params{Tekton: tp.input.Pipeline}
+			clustertask := Command(p)
+
+			if tp.inputStream != nil {
+				clustertask.SetIn(tp.inputStream)
+			}
+
+			out, err := test.ExecuteCommand(clustertask, tp.command...)
+			if tp.wantError {
+				if err == nil {
+					t.Errorf("Error expected here")
+				}
+				test.AssertOutput(t, tp.want, err.Error())
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected Error")
+				}
+				test.AssertOutput(t, tp.want, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add delete command for clustertasks so it doesn't feel left out.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes


```
Clustertasks can now be deleted with the tkn tool
```
