### PR TITLE
Fix interactive prompt with --last

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/fatih/color v1.7.0
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-containerregistry v0.0.0-20190320210540-8d4083db9aa0 // indirect
@@ -37,6 +39,7 @@ require (
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/prometheus/procfs v0.0.0-20190322151404-55ae3d9d5573 // indirect
 	github.com/spf13/cobra v0.0.5
@@ -50,6 +53,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	google.golang.org/grpc v1.19.1 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	k8s.io/api v0.0.0-20190226173710-145d52631d00
 	k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc
 	k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -158,7 +158,7 @@ func (opt *startOptions) getInput(pname string) error {
 		return err
 	}
 
-	if len(opt.Resources) == 0 {
+	if len(opt.Resources) == 0 && !opt.Last {
 		pres, err := getPipelineResources(cs.Tekton, opt.cliparams.Namespace())
 		if err != nil {
 			fmt.Fprintf(opt.stream.Err, "failed to list pipelineresources from %s namespace \n", opt.cliparams.Namespace())
@@ -173,7 +173,7 @@ func (opt *startOptions) getInput(pname string) error {
 		}
 	}
 
-	if len(opt.Params) == 0 {
+	if len(opt.Params) == 0 && !opt.Last {
 		err = opt.getInputParams(pipeline)
 		if err != nil {
 			return err
@@ -196,7 +196,7 @@ func (opt *startOptions) getInputResources(resources resourceOptionsFilter, pipe
 			{
 				Name: "pipelineresource",
 				Prompt: &survey.Select{
-					Message: fmt.Sprintf("Which %s resource to use for %s ?", res.Type, res.Name),
+					Message: fmt.Sprintf("Choose the %s resource to use for %s:", res.Type, res.Name),
 					Options: options,
 				},
 			},


### PR DESCRIPTION
This will fix the issue of interactive prompt getting
started with --last flag in scenario of not using
resource or param flag. It should take the value from
last pipelinerun in case of no use of resource and
param flag. In case of using the flag, it will override
the value of last run but should never start
interactive prompt.

Change the resource selection question in interactive
prompt for better user experience.

Adds tests for the given scenario

Fixes https://github.com/tektoncd/cli/issues/297

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)