### PR TITLE
Add Check to Taskrun Cancel for Already Executed Taskrun

### DIFF
--- a/pkg/cmd/taskrun/cancel_test.go
+++ b/pkg/cmd/taskrun/cancel_test.go
@@ -26,6 +26,16 @@ func TestTaskRunCancel(t *testing.T) {
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonRunning,
+				}),
+			),
+		),
+		tb.TaskRun("taskrun-2", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "failure-task"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("failure-task")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
 					Reason: resources.ReasonSucceeded,
 				}),
 			),
@@ -38,7 +48,7 @@ func TestTaskRunCancel(t *testing.T) {
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
+					Reason: resources.ReasonFailed,
 				}),
 			),
 		),
@@ -80,6 +90,13 @@ func TestTaskRunCancel(t *testing.T) {
 			input:     failures[0],
 			wantError: true,
 			want:      "failed to cancel taskrun \"failure-taskrun-1\": test error",
+		},
+		{
+			name:      "Failed canceling taskrun that succeeded",
+			command:   []string{"cancel", "taskrun-2", "-n", "ns"},
+			input:     seeds[0],
+			wantError: true,
+			want:      "failed to cancel taskrun taskrun-2: taskrun has already finished execution",
 		},
 	}
 


### PR DESCRIPTION
Closes #326 

This pull request introduces a change to `tkn tr cancel` to check to see if the `taskrun` has already executed. Currently, the command just sets the `taskrun` status to cancel regardless of whether or not the `taskrun` has actually already executed.

# Changes

The changes here in `cancel.go` under `github.com/tektoncd/cli/pkg/cmd/taskrun` add an if block that checks the current status of if the task has `Succeeded`, `Failed`, or `Failed(TaskRunCancelled)`. `Failed(TaskRunCancelled)` corresponds to if the `taskrun` was already cancelled. 

If the taskrun is running or pending, the cancel command will allow the user to cancel the `taskrun`. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Change tkn tr cancel to check if a taskrun has succeeded, failed, or already been cancelled
```

# Additional Info

Assuming this is an appropriate solution, the same approach should be implemented for `tkn pr cancel`.