### PR TITLE
Fix CI breakage due to changes in pipeline-0.7.0 release

### DIFF
--- a/test/resources/output-pipelinerun.yaml
+++ b/test/resources/output-pipelinerun.yaml
@@ -49,7 +49,7 @@ spec:
   - name: write-new-stuff
     image: ubuntu
     command: ['bash']
-    args: ['-c', 'echo some stuff > /workspace/damnworkspace/stuff']
+    args: ['-c', 'ln -s /workspace/damnworkspace /workspace/output/workspace && echo some stuff > /workspace/output/workspace/stuff']
 ---
 # Reads a file from a predefined path in the workspace git PipelineResource
 apiVersion: tekton.dev/v1alpha1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

## Fix CI breakage
    
Cause:
Changes in pipeline release 0.7.0 broke CLI e2e test
Specifically "Change the behavior of outputs that are also used as inputs"
ref: https://github.com/tektoncd/pipeline/commit/f5ff8a6a24551289801519e2887aefd0bd80ee8d

Fix:
Modify create file task in e2e test resource as the e2e is test is failing after pipeline 0.7.0 release

Modifies `create-file` task in e2e test resource as the e2e is test is failing after pipeline 0.7.0 release
Updates `write-new-stuff` step output path based on pipeline 0.7.0 release

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
