### PR TITLE
Update the new brew location

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,8 +48,8 @@ brews:
   -
     name: tektoncd-cli
     github:
-      owner: chmouel
-      name: homebrew-tektoncd-cli
+      owner: tektoncd
+      name: homebrew-tools
     folder: Formula
     homepage: "https://github.com/tektoncd/cli"
     description: Tekton CLI - The command line interface for interacting with Tekton

--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ Tekton!
 
 Download the latest binary executable for your operating system:
 
-* [Mac OS X](https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Darwin_x86_64.tar.gz)
+* Mac OS X
+  - `tektoncd-cli` can be installed as a [brew tap](https://brew.sh) :
+
+  ```shell
+  brew tap tektoncd/tools
+  brew install tektoncd-cli
+  ```
+
+  - Or by the [released tarball](https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Darwin_x86_64.tar.gz) :
 
   ```shell
   # Get the tar.xz
   curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Darwin_x86_64.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
   sudo tar xvzf tkn_0.4.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
-  ```
-
-  You can also use [@chmouel](https://github.com/chmouel)'s unofficial
-  brew tap for the time being.
-
-  ```shell
-  brew tap chmouel/tektoncd-cli
-  brew install tektoncd-cli
   ```
 
 * [Linux AMD 64](https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Linux_x86_64.tar.gz)


### PR DESCRIPTION
/closes #99
/cc @vdemeester

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the new brew location to github.com/tektoncd/homebrew-tools

# Release Notes

```
homebrew formulas has been moved from chmouel's repository to :

https://github.com/tektoncd/homebrew-tools

If you were using it previously you will need to remove the old tap with :

brew untap chmouel/tektoncd-cli

and switch to the new one :

brew tap tektoncd/tools
brew install tektoncd-cli

```