### PR TITLE
Add release script

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -15,53 +15,33 @@ them manually.
 
 ## Release Pipeline
 
-The release pipeline uses the
-[`golang`](https://github.com/tektoncd/catalog/tree/master/golang)
-Tasks from the
-[`tektoncd/catalog`](https://github.com/tektoncd/catalog). To add them
-to your cluster:
+You can use the script [`./release.sh`](release.sh) that would do everything
+that needs to be done for the release.
 
-```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/lint.yaml
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/build.yaml
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/tests.yaml
-```
+The first argument if not provided is the release version you want to do, it
+need to respect a format like `v1.2.3` which is basically SEMVER.
 
-It also uses the [`goreleaser`](./goreleaser.yml) Task from this
-repository.
+If it detects that you are doing a minor release it would ask you for some
+commits to be cherry-picked in this release. Alternatively you can provide the
+commits separed by a space to the second argument of the script. You do need to
+make sure to provide them in order from the oldest to the newest (as listed).
 
-```
-kubectl apply -f ./goreleaser.yml
-```
+If you give the `*` argument for the commits to pick up it would apply all the new
+commits.
 
-Next is the actual release pipeline. It is defined in
-[`release-pipeline.yml`](./release-pipeline.yml).
+It will them use your TektonCD cluster and apply what needs to be done for
+running the release.
 
-```
-kubectl apply -f ./release-pipeline.yml
-```
+And finally it will launch the `tkn`  cli to show the logs.
 
-Note that the [`goreleaser.yml`](./goreleaser.yml) `Task` needs a
-secret for the GitHub token, named `bot-token-github`.
+Make sure we have a nice ChangeLog before doign the release, listing `features`
+and `bugs` and be thankful to the contributors by listing them.
 
-TODO(vdemeester): It is hardcoded for now as Tekton Pipeline doesn't
-support variable interpolation in the environment. This needs to be
-fixed upstream.
+## Debugging
 
-```
-kubectl create secret generic bot-token-github --from-literal=bot-token=${GITHUB_TOKEN}
-```
+You can define the env variable `PUSH_REMOTE` to push to your own remote (i.e:
+which pont to your username on github),
 
-
-### Running
-
-To run these `Pipelines` and `Tasks`, you must have Tekton Pipelines installed
-(in your own kubernetes cluster) either via
-[an official release](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
-or
-[from `HEAD`](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#install-pipeline).
-
-- [`release-pipeline-run.yml`](./release-pipeline-run.yml) — this
-  runs the `ci-release-pipeline` on `tektoncd/cli` master branch. The
-  way [`goreleaser`](https://goreleaser.com) works, it will build the
-  latest tag.
+You need to be **careful** if you have write access to the `homebrew` repository, it
+would do a release there. Until we can find a proper fix I would generate a
+commit which remove the brews data and cherry-pick it in the script.

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+RELEASE_VERSION="${1}"
+COMMITS="${2}"
+
+UPSTREAM_REMOTE=upstream
+MASTER_BRANCH="master"
+TARGET_NAMESPACE="release"
+SECRET_NAME=bot-token-github
+PUSH_REMOTE="${PUSH_REMOTE:-${UPSTREAM_REMOTE}}" # export PUSH_REMOTE to your own for testing
+
+CATALOG_TASKS="lint build tests"
+
+set -e
+
+[[ -z ${RELEASE_VERSION} ]] && {
+    read -e -p "Enter a target release (i.e: v0.1.2): " RELEASE_VERSION
+    [[ -z ${RELEASE_VERSION} ]] && { echo "no target release"; exit 1 ;}
+}
+
+[[ ${RELEASE_VERSION} =~ v[0-9]+\.[0-9]*\.[0-9]+ ]] || { echo "invalid version provided, need to match v\d+\.\d+\.\d+"; exit 1 ;}
+lasttag=$(git describe --abbrev=0 --tags)
+echo ${lasttag}|sed 's/\.[0-9]*$//'|grep -q ${RELEASE_VERSION%.*} && { echo "Minor version of ${RELEASE_VERSION%.*} detected"; minor_version=true ; }
+
+cd ${GOPATH}/src/github.com/tektoncd/cli
+
+git fetch -a ${UPSTREAM_REMOTE} >/dev/null
+git checkout ${MASTER_BRANCH}
+git reset --hard ${UPSTREAM_REMOTE}/${MASTER_BRANCH}
+git checkout -B release-${RELEASE_VERSION}  ${MASTER_BRANCH} >/dev/null
+
+if [[ -n ${minor_version} ]];then
+    git reset --hard ${lasttag} >/dev/null
+
+    if [[ -z ${COMMITS} ]];then
+        echo "Showing commit between last minor tag '${lasttag} to '${MASTER_BRANCH}'"
+        echo
+        git log --reverse --no-merges --pretty=format:"%h | %s | %cd | %ae" ${lasttag}..${MASTER_BRANCH}
+        echo
+        read -e -p "Pick a list of ordered commits to cherry-pick space separated (* mean all of them): " COMMITS
+    fi
+    [[ -z ${COMMITS} ]] && { echo "no commits picked"; exit 1;}
+    if [[ ${COMMITS} == "*" ]];then
+        COMMITS=$(git log --reverse --no-merges --pretty=format:"%h" ${lasttag}..${MASTER_BRANCH})
+    fi
+    for commit in ${COMMITS};do
+        git branch --contains ${commit} >/dev/null || { echo "Invalid commit ${commit}" ; exit 1;}
+        echo "Cherry-picking commit: ${commit}"
+        git cherry-pick ${commit} >/dev/null
+    done
+
+else
+    echo "Major release ${RELEASE_VERSION%.*} detected: picking up ${UPSTREAM_REMOTE}/${MASTER_BRANCH}"
+    git reset --hard ${UPSTREAM_REMOTE}/${MASTER_BRANCH}
+fi
+
+# TODO: toremove! this is temporary to disable the upload to homebrew
+# need to find a way how to do this automatically (push to upstream/revert and
+# then being able to cherry-pick if $PUSH_REMOTE != 'upstream/origin'?)
+# git cherry-pick 052b0b4ce989fe9aee01027e67e61538b48e1179
+
+# Add our VERSION so Makefile will pick it up when compiling
+echo ${RELEASE_VERSION} > VERSION
+git add VERSION
+git commit -sm "New version ${RELEASE_VERSION}" -m "${COMMITS}" VERSION
+git tag --sign -m \
+    "New version ${RELEASE_VERSION}
+COMMITS:
+$(git log --reverse --no-merges --pretty=format:"%h | %s | %cd | %ae" ${lasttag}..${MASTER_BRANCH})" \
+    --force ${RELEASE_VERSION}
+
+git push --force ${PUSH_REMOTE} ${RELEASE_VERSION}
+
+kubectl version 2>/dev/null >/dev/null || {
+    echo "you need to have access to a kubernetes cluster"
+    exit 1
+}
+
+kubectl get pipelineresource 2>/dev/null >/dev/null || {
+    echo "you need to have tekton install onto the cluster"
+    exit 1
+}
+
+kubectl create ${TARGET_NAMESPACE} 2>/dev/null || true
+
+for task in ${CATALOG_TASKS};do
+    kubectl -n ${TARGET_NAMESPACE} apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/${task}.yaml
+done
+
+kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/goreleaser.yml
+
+if ! kubectl get secret ${SECRET_NAME} -o name >/dev/null 2>/dev/null;then
+    github_token=$(git config --get github.oauth-token || true)
+
+    [[ -z ${github_token} ]] && {
+        read -e -p "Enter your Github Token: " github_token
+        [[ -z ${github_token} ]] && { echo "no token provided"; exit 1;}
+    }
+
+    kubectl -n ${TARGET_NAMESPACE} create secret generic ${SECRET_NAME} --from-literal=bot-token=${github_token}
+fi
+
+kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/release-pipeline.yml
+
+# Until tkn supports tkn create with parameters we do like this,
+cat <<EOF | kubectl -n ${TARGET_NAMESPACE} apply -f-
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: tektoncd-cli-git
+spec:
+  type: git
+  params:
+  - name: revision
+    value: ${RELEASE_VERSION}
+  - name: url
+    value: $(git remote get-url ${PUSH_REMOTE}|sed 's,git@github.com:,https://github.com/,')
+EOF
+
+# Start the pipeline, We can't use tkn start because until #272 and #262 are imp/fixed
+cat <<EOF | kubectl -n ${TARGET_NAMESPACE} create -f-
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: cli-release-pipeline-run
+spec:
+  pipelineRef:
+    name: cli-release-pipeline
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: tektoncd-cli-git
+EOF
+
+type -p tkn >/dev/null 2>/dev/null || { echo  "Could not find the 'tkn' binary, you are on your own buddy"; exit 0 ;}
+
+tkn pipeline logs cli-release-pipeline -f


### PR DESCRIPTION
Add a release script that streamline how we want to do the release.

All the documentation should be in the README.

This create a VERSION file and push the tag which would then get picked up by
gorelease.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

