### PR TITLE
Don't show just Error if container came back only with "Error"

### DIFF
--- a/pkg/helper/pods/container.go
+++ b/pkg/helper/pods/container.go
@@ -44,11 +44,11 @@ func (c *Container) Status() error {
 		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 1 {
 			msg := ""
 
-			if cs.State.Terminated.Reason != "" {
+			if cs.State.Terminated.Reason != "" && cs.State.Terminated.Reason != "Error" {
 				msg = msg + " : " + cs.State.Terminated.Reason
 			}
 
-			if cs.State.Terminated.Message != "" {
+			if cs.State.Terminated.Message != "" && cs.State.Terminated.Message != "Error" {
 				msg = msg + " : " + cs.State.Terminated.Message
 			}
 


### PR DESCRIPTION
Closes #83

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Avoid showing just Error if we don't have any other message from the failed container

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [*] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [*] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [*] Run the code checkers with `make check`
- [*] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```