### PR TITLE
🎨 Add rainbow colouring of steps label

### DIFF
--- a/pkg/cmd/pipelinerun/log_writer.go
+++ b/pkg/cmd/pipelinerun/log_writer.go
@@ -45,7 +45,8 @@ func (lw *LogWriter) Write(s *cli.Stream, logC <-chan Log, errC <-chan error) {
 				fmt.Fprintf(s.Out, "\n")
 				continue
 			}
-			lw.fmt.Header(s.Out, "[%s : %s] ", l.Task, l.Step)
+
+			lw.fmt.Rainbow.Fprintf(l.Step, s.Out, "[%s : %s] ", l.Task, l.Step)
 			fmt.Fprintf(s.Out, "%s\n", l.Log)
 		case e, ok := <-errC:
 			if !ok {

--- a/pkg/cmd/taskrun/log_writer.go
+++ b/pkg/cmd/taskrun/log_writer.go
@@ -46,7 +46,7 @@ func (lw *LogWriter) Write(s *cli.Stream, logC <-chan Log, errC <-chan error) {
 				continue
 			}
 
-			lw.fmt.Header(s.Out, "[%s] ", l.Step)
+			lw.fmt.Rainbow.Fprintf(l.Step, s.Out, "[%s] ", l.Step)
 			fmt.Fprintf(s.Out, "%s\n", l.Log)
 		case e, ok := <-errC:
 			if !ok {

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -1,0 +1,41 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package formatted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRainbowsColours(t *testing.T) {
+	rb := newRainbow()
+	assert.Equal(t, rb.counter.value, uint32(0)) // nothing
+
+	c := rb.get("a") // get a label
+	assert.NotNil(t, c)
+	assert.Equal(t, rb.counter.value, uint32(1))
+
+	_ = rb.get("b") // incremented
+	assert.Equal(t, rb.counter.value, uint32(2))
+
+	_ = rb.get("a") // no increment (cached)
+	assert.Equal(t, rb.counter.value, uint32(2))
+
+	rb = newRainbow()
+	for c := range palette {
+		rb.get(string(c))
+	}
+	assert.Equal(t, rb.counter.value, uint32(0)) // Looped back to 0
+}


### PR DESCRIPTION
We were showing the same blue color for every steps, let's now cycle of a list of
colors.


- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

Demo: https://asciinema.org/a/hbJk1PqMFE8hleRpDsraPw0WB

Closes #285 

# Release Notes
```
Steps are now labelled with different colours instead of the same one 🎨
```
