### PR TITLE
Fix -n not working with pipeline logs

### DIFF
--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/pipelinerun"
+	"github.com/tektoncd/cli/pkg/flags"
 	"github.com/tektoncd/cli/pkg/formatted"
 	prhsort "github.com/tektoncd/cli/pkg/helper/pipelinerun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -92,6 +93,9 @@ func logCommand(p cli.Params) *cobra.Command {
 			"commandType": "main",
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
+			if err := flags.InitParams(p, cmd); err != nil {
+				return err
+			}
 			return nameArg(args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -157,9 +161,7 @@ func (opts *logOptions) init(args []string) error {
 }
 
 func (opts *logOptions) getAllInputs() error {
-	err := validate(opts)
-
-	if err != nil {
+	if err := validate(opts); err != nil {
 		return err
 	}
 
@@ -181,8 +183,7 @@ func (opts *logOptions) getAllInputs() error {
 		},
 	}}
 
-	err = survey.Ask(qs1, &opts.pipelineName, opts.askOpts)
-	if err != nil {
+	if err = survey.Ask(qs1, &opts.pipelineName, opts.askOpts); err != nil {
 		fmt.Println(err.Error())
 		return err
 	}
@@ -191,8 +192,7 @@ func (opts *logOptions) getAllInputs() error {
 }
 
 func (opts *logOptions) askRunName() error {
-	err := validate(opts)
-	if err != nil {
+	if err := validate(opts); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -110,8 +110,7 @@ like cat,foo.bar
 `,
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
-			err := flags.InitParams(p, cmd)
-			if err != nil {
+			if err := flags.InitParams(p, cmd); err != nil {
 				return err
 			}
 			return NameArg(args, p)
@@ -167,15 +166,13 @@ func (opt *startOptions) getInput(pname string) error {
 
 		resources := getPipelineResourcesByFormat(pres.Items)
 
-		err = opt.getInputResources(resources, pipeline)
-		if err != nil {
+		if err = opt.getInputResources(resources, pipeline); err != nil {
 			return err
 		}
 	}
 
 	if len(opt.Params) == 0 && !opt.Last {
-		err = opt.getInputParams(pipeline)
-		if err != nil {
+		if err = opt.getInputParams(pipeline); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This will fix the issue of -n flag not working with
tkn pipeline logs

Actually the namespace param was not getting initialised

Adds test for that

Fixes https://github.com/tektoncd/cli/issues/287

Fixes https://github.com/tektoncd/cli/issues/306

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._