### PR TITLE
Fix the logs command when creating a pipelinerun

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -367,7 +367,7 @@ func (opt *startOptions) startPipeline(pName string) error {
 	}
 
 	fmt.Fprintf(opt.stream.Out, "Pipelinerun started: %s\n\n"+
-		"In order to track the pipelinerun progress run:\ntkn pipelinerun logs %s -f\n", prCreated.Name, prCreated.Name)
+		"In order to track the pipelinerun progress run:\ntkn pipelinerun logs -n %s %s -f\n", prCreated.Name, prCreated.Namespace, prCreated.Name)
 	return nil
 }
 

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -150,7 +150,7 @@ func Test_start_pipeline(t *testing.T) {
 		"-s=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f\n"
+	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns  -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns("ns").List(v1.ListOptions{})
@@ -332,7 +332,7 @@ func Test_start_pipeline_last(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns random -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})
@@ -403,7 +403,7 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 		"--last",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns random -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})
@@ -481,7 +481,7 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n=ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f\n"
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs -n ns random -f\n"
 	test.AssertOutput(t, expected, got)
 
 	pr, err := cs.Pipeline.TektonV1alpha1().PipelineRuns(p.Namespace()).Get("random", v1.GetOptions{})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When creating a pipelinerun out of a pipeline, the cli outputs the
command to follow the pr logs, which is very handy, only it does
not include the namespace. Fixing that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._