### PR TITLE
Align TaskRun Describe Output with Task Describe Output

### DIFF
--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -46,7 +46,7 @@ Message
 {{ $msg }}
 {{- end }}
 
-Inputs
+Input Resources
 {{- $l := len .TaskRun.Spec.Inputs.Resources }}{{ if eq $l 0 }}
 No resources
 {{- else }}
@@ -56,7 +56,7 @@ NAME	RESOURCE REF
 {{- end }}
 {{- end }}
 
-Outputs
+Output Resources
 {{- $l := len .TaskRun.Spec.Outputs.Resources }}{{ if eq $l 0 }}
 No resources
 {{- else }}
@@ -84,7 +84,7 @@ Steps
 {{- $l := len .TaskRun.Status.Steps }}{{ if eq $l 0 }}
 No steps
 {{- else }}
-STEP NAME
+NAME
 {{- range $steps := .TaskRun.Status.Steps }}
 {{ $steps.Name }}
 {{- end }}

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -78,10 +78,10 @@ Status
 STARTED    DURATION    STATUS
 ---        ---         Succeeded
 
-Inputs
+Input Resources
 No resources
 
-Outputs
+Output Resources
 No resources
 
 Params
@@ -146,12 +146,12 @@ Status
 STARTED         DURATION    STATUS
 9 minutes ago   ---         Succeeded
 
-Inputs
+Input Resources
 NAME          RESOURCE REF
 git           git
 image-input   image
 
-Outputs
+Output Resources
 NAME            RESOURCE REF
 image-output    image
 image-output2   image
@@ -162,7 +162,7 @@ input    param
 input2   param2
 
 Steps
-STEP NAME
+NAME
 step1
 step2
 `
@@ -213,10 +213,10 @@ STARTED         DURATION    STATUS
 Message
 Testing tr failed
 
-Inputs
+Input Resources
 No resources
 
-Outputs
+Output Resources
 No resources
 
 Params


### PR DESCRIPTION
This pull request aligns the output from `tkn tr describe` with the output the will be a part of `tkn task describe` in #323. 

# Changes

* Change `Inputs` to `Input Resources`
* Change `Outputs` to `Output Resources`
* Change `STEP NAME` to `NAME`
* Update tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Align output from tkn taskrun describe with tkn task describe
```
