### PR TITLE
E2E tests fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: bin/tkn test
 
 FORCE:
 
-vendor: 
+vendor:
 	@go mod vendor
 
 .PHONY: cross
@@ -57,7 +57,7 @@ test-unit: ./vendor ## run unit tests
 	@go test -failfast -v -cover ./...
 
 .PHONY: test-e2e
-test-e2e: ./vendor ## run e2e tests
+test-e2e: bin/tkn ## run e2e tests
 	@echo "Running e2e tests..."
 	@LOCAL_CI_RUN=true bash ./test/e2e-tests.sh
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,15 +30,18 @@ ci_run && {
 # Run the integration tests
 ci_run && {
   header "Running Go e2e tests"
-  local failed=0
+  failed=0
   go_test_e2e ./test || failed=1
   (( failed )) && fail_test
 }
 
-go build github.com/tektoncd/cli/cmd/tkn
-
 tkn() {
- ./tkn "$@"
+    if [[ -e ./bin/tkn ]];then
+        ./bin/tkn $@
+    else
+        go build github.com/tektoncd/cli/cmd/tkn
+        ./tkn "$@"
+    fi
 }
 
 kubectl get crds|grep tekton\\.dev && fail_test "TektonCD CRDS should not be installed, you should reset them before each runs"


### PR DESCRIPTION
Try first to use the makefile target when running the e2e tests and use the
binary build from there. try other different ways to get the tkn binary if it's
in the path or if we can compile it.