### PR TITLE
Allow passing labels to start

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -37,6 +37,7 @@ two parameters (foo and bar)
 
 ```
   -h, --help                          help for start
+  -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the pipeline using last pipelinerun values
   -p, --param strings                 pass the param as key=value
   -r, --resource strings              pass the resource name and ref as name=ref

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -32,6 +32,10 @@ Parameters, at least those that have no default value
     help for start
 
 .PP
+\fB\-l\fP, \fB\-\-labels\fP=[]
+    pass labels as label=value.
+
+.PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
     re\-run the pipeline using last pipelinerun values
 

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -40,6 +40,7 @@ var (
 const (
 	invalidResource = "invalid input format for resource parameter : "
 	invalidParam    = "invalid input format for param parameter : "
+	invalidLabel    = "invalid input format for label parameter : "
 	invalidSvc      = "invalid service account parameter: "
 )
 
@@ -52,6 +53,7 @@ type startOptions struct {
 	ServiceAccountName string
 	ServiceAccounts    []string
 	Last               bool
+	Labels             []string
 }
 
 type resourceOptionsFilter struct {
@@ -132,6 +134,7 @@ like cat,foo.bar
 	c.Flags().StringSliceVar(&opt.ServiceAccounts, "task-serviceaccount", []string{}, "pass the service account corresponding to the task")
 	flags.AddShellCompletion(c.Flags().Lookup("task-serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the pipeline using last pipelinerun values")
+	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 
@@ -350,6 +353,10 @@ func (opt *startOptions) startPipeline(pName string) error {
 		return err
 	}
 
+	if err := mergeLabels(pr, opt.Labels); err != nil {
+		return err
+	}
+
 	if err := mergeParam(pr, opt.Params); err != nil {
 		return err
 	}
@@ -390,6 +397,26 @@ func mergeRes(pr *v1alpha1.PipelineRun, optRes []string) error {
 	}
 	for _, v := range res {
 		pr.Spec.Resources = append(pr.Spec.Resources, v)
+	}
+	return nil
+}
+
+func mergeLabels(pr *v1alpha1.PipelineRun, labelPar []string) error {
+	labels, err := parseLabels(labelPar)
+	if err != nil {
+		return err
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+
+	if pr.ObjectMeta.Labels == nil {
+		pr.ObjectMeta.Labels = labels
+	} else {
+		// This will update the updated value and add the new ones passed
+		for k, v := range labels {
+			pr.ObjectMeta.Labels[k] = v
+		}
 	}
 	return nil
 }
@@ -457,6 +484,18 @@ func parseRes(res []string) (map[string]v1alpha1.PipelineResourceBinding, error)
 		}
 	}
 	return resources, nil
+}
+
+func parseLabels(p []string) (map[string]string, error) {
+	labels := map[string]string{}
+	for _, v := range p {
+		r := strings.SplitN(v, "=", 2)
+		if len(r) != 2 {
+			return nil, errors.New(invalidLabel + v)
+		}
+		labels[r[0]] = r[1]
+	}
+	return labels, nil
 }
 
 func parseParam(p []string) (map[string]v1alpha1.Param, error) {


### PR DESCRIPTION
# Changes

Add -l flag for start to pass labels to pipelineruns (and then to pods)

Closes #339

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Allow passing labels when starting a pipeline with the `-l` option
```