### PR TITLE
Improve release script

### DIFF
--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -10,65 +10,14 @@ PUSH_REMOTE="${PUSH_REMOTE:-${UPSTREAM_REMOTE}}" # export PUSH_REMOTE to your ow
 
 CATALOG_TASKS="lint build tests"
 
+BINARIES="kubectl jq tkn git"
+
 set -e
 
-[[ -z ${RELEASE_VERSION} ]] && {
-    read -e -p "Enter a target release (i.e: v0.1.2): " RELEASE_VERSION
-    [[ -z ${RELEASE_VERSION} ]] && { echo "no target release"; exit 1 ;}
-}
+for b in ${BINARIES};do
+    type -p ${b} >/dev/null || { echo "'${b}' need to be avail"; exit 1 ;}
+done
 
-[[ ${RELEASE_VERSION} =~ v[0-9]+\.[0-9]*\.[0-9]+ ]] || { echo "invalid version provided, need to match v\d+\.\d+\.\d+"; exit 1 ;}
-lasttag=$(git describe --abbrev=0 --tags)
-echo ${lasttag}|sed 's/\.[0-9]*$//'|grep -q ${RELEASE_VERSION%.*} && { echo "Minor version of ${RELEASE_VERSION%.*} detected"; minor_version=true ; }
-
-cd ${GOPATH}/src/github.com/tektoncd/cli
-
-git fetch -a ${UPSTREAM_REMOTE} >/dev/null
-git checkout ${MASTER_BRANCH}
-git reset --hard ${UPSTREAM_REMOTE}/${MASTER_BRANCH}
-git checkout -B release-${RELEASE_VERSION}  ${MASTER_BRANCH} >/dev/null
-
-if [[ -n ${minor_version} ]];then
-    git reset --hard ${lasttag} >/dev/null
-
-    if [[ -z ${COMMITS} ]];then
-        echo "Showing commit between last minor tag '${lasttag} to '${MASTER_BRANCH}'"
-        echo
-        git log --reverse --no-merges --pretty=format:"%h | %s | %cd | %ae" ${lasttag}..${MASTER_BRANCH}
-        echo
-        read -e -p "Pick a list of ordered commits to cherry-pick space separated (* mean all of them): " COMMITS
-    fi
-    [[ -z ${COMMITS} ]] && { echo "no commits picked"; exit 1;}
-    if [[ ${COMMITS} == "*" ]];then
-        COMMITS=$(git log --reverse --no-merges --pretty=format:"%h" ${lasttag}..${MASTER_BRANCH})
-    fi
-    for commit in ${COMMITS};do
-        git branch --contains ${commit} >/dev/null || { echo "Invalid commit ${commit}" ; exit 1;}
-        echo "Cherry-picking commit: ${commit}"
-        git cherry-pick ${commit} >/dev/null
-    done
-
-else
-    echo "Major release ${RELEASE_VERSION%.*} detected: picking up ${UPSTREAM_REMOTE}/${MASTER_BRANCH}"
-    git reset --hard ${UPSTREAM_REMOTE}/${MASTER_BRANCH}
-fi
-
-# TODO: toremove! this is temporary to disable the upload to homebrew
-# need to find a way how to do this automatically (push to upstream/revert and
-# then being able to cherry-pick if $PUSH_REMOTE != 'upstream/origin'?)
-# git cherry-pick 052b0b4ce989fe9aee01027e67e61538b48e1179
-
-# Add our VERSION so Makefile will pick it up when compiling
-echo ${RELEASE_VERSION} > VERSION
-git add VERSION
-git commit -sm "New version ${RELEASE_VERSION}" -m "${COMMITS}" VERSION
-git tag --sign -m \
-    "New version ${RELEASE_VERSION}
-COMMITS:
-$(git log --reverse --no-merges --pretty=format:"%h | %s | %cd | %ae" ${lasttag}..${MASTER_BRANCH})" \
-    --force ${RELEASE_VERSION}
-
-git push --force ${PUSH_REMOTE} ${RELEASE_VERSION}
 
 kubectl version 2>/dev/null >/dev/null || {
     echo "you need to have access to a kubernetes cluster"
@@ -80,7 +29,89 @@ kubectl get pipelineresource 2>/dev/null >/dev/null || {
     exit 1
 }
 
-kubectl create ${TARGET_NAMESPACE} 2>/dev/null || true
+[[ -z ${RELEASE_VERSION} ]] && {
+    read -e -p "Enter a target release (i.e: v0.1.2): " RELEASE_VERSION
+    [[ -z ${RELEASE_VERSION} ]] && { echo "no target release"; exit 1 ;}
+}
+
+[[ ${RELEASE_VERSION} =~ v[0-9]+\.[0-9]*\.[0-9]+ ]] || { echo "invalid version provided, need to match v\d+\.\d+\.\d+"; exit 1 ;}
+git fetch -a --tags ${UPSTREAM_REMOTE} >/dev/null
+lasttag=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo ${lasttag}|sed 's/\.[0-9]*$//'|grep -q ${RELEASE_VERSION%.*} && {
+    echo "Minor version of ${RELEASE_VERSION%.*} detected, previous ${lasttag}"; minor_version=true ;
+} || {
+    echo "Major version for ${RELEASE_VERSION%.*} detected, previous ${lasttag}";
+}
+
+cd ${GOPATH}/src/github.com/tektoncd/cli
+
+[[ -n $(git status --porcelain 2>&1) ]] && {
+    echo "We have detected some changes in your repo"
+    echo "Stash them before executing this script"
+    exit 1
+}
+
+git checkout ${MASTER_BRANCH}
+git reset --hard ${UPSTREAM_REMOTE}/${MASTER_BRANCH}
+git checkout -B release-${RELEASE_VERSION}  ${MASTER_BRANCH} >/dev/null
+
+if [[ -n ${minor_version} ]];then
+    git reset --hard ${lasttag} >/dev/null
+
+    if [[ -z ${COMMITS} ]];then
+        echo "Showing commit between last minor tag '${lasttag} to '${MASTER_BRANCH}'"
+        echo
+        git log --reverse --no-merges --pretty=format:"%C(bold cyan)%h%Creset | %cd | %s | %ae" ${MASTER_BRANCH} --since "$(git log --pretty=format:%cd -1 ${lasttag})"
+        echo
+        read -e -p "Pick a list of ordered commits to cherry-pick space separated (* mean all of them): " COMMITS
+    fi
+    [[ -z ${COMMITS} ]] && { echo "no commits picked"; exit 1;}
+    if [[ ${COMMITS} == "*" ]];then
+        COMMITS=$(git log --reverse --no-merges --pretty=format:"%h" ${MASTER_BRANCH} \
+                      --since "$(git log --pretty=format:%cd -1 ${lasttag})")
+    fi
+    for commit in ${COMMITS};do
+        git branch --contains ${commit} >/dev/null || { echo "Invalid commit ${commit}" ; exit 1;}
+        echo "Cherry-picking commit: ${commit}"
+        git cherry-pick ${commit} >/dev/null
+    done
+else
+    echo "Major release ${RELEASE_VERSION%.*} detected: picking up ${UPSTREAM_REMOTE}/${MASTER_BRANCH}"
+    git reset --hard ${UPSTREAM_REMOTE}/${MASTER_BRANCH}
+fi
+
+# HACK:! this is temporary to disable the upload to homebrew when we do our testing
+# need to find a way how to do this automatically (push to upstream/revert and
+# then being able to cherry-pick if $PUSH_REMOTE != 'upstream/origin'?)
+[[ ${PUSH_REMOTE} != origin* && ${PUSH_REMOTE} != upstream* ]] && {
+    echo "Testing mode detected Cherry-picking commit: 052b0b4ce989fe9aee01027e67e61538b48e1179"
+    git cherry-pick 052b0b4ce989fe9aee01027e67e61538b48e1179 >/dev/null
+}
+
+COMMITS=$(git log --reverse --no-merges \
+              --pretty=format:'%H' ${MASTER_BRANCH} \
+              --since "$(git log --pretty=format:%cd -1 ${lasttag})")
+
+changelog=""
+for c in ${COMMITS};do
+    pr=$(curl -s "https://api.github.com/search/issues?q=${c}" |jq -r '.items[0].html_url')
+    pr=$(echo ${pr}|sed 's,https://github.com/tektoncd/cli/pull/,tektoncd/cli#,')
+    changelog+="${pr} | $(git log -1 --date=format:'%Y/%m/%d-%H:%M' --pretty=format:'[%an] %s | %cd' ${c})
+"
+done
+
+# Add our VERSION so Makefile will pick it up when compiling
+echo ${RELEASE_VERSION} > VERSION
+git add VERSION
+git commit -sm "New version ${RELEASE_VERSION}" -m "${changelog}" VERSION
+git tag --sign -m \
+    "New version ${RELEASE_VERSION}" \
+    -m "${changelog}" --force ${RELEASE_VERSION}
+
+git push --force ${PUSH_REMOTE} ${RELEASE_VERSION}
+git push --force ${PUSH_REMOTE} release-${RELEASE_VERSION}
+
+kubectl create namespace ${TARGET_NAMESPACE} 2>/dev/null || true
 
 for task in ${CATALOG_TASKS};do
     kubectl -n ${TARGET_NAMESPACE} apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/${task}.yaml
@@ -88,7 +119,7 @@ done
 
 kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/goreleaser.yml
 
-if ! kubectl get secret ${SECRET_NAME} -o name >/dev/null 2>/dev/null;then
+if ! kubectl -n ${TARGET_NAMESPACE} get secret ${SECRET_NAME} -o name >/dev/null 2>/dev/null;then
     github_token=$(git config --get github.oauth-token || true)
 
     [[ -z ${github_token} ]] && {
@@ -100,6 +131,8 @@ if ! kubectl get secret ${SECRET_NAME} -o name >/dev/null 2>/dev/null;then
 fi
 
 kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/release-pipeline.yml
+
+sleep 2
 
 # Until tkn supports tkn create with parameters we do like this,
 cat <<EOF | kubectl -n ${TARGET_NAMESPACE} apply -f-
@@ -131,6 +164,4 @@ spec:
         name: tektoncd-cli-git
 EOF
 
-type -p tkn >/dev/null 2>/dev/null || { echo  "Could not find the 'tkn' binary, you are on your own buddy"; exit 0 ;}
-
-tkn pipeline logs cli-release-pipeline -f
+tkn -n ${TARGET_NAMESPACE} pipeline logs cli-release-pipeline -f --last


### PR DESCRIPTION
* checks for our binaries
* push release-${VERSION} to the upstream remote too, since pushed tag doesnt
* Do checks early
* Show if we are in a major version
* discover last tag better
* detect if we have changes in the current repo and abort if we do
* use --since to see the commits between old tag and current
* better showing the commits to pick up
* get the pr from github API

/cc @sthaha  @vdemeester 