### PR TITLE
Improve the error message on pipeline create

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	errNoPipeline      = errors.New("missing pipeline name")
-	errInvalidPipeline = "invalid pipeline name %s in namespace %s"
+	errInvalidPipeline = "pipeline name %s does not exist in namespace %s"
 )
 
 const (
@@ -368,7 +368,7 @@ func (opt *startOptions) startPipeline(pName string) error {
 	}
 
 	fmt.Fprintf(opt.stream.Out, "Pipelinerun started: %s\n\n"+
-		"In order to track the pipelinerun progress run:\ntkn pipelinerun logs -n %s %s -f\n", prCreated.Name, prCreated.Namespace, prCreated.Name)
+		"In order to track the pipelinerun progress run:\ntkn pipelinerun logs %s -f -n %s\n", prCreated.Name, prCreated.Name, prCreated.Namespace)
 	return nil
 }
 

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	errNoPipeline      = errors.New("missing pipeline name")
-	errInvalidPipeline = errors.New("invalid pipeline name")
+	errInvalidPipeline = "invalid pipeline name %s in namespace %s"
 )
 
 const (
@@ -76,7 +76,7 @@ func NameArg(args []string, p cli.Params) error {
 	name, ns := args[0], p.Namespace()
 	_, err = c.Tekton.TektonV1alpha1().Pipelines(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return errInvalidPipeline
+		return fmt.Errorf(errInvalidPipeline, name, ns)
 	}
 
 	return nil

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -119,7 +119,7 @@ func Test_start_pipeline_not_found(t *testing.T) {
 
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", "test-pipeline-2", "-n", "ns")
-	expected := "Error: " + fmt.Sprintf(errInvalidPipeline, "test-pipeline-2", "ns") + "\n"
+	expected := "Error: pipeline name test-pipeline-2 does not exist in namespace ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -152,7 +152,7 @@ func Test_start_pipeline(t *testing.T) {
 		"-s=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns  -f\n"
+	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns("ns").List(v1.ListOptions{})
@@ -334,7 +334,7 @@ func Test_start_pipeline_last(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns random -f\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})
@@ -405,7 +405,7 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 		"--last",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns random -f\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})
@@ -483,7 +483,7 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n=ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns random -f\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -119,7 +119,7 @@ func Test_start_pipeline_not_found(t *testing.T) {
 
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", "test-pipeline-2", "-n", "ns")
-	expected := "Error: " + errInvalidPipeline.Error() + "\n"
+	expected := "Error: " + fmt.Sprintf(errInvalidPipeline, "test-pipeline-2", "ns") + "\n"
 	test.AssertOutput(t, expected, got)
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If the pipeline is not found on pipeline create, it may be due to
a misspelled pipeline name or namespace name. Include both in the
error message to help troubleshooting.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
