### PR TITLE
Align Pipeline Describe Output with Other Describe Commands

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -50,9 +50,9 @@ NAME	TASKREF	RUNAFTER
 {{- end }}
 {{- end }}
 
-Runs
+Pipelineruns
 {{- $rl := len .PipelineRuns.Items }}{{ if eq $rl 0 }}
-No runs
+No pipelineruns
 {{- else }}
 NAME	STARTED	DURATION	STATUS
 {{- range $i, $pr := .PipelineRuns.Items }}


### PR DESCRIPTION
This pull request is similar to #324 in that it aligns the output from `tkn pipeline describe` with other describe commands. 

# Changes

This simply changes the `Runs` section of the output to be `Pipelineruns` to explicitly call out what is being listed in the output for `tkn pipeline describe`. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Changes output from tkn pipeline describe to say Pipelineruns instead of Runs for listing pipelineruns for the pipeline described
```
