### PR TITLE
Add Namespace Check to TaskRun Describe Command

### DIFF
--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,6 +116,16 @@ tkn tr desc foo -n bar
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
+
+			cs, err := p.Clients()
+			if err != nil {
+				return fmt.Errorf("failed to create tekton client")
+			}
+
+			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+				return err
+			}
+
 			return printTaskRunDescription(s, args[0], p)
 		},
 	}

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -26,17 +26,47 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
+func TestTaskRunDescribe_invalid_namespace(t *testing.T) {
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "defaul",
+				},
+			},
+		},
+	})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	taskrun := Command(p)
+	_, err := test.ExecuteCommand(taskrun, "desc", "bar", "-n", "invalid")
+	if err == nil {
+		t.Errorf("Expected error but did not get one")
+	}
+	expected := "namespaces \"invalid\" not found"
+	test.AssertOutput(t, expected, err.Error())
+}
+
 func TestTaskRunDescribe_not_found(t *testing.T) {
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
-	p := &test.Params{Tekton: cs.Pipeline}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
+	})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	taskrun := Command(p)
 	_, err := test.ExecuteCommand(taskrun, "desc", "bar", "-n", "ns")
 	if err == nil {
-		t.Errorf("Expected error, did not get any")
+		t.Errorf("Expected error but did not get one")
 	}
 	expected := "failed to find taskrun \"bar\""
 	test.AssertOutput(t, expected, err.Error())
@@ -60,9 +90,16 @@ func TestTaskRunDescribe_empty_taskrun(t *testing.T) {
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		TaskRuns: trs,
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -128,9 +165,16 @@ func TestTaskRunDescribe_only_taskrun(t *testing.T) {
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		TaskRuns: trs,
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -192,9 +236,16 @@ func TestTaskRunDescribe_failed(t *testing.T) {
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		TaskRuns: trs,
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)


### PR DESCRIPTION
Following similar approaches outlined for `tkn task` commands, this pull request is part of addressing #311. An error message has been added for `tkn taskrun desc` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn taskrun describe when a namespace does not exist
```
