### PR TITLE
Add Namespace Check for Task Describe Command

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -119,6 +120,16 @@ tkn t desc foo -n bar
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
+
+			cs, err := p.Clients()
+			if err != nil {
+				return fmt.Errorf("failed to create tekton client")
+			}
+
+			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+				return err
+			}
+
 			return printTaskDescription(s, p, args[0])
 		},
 	}
@@ -131,7 +142,7 @@ tkn t desc foo -n bar
 func printTaskDescription(s *cli.Stream, p cli.Params, tname string) error {
 	cs, err := p.Clients()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create tekton client")
 	}
 
 	task, err := cs.Tekton.TektonV1alpha1().Tasks(p.Namespace()).Get(tname, metav1.GetOptions{})


### PR DESCRIPTION
Following similar approaches outlined in #350 and #349, this pull request is part of addressing #311. An error message has been added for `tkn task desc` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn task describe when a namespace does not exist
```
