### PR TITLE
Refactor TaskRun and PipelineRun Sorting

### DIFF
--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -17,7 +17,6 @@ package pipeline
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -26,6 +25,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/pipelinerun"
 	"github.com/tektoncd/cli/pkg/formatted"
+	prhsort "github.com/tektoncd/cli/pkg/helper/pipelinerun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -278,7 +278,7 @@ func allRuns(p cli.Params, pName string, limit int) ([]string, error) {
 	runslen := len(runs.Items)
 
 	if runslen > 1 {
-		sort.Sort(byStartTime(runs.Items))
+		runs.Items = prhsort.SortPipelineRunsByStartTime(runs.Items)
 	}
 
 	if limit > runslen {
@@ -315,22 +315,6 @@ func lastRun(cs *cli.Clients, ns, pName string) (string, error) {
 		}
 	}
 	return latest.ObjectMeta.Name, nil
-}
-
-type byStartTime []v1alpha1.PipelineRun
-
-func (s byStartTime) Len() int      { return len(s) }
-func (s byStartTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s byStartTime) Less(i, j int) bool {
-	if s[j].Status.StartTime == nil {
-		return false
-	}
-
-	if s[i].Status.StartTime == nil {
-		return true
-	}
-
-	return s[j].Status.StartTime.Before(s[i].Status.StartTime)
 }
 
 func validate(opts *logOptions) error {

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -17,13 +17,13 @@ package pipelinerun
 import (
 	"fmt"
 	"os"
-	"sort"
 	"text/tabwriter"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	prhsort "github.com/tektoncd/cli/pkg/helper/pipelinerun/sort"
 	"github.com/tektoncd/cli/pkg/printer"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -131,7 +131,7 @@ func list(p cli.Params, pipeline string, limit int) (*v1alpha1.PipelineRunList, 
 	prslen := len(prs.Items)
 
 	if prslen != 0 {
-		sort.Sort(byStartTime(prs.Items))
+		prs.Items = prhsort.SortPipelineRunsByStartTime(prs.Items)
 	}
 
 	// If greater than maximum amount of pipelineruns, return all pipelineruns by setting limit to default
@@ -174,20 +174,4 @@ func printFormatted(s *cli.Stream, prs *v1alpha1.PipelineRunList, c clockwork.Cl
 	}
 
 	return w.Flush()
-}
-
-type byStartTime []v1alpha1.PipelineRun
-
-func (s byStartTime) Len() int      { return len(s) }
-func (s byStartTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s byStartTime) Less(i, j int) bool {
-	if s[j].Status.StartTime == nil {
-		return false
-	}
-
-	if s[i].Status.StartTime == nil {
-		return true
-	}
-
-	return s[j].Status.StartTime.Before(s[i].Status.StartTime)
 }

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -17,13 +17,13 @@ package taskrun
 import (
 	"fmt"
 	"os"
-	"sort"
 	"text/tabwriter"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	trhsort "github.com/tektoncd/cli/pkg/helper/taskrun/sort"
 	"github.com/tektoncd/cli/pkg/printer"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,7 +133,7 @@ func list(p cli.Params, task string, limit int) (*v1alpha1.TaskRunList, error) {
 	trslen := len(trs.Items)
 
 	if trslen != 0 {
-		sort.Sort(byStartTime(trs.Items))
+		trs.Items = trhsort.SortTaskRunsByStartTime(trs.Items)
 	}
 
 	// If greater than maximum amount of taskruns, return all taskruns by setting limit to default
@@ -175,20 +175,4 @@ func printFormatted(s *cli.Stream, trs *v1alpha1.TaskRunList, c clockwork.Clock)
 		)
 	}
 	return w.Flush()
-}
-
-type byStartTime []v1alpha1.TaskRun
-
-func (s byStartTime) Len() int      { return len(s) }
-func (s byStartTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s byStartTime) Less(i, j int) bool {
-	if s[j].Status.StartTime == nil {
-		return false
-	}
-
-	if s[i].Status.StartTime == nil {
-		return true
-	}
-
-	return s[j].Status.StartTime.Before(s[i].Status.StartTime)
 }

--- a/pkg/helper/pipelinerun/sort/sort_pipelineruns.go
+++ b/pkg/helper/pipelinerun/sort/sort_pipelineruns.go
@@ -1,0 +1,36 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"sort"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+func SortPipelineRunsByStartTime(prs []v1alpha1.PipelineRun) []v1alpha1.PipelineRun {
+	sort.Slice(prs, func(i, j int) bool {
+		if prs[j].Status.StartTime == nil {
+			return false
+		}
+
+		if prs[i].Status.StartTime == nil {
+			return true
+		}
+		return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
+	})
+
+	return prs
+}

--- a/pkg/helper/taskrun/sort/sort_taskruns.go
+++ b/pkg/helper/taskrun/sort/sort_taskruns.go
@@ -1,0 +1,36 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskrun
+
+import (
+	"sort"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+func SortTaskRunsByStartTime(trs []v1alpha1.TaskRun) []v1alpha1.TaskRun {
+	sort.Slice(trs, func(i, j int) bool {
+		if trs[j].Status.StartTime == nil {
+			return false
+		}
+
+		if trs[i].Status.StartTime == nil {
+			return true
+		}
+		return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
+	})
+
+	return trs
+}


### PR DESCRIPTION
Closes #241 

Refactoring sorting in the CLI for `taskruns` and `pipelineruns` by encapsulating by start time sorting so these patterns can easily be used in other areas of the CLI. 

`sort_pipelineruns.go` and `sort_taskruns.go` can also hold additional sorting patterns for `pipelineruns` and `taskruns`. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
