### PR TITLE
Add Namespace Check to Task Delete Command

### DIFF
--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -58,6 +59,15 @@ tkn t rm foo -n bar
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
+			}
+
+			cs, err := p.Clients()
+			if err != nil {
+				return fmt.Errorf("failed to create tekton client")
+			}
+
+			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+				return err
 			}
 
 			if err := checkOptions(opts, s, p, args[0]); err != nil {

--- a/pkg/helper/validate/validate.go
+++ b/pkg/helper/validate/validate.go
@@ -1,0 +1,32 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	k8s "k8s.io/client-go/kubernetes"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Check if namespace exists. Returns error if namespace specified with -n doesn't exist or if user doesn't have permissions to view.
+func NamespaceExists(kube k8s.Interface, ns string) error {
+
+	_, err := kube.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/helper/validate/validate_test.go
+++ b/pkg/helper/validate/validate_test.go
@@ -1,0 +1,54 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/test"
+	pipelinetest "github.com/tektoncd/pipeline/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNamespaceExists_Invalid_Namespace(t *testing.T) {
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		},
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+	p := &test.Params{Kube: cs.Kube}
+
+	err := NamespaceExists(p.Kube, "foo")
+	test.AssertOutput(t, "namespaces \"foo\" not found", err.Error())
+}
+
+func TestNamespaceExists_Valid_Namespace(t *testing.T) {
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		},
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+	p := &test.Params{Kube: cs.Kube}
+
+	err := NamespaceExists(p.Kube, "default")
+	test.AssertOutput(t, nil, err)
+}


### PR DESCRIPTION
This pull request follows up #349 and also helps to address #311. The goal is to check whether a namespace exists to alert the user if the namespace provided is invalid. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn task delete when a namespace does not exist
```
