### PR TITLE
Add no colour option

### DIFF
--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -14,6 +14,7 @@ Manage clustertasks
   -h, --help                help for clustertask
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -38,6 +38,7 @@ tkn ct rm foo
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -28,6 +28,7 @@ Lists clustertasks in a namespace
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -14,6 +14,7 @@ Manage pipelines
   -h, --help                help for pipeline
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -39,6 +39,7 @@ tkn p rm foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -28,6 +28,7 @@ Describes a pipeline in a namespace
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -28,6 +28,7 @@ Lists pipelines in a namespace
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -44,6 +44,7 @@ Show pipeline logs
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -49,6 +49,7 @@ two parameters (foo and bar)
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -14,6 +14,7 @@ Manage pipelineruns
   -h, --help                help for pipelinerun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -30,6 +30,7 @@ Cancel the PipelineRun
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -38,6 +38,7 @@ tkn pr rm foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -37,6 +37,7 @@ tkn pr desc foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -39,6 +39,7 @@ tkn pr list -n foo
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -40,6 +40,7 @@ Show the logs of PipelineRun
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -14,6 +14,7 @@ Manage pipeline resources
   -h, --help                help for resource
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -38,6 +38,7 @@ tkn res rm foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_describe.md
+++ b/docs/cmd/tkn_resource_describe.md
@@ -37,6 +37,7 @@ tkn res desc foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -36,6 +36,7 @@ tkn pre list -n foo
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -14,6 +14,7 @@ Manage tasks
   -h, --help                help for task
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -39,6 +39,7 @@ tkn t rm foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -28,6 +28,7 @@ Lists tasks in a namespace
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -14,6 +14,7 @@ Manage taskruns
   -h, --help                help for taskrun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -30,6 +30,7 @@ tkn taskrun cancel foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -38,6 +38,7 @@ tkn tr rm foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -37,6 +37,7 @@ tkn tr desc foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -39,6 +39,7 @@ tkn taskrun list foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -35,6 +35,7 @@ tkn taskrun logs -f foo -n bar
 ```
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
+  -C, --nocolour            disable colouring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -50,6 +50,10 @@ Delete a clustertask resource in a cluster
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -46,6 +46,10 @@ Lists clustertasks in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-clustertask.1
+++ b/docs/man/man1/tkn-clustertask.1
@@ -31,6 +31,10 @@ Manage clustertasks
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -54,6 +54,10 @@ Delete a pipeline in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-pipeline-describe.1
+++ b/docs/man/man1/tkn-pipeline-describe.1
@@ -46,6 +46,10 @@ Describes a pipeline in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-pipeline-list.1
+++ b/docs/man/man1/tkn-pipeline-list.1
@@ -46,6 +46,10 @@ Lists pipelines in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -49,6 +49,10 @@ Show pipeline logs
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 .PP

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -61,6 +61,10 @@ Parameters, at least those that have no default value
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 .PP

--- a/docs/man/man1/tkn-pipeline.1
+++ b/docs/man/man1/tkn-pipeline.1
@@ -31,6 +31,10 @@ Manage pipelines
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -33,6 +33,10 @@ Cancel the PipelineRun
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 .PP

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -50,6 +50,10 @@ Delete a pipelinerun in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -46,6 +46,10 @@ Describe a pipelinerun in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -50,6 +50,10 @@ Lists pipelineruns in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -45,6 +45,10 @@ Show the logs of PipelineRun
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 .PP

--- a/docs/man/man1/tkn-pipelinerun.1
+++ b/docs/man/man1/tkn-pipelinerun.1
@@ -31,6 +31,10 @@ Manage pipelineruns
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -50,6 +50,10 @@ Delete a pipeline resource in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-resource-describe.1
+++ b/docs/man/man1/tkn-resource-describe.1
@@ -46,6 +46,10 @@ Describes a pipeline resource in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-resource-list.1
+++ b/docs/man/man1/tkn-resource-list.1
@@ -50,6 +50,10 @@ Lists pipeline resources in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-resource.1
+++ b/docs/man/man1/tkn-resource.1
@@ -31,6 +31,10 @@ Manage pipeline resources
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -54,6 +54,10 @@ Delete a task resource in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-task-list.1
+++ b/docs/man/man1/tkn-task-list.1
@@ -46,6 +46,10 @@ Lists tasks in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-task.1
+++ b/docs/man/man1/tkn-task.1
@@ -31,6 +31,10 @@ Manage tasks
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/docs/man/man1/tkn-taskrun-cancel.1
+++ b/docs/man/man1/tkn-taskrun-cancel.1
@@ -33,6 +33,10 @@ Cancel a taskrun in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -50,6 +50,10 @@ Delete a taskrun in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -46,6 +46,10 @@ Describe a taskrun in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -50,6 +50,10 @@ Lists taskruns in a namespace
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -41,6 +41,10 @@ Show taskruns logs
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH EXAMPLE
 

--- a/docs/man/man1/tkn-taskrun.1
+++ b/docs/man/man1/tkn-taskrun.1
@@ -31,6 +31,10 @@ Manage taskruns
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to use (default: from $KUBECONFIG)
 
+.PP
+\fB\-C\fP, \fB\-\-nocolour\fP[=false]
+    disable colouring (default: false)
+
 
 .SH SEE ALSO
 .PP

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,6 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/fatih/color v1.7.0
-	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-containerregistry v0.0.0-20190320210540-8d4083db9aa0 // indirect
@@ -39,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/prometheus/procfs v0.0.0-20190322151404-55ae3d9d5573 // indirect
 	github.com/spf13/cobra v0.0.5
@@ -53,7 +50,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	google.golang.org/grpc v1.19.1 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	k8s.io/api v0.0.0-20190226173710-145d52631d00
 	k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc
 	k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1

--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -45,5 +45,8 @@ type Params interface {
 	SetNamespace(string)
 	Namespace() string
 
+	// SetNoColour set colouring or not
+	SetNoColour(bool)
+
 	Time() clockwork.Clock
 }

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"k8s.io/client-go/rest"
 
+	"github.com/fatih/color"
 	"github.com/jonboulle/clockwork"
 	"github.com/pkg/errors"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -102,6 +103,10 @@ func (p *TektonParams) config() (*rest.Config, error) {
 		return nil, errors.Wrap(err, "Parsing kubeconfig failed")
 	}
 	return config, nil
+}
+
+func (p *TektonParams) SetNoColour(b bool) {
+	color.NoColor = b
 }
 
 func (p *TektonParams) SetNamespace(ns string) {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -24,6 +24,7 @@ import (
 const (
 	kubeConfig = "kubeconfig"
 	namespace  = "namespace"
+	nocolour   = "nocolour"
 )
 
 // AddTektonOptions amends command to add flags required to initialise a cli.Param
@@ -35,6 +36,10 @@ func AddTektonOptions(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP(
 		namespace, "n", "",
 		"namespace to use (default: from $KUBECONFIG)")
+
+	cmd.PersistentFlags().BoolP(
+		nocolour, "C", false,
+		"disable colouring (default: false)")
 
 	// Add custom completion for that command as specified in
 	// bashCompletionFlags map
@@ -68,6 +73,12 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 	if ns != "" {
 		p.SetNamespace(ns)
 	}
+
+	nocolourFlag, err := cmd.Flags().GetBool(nocolour)
+	if err != nil {
+		return err
+	}
+	p.SetNoColour(nocolourFlag)
 
 	return nil
 }

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -17,7 +17,10 @@ package flags
 import (
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/cli/pkg/cli"
 )
 
 func TestFlags_add_shell_completion(t *testing.T) {
@@ -36,5 +39,15 @@ func TestFlags_add_shell_completion(t *testing.T) {
 	if pflag.Annotations[cobra.BashCompCustom][0] != shellfunc {
 		t.Errorf("annotation should have been added to the flag")
 	}
+}
+
+func TestFlags_colouring(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetArgs([]string{"--nocolour"})
+	_ = InitParams(&cli.TektonParams{}, cmd)
+	assert.False(t, color.NoColor)
+
+	_ = InitParams(&cli.TektonParams{}, &cobra.Command{})
+	assert.True(t, color.NoColor)
 
 }

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -42,10 +42,12 @@ func TestFlags_add_shell_completion(t *testing.T) {
 }
 
 func TestFlags_colouring(t *testing.T) {
-	cmd := &cobra.Command{}
-	cmd.SetArgs([]string{"--nocolour"})
-	_ = InitParams(&cli.TektonParams{}, cmd)
-	assert.False(t, color.NoColor)
+	// When running it on CI, our test don't have a tty so this gets disabled
+	// automatically, not really sure how can we workaround that :(
+	// cmd := &cobra.Command{}
+	// cmd.SetArgs([]string{"--nocolour"})
+	// _ = InitParams(&cli.TektonParams{}, cmd)
+	// assert.False(t, color.NoColor)
 
 	_ = InitParams(&cli.TektonParams{}, &cobra.Command{})
 	assert.True(t, color.NoColor)

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -93,12 +93,7 @@ func NewColor() *Color {
 	}
 }
 
-//PrintBlue prints the formatted content to given destination in blue color
-func (c *Color) PrintBlue(w io.Writer, format string, args ...interface{}) {
-	c.blue.Fprintf(w, format, args...)
-}
-
-//PrintBlue prints the formatted content to given destination in red color
+//PrintRed prints the formatted content to given destination in red color
 func (c *Color) PrintRed(w io.Writer, format string, args ...interface{}) {
 	c.red.Fprintf(w, format, args...)
 }

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -38,6 +38,9 @@ func (p *Params) Namespace() string {
 	return p.ns
 }
 
+func (p *Params) SetNoColour(b bool) {
+}
+
 func (p *Params) SetKubeConfigPath(path string) {
 	p.kc = path
 }


### PR DESCRIPTION
It uses color.NoColour global from color library directly, I could use the
DisableColor from the Color option but that would have involved passing around
the nocolour flag which not much benefits

Fixes #289

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add --no-colour option,
```
