### PR TITLE
Cleanup -l flag across commands

### DIFF
--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -35,8 +35,8 @@ Show pipeline logs
   -a, --all         show all logs including init steps injected by tekton
   -f, --follow      stream live logs
   -h, --help        help for logs
-  -l, --last        show logs for last run
-  -L, --limit int   lists number of pipelineruns (default 5)
+  -L, --last        show logs for last run
+      --limit int   lists number of pipelineruns (default 5)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -37,7 +37,7 @@ two parameters (foo and bar)
 
 ```
   -h, --help                          help for start
-  -l, --last                          re-run the pipeline using last pipelinerun values
+  -L, --last                          re-run the pipeline using last pipelinerun values
   -p, --param strings                 pass the param as key=value
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -29,7 +29,7 @@ tkn pr list -n foo
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
-  -l, --limit int                     limit pipelineruns listed (default: return all pipelineruns)
+      --limit int                     limit pipelineruns listed (default: return all pipelineruns)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -29,7 +29,7 @@ tkn taskrun list foo -n bar
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
-  -l, --limit int                     limit taskruns listed (default: return all taskruns)
+      --limit int                     limit taskruns listed (default: return all taskruns)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -32,11 +32,11 @@ Show pipeline logs
     help for logs
 
 .PP
-\fB\-l\fP, \fB\-\-last\fP[=false]
+\fB\-L\fP, \fB\-\-last\fP[=false]
     show logs for last run
 
 .PP
-\fB\-L\fP, \fB\-\-limit\fP=5
+\fB\-\-limit\fP=5
     lists number of pipelineruns
 
 

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -32,7 +32,7 @@ Parameters, at least those that have no default value
     help for start
 
 .PP
-\fB\-l\fP, \fB\-\-last\fP[=false]
+\fB\-L\fP, \fB\-\-last\fP[=false]
     re\-run the pipeline using last pipelinerun values
 
 .PP

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -28,7 +28,7 @@ Lists pipelineruns in a namespace
     help for list
 
 .PP
-\fB\-l\fP, \fB\-\-limit\fP=0
+\fB\-\-limit\fP=0
     limit pipelineruns listed (default: return all pipelineruns)
 
 .PP

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -28,7 +28,7 @@ Lists taskruns in a namespace
     help for list
 
 .PP
-\fB\-l\fP, \fB\-\-limit\fP=0
+\fB\-\-limit\fP=0
     limit taskruns listed (default: return all taskruns)
 
 .PP

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,6 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/fatih/color v1.7.0
-	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-containerregistry v0.0.0-20190320210540-8d4083db9aa0 // indirect
@@ -42,7 +40,6 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/prometheus/procfs v0.0.0-20190322151404-55ae3d9d5573 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -106,10 +106,10 @@ func logCommand(p cli.Params) *cobra.Command {
 			return opts.run(args)
 		},
 	}
-	c.Flags().BoolVarP(&opts.last, "last", "l", false, "show logs for last run")
+	c.Flags().BoolVarP(&opts.last, "last", "L", false, "show logs for last run")
 	c.Flags().BoolVarP(&opts.allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream live logs")
-	c.Flags().IntVarP(&opts.limit, "limit", "L", 5, "lists number of pipelineruns")
+	c.Flags().IntVarP(&opts.limit, "limit", "", 5, "lists number of pipelineruns")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 	return c

--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -116,7 +116,7 @@ func TestLogs_negative_limit(t *testing.T) {
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	c := Command(p)
-	_, err := test.ExecuteCommand(c, "logs", pipelineName, "-n", ns, "-L", fmt.Sprintf("%d", -1))
+	_, err := test.ExecuteCommand(c, "logs", pipelineName, "-n", ns, "--limit", fmt.Sprintf("%d", -1))
 
 	expected := "limit was -1 but must be a positive number"
 	test.AssertOutput(t, expected, err.Error())
@@ -712,7 +712,7 @@ func TestLogs_last_run_diff_namespace(t *testing.T) {
 	p.SetNamespace("default")
 
 	c := Command(p)
-	_, err := test.ExecuteCommand(c, "logs", pipelineName, "-n", ns, "-l")
+	_, err := test.ExecuteCommand(c, "logs", pipelineName, "-n", ns, "-L")
 	if err != nil {
 		t.Error("Expecting no error")
 	}

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -131,7 +131,7 @@ like cat,foo.bar
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().StringSliceVar(&opt.ServiceAccounts, "task-serviceaccount", []string{}, "pass the service account corresponding to the task")
 	flags.AddShellCompletion(c.Flags().Lookup("task-serviceaccount"), "__kubectl_get_serviceaccount")
-	c.Flags().BoolVarP(&opt.Last, "last", "l", false, "re-run the pipeline using last pipelinerun values")
+	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the pipeline using last pipelinerun values")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -104,7 +104,7 @@ tkn pr list -n foo
 	}
 
 	f.AddFlags(c)
-	c.Flags().IntVarP(&opts.Limit, "limit", "l", 0, "limit pipelineruns listed (default: return all pipelineruns)")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit pipelineruns listed (default: return all pipelineruns)")
 
 	return c
 }

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -129,7 +129,7 @@ func TestListPipelineRuns(t *testing.T) {
 		{
 			name:    "limit pipelineruns returned to 1",
 			command: command(t, prs, clock.Now()),
-			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", 1)},
+			args:    []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", 1)},
 			expected: []string{
 				"NAME    STARTED   DURATION   STATUS   ",
 				"pr0-1   ---       ---        ---      ",
@@ -139,7 +139,7 @@ func TestListPipelineRuns(t *testing.T) {
 		{
 			name:    "limit pipelineruns negative case",
 			command: command(t, prs, clock.Now()),
-			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", -1)},
+			args:    []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", -1)},
 			expected: []string{
 				"",
 			},
@@ -147,7 +147,7 @@ func TestListPipelineRuns(t *testing.T) {
 		{
 			name:    "limit pipelineruns greater than maximum case",
 			command: command(t, prs, clock.Now()),
-			args:    []string{"list", "-n", "namespace", "-l", fmt.Sprintf("%d", 7)},
+			args:    []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", 7)},
 			expected: []string{
 				"NAME    STARTED          DURATION   STATUS               ",
 				"pr0-1   ---              ---        ---                  ",
@@ -161,7 +161,7 @@ func TestListPipelineRuns(t *testing.T) {
 		{
 			name:    "limit pipelineruns with output flag set",
 			command: command(t, prs, clock.Now()),
-			args:    []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "-l", fmt.Sprintf("%d", 2)},
+			args:    []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "--limit", fmt.Sprintf("%d", 2)},
 			expected: []string{
 				"pr0-1",
 				"pr3-1",

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -106,7 +106,7 @@ tkn taskrun list foo -n bar
 	}
 
 	f.AddFlags(c)
-	c.Flags().IntVarP(&opts.Limit, "limit", "l", 0, "limit taskruns listed (default: return all taskruns)")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit taskruns listed (default: return all taskruns)")
 
 	return c
 }

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -147,7 +147,7 @@ func TestListTaskRuns(t *testing.T) {
 		{
 			name:    "limit taskruns returned to 1",
 			command: command(t, trs, now),
-			args:    []string{"list", "-n", "foo", "-l", fmt.Sprintf("%d", 1)},
+			args:    []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", 1)},
 			expected: []string{
 				"NAME    STARTED   DURATION   STATUS      ",
 				"tr0-1   ---       ---        Succeeded   ",
@@ -157,7 +157,7 @@ func TestListTaskRuns(t *testing.T) {
 		{
 			name:    "limit taskruns negative case",
 			command: command(t, trs, now),
-			args:    []string{"list", "-n", "foo", "-l", fmt.Sprintf("%d", -1)},
+			args:    []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", -1)},
 			expected: []string{
 				"",
 			},
@@ -165,7 +165,7 @@ func TestListTaskRuns(t *testing.T) {
 		{
 			name:    "limit taskruns greater than maximum case",
 			command: command(t, trs, now),
-			args:    []string{"list", "-n", "foo", "-l", fmt.Sprintf("%d", 7)},
+			args:    []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", 7)},
 			expected: []string{
 				"NAME    STARTED          DURATION   STATUS      ",
 				"tr0-1   ---              ---        Succeeded   ",
@@ -179,7 +179,7 @@ func TestListTaskRuns(t *testing.T) {
 		{
 			name:    "limit taskruns with output flag set",
 			command: command(t, trs, now),
-			args:    []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "-l", fmt.Sprintf("%d", 2)},
+			args:    []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "--limit", fmt.Sprintf("%d", 2)},
 			expected: []string{
 				"tr0-1",
 				"tr3-1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We has an inconsistentie across commands for the `-l` flag, it will sometime
mean for some commands as `--limit` or sometime behaving for some other command
as `--last`.

I have moved last-log to `-L` and removed the short option for limits.

We keep `-l` for a future work with the --label filter to be consistent on
kubectl and other kubernetes based cli as `-l`  see tektoncd/cli#339.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
* Renamed the last log short flag to -L instead of -l
* Removed the short flag -l as --limit
```