### PR TITLE
Increase read timeout for expect statements

### DIFF
--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -1130,7 +1130,7 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.SendLine("	https://github.com/wizzbangcorp/wizzbang/pulls/1"); err != nil {
+				if _, err := c.SendLine("https://github.com/wizzbangcorp/wizzbang/pulls/1"); err != nil {
 					return err
 				}
 

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -56,7 +56,7 @@ func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) erro
 
 	// Multiplex output to a buffer as well for the raw bytes.
 	buf := new(bytes.Buffer)
-	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(1*time.Minute))
+	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(3*time.Minute))
 	require.Nil(t, err)
 	defer c.Close()
 

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -56,7 +56,7 @@ func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) erro
 
 	// Multiplex output to a buffer as well for the raw bytes.
 	buf := new(bytes.Buffer)
-	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(3*time.Minute))
+	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(5*time.Minute))
 	require.Nil(t, err)
 	defer c.Close()
 

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -56,7 +56,7 @@ func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) erro
 
 	// Multiplex output to a buffer as well for the raw bytes.
 	buf := new(bytes.Buffer)
-	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(5*time.Minute))
+	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(10*time.Minute))
 	require.Nil(t, err)
 	defer c.Close()
 


### PR DESCRIPTION
removes extra unwanted space while entering url value in test
increases read timeout to 3 minutes for expect statement as test
still fails with 1 minute of timeout

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
