### PR TITLE
Remove the VERSION generation from goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ tags
 
 #Mac
 .DS_Store
-
-# Generated from gorelease
-VERSION

--- a/tekton/goreleaser.yml
+++ b/tekton/goreleaser.yml
@@ -27,7 +27,6 @@ spec:
     args:
     - -c
     - "git status; git fetch -p --all"
-    - "git describe --tags > VERSION"
   - name: release
     image: goreleaser/goreleaser
     workingdir: /workspace/src/${inputs.params.package}


### PR DESCRIPTION
goreleaser use the git repo anyway, so that wasn't working

Working on another way to make the RELEASE where we will still use the makefile VERSION trick,