### PR TITLE
Silence Usage When an Error Occurs

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -64,9 +64,10 @@ func Root(p cli.Params) *cobra.Command {
 	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 
 	var cmd = &cobra.Command{
-		Use:   "tkn",
-		Short: "CLI for tekton pipelines",
-		Long:  ``,
+		Use:          "tkn",
+		Short:        "CLI for tekton pipelines",
+		Long:         ``,
+		SilenceUsage: true,
 	}
 	cobra.AddTemplateFunc("HasMainSubCommands", hasMainSubCommands)
 	cobra.AddTemplateFunc("HasUtilitySubCommands", hasUtilitySubCommands)


### PR DESCRIPTION
This pull request partially addresses #183. It sets `SilenceUsage: true` in `root.go` so the help message for each command does not display when an error occurs. 

Previously, when an error was displayed, the usage of the command would display. An example is below:

```
$ tkn pr ls -n 
Error: flag needs an argument: 'n' in -n
Usage:
  tkn pipelinerun list [flags]

Aliases:
  list, ls

Examples:

# List all PipelineRuns of Pipeline name 'foo'
tkn pipelinerun list foo -n bar

# List all pipelineruns in a namespaces 'foo'
tkn pr list -n foo",


Flags:
      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
  -h, --help                          help for list
  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

Global Flags:
  -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
``` 

With the change in this pr, the output would change to the following:

```
$ tkn pr ls -n 
Error: flag needs an argument: 'n' in -n
```

My opinion is that displaying all the `--help` information makes the error message difficult to find and is much more information than the user needs to solve the situation. 

What is still needed is an elegant way to suggest to the user to run `--help` for the specific subcommand. I am open to any suggestions that can happen as part of this pr or can be discussed in #183. This is something that looks like it is [being discussed](https://github.com/spf13/cobra/issues/950) in the Cobra project.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Error messages no longer display the usage of the CLI command for which the error occurred. 
```
