### PR TITLE
Check if Namespace Exists for Task List Command

### DIFF
--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -76,6 +76,12 @@ func printTaskDetails(s *cli.Stream, p cli.Params) error {
 		return err
 	}
 
+	// Check if namespace exists. Return error if namespace specified with -n doesn't exist or if user doesn't have permissions to view.
+	_, err = cs.Kube.CoreV1().Namespaces().Get(p.Namespace(), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
 	tasks, err := listAllTasks(cs.Tekton, p.Namespace())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to list tasks from %s namespace \n", p.Namespace())

--- a/pkg/test/cobra.go
+++ b/pkg/test/cobra.go
@@ -33,6 +33,7 @@ func ExecuteCommandC(c *cobra.Command, args ...string) (*cobra.Command, string, 
 	buf := new(bytes.Buffer)
 	c.SetOutput(buf)
 	c.SetArgs(args)
+	c.SilenceUsage = true
 
 	root, err := c.ExecuteC()
 


### PR DESCRIPTION
This pull request is a proposal to help deal with #311. It adds an error message to the CLI to check whether the namespace specified by the user exists on his or her cluster. 

Assuming this is a valid proposal, I can begin implementing this same change for other locations in the CLI that use `-n`.

# Changes

Adds a check to `task/list.go` to see whether a namespace exists. If it does not, an error message is returned: `"Error: namespaces \"foo\" not found\n"`. The use of `namespaces` versus non-plural `namespace` in the error message is [not considered an issue](https://github.com/kubernetes/client-go/issues/696) for client-go. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Adds error message to tkn task ls when a namespace does not exist
```
