### PR TITLE
Use *** instead of plain text for password

### DIFF
--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -307,7 +307,7 @@ func (res *resource) askClusterParams() error {
 	}
 	switch ans {
 	case qsOpts[0]: // Using password authentication technique
-		passwordParam, err := askParam("password", res.askOpts)
+		passwordParam, err := askPassword(res.askOpts)
 		if err != nil {
 			return err
 		}
@@ -509,6 +509,25 @@ func askToSelect(message string, options []string, askOpts survey.AskOpt) (strin
 	}
 
 	return ans, nil
+}
+
+func askPassword(askOpts survey.AskOpt) (v1alpha1.ResourceParam, error) {
+	var param v1alpha1.ResourceParam
+	var qs = []*survey.Question{{
+		Name: "value",
+		Prompt: &survey.Password{
+			Message: fmt.Sprintf("Enter a value for password :"),
+		},
+	}}
+
+	err := survey.Ask(qs, &param, askOpts)
+	if err != nil {
+		return param, Error(err)
+	}
+
+	param.Name = "password"
+
+	return param, nil
 }
 
 func allResourceType() []string {

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -391,6 +391,10 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 					return err
 				}
 
+				if _, err := c.ExpectString("*********"); err != nil {
+					return err
+				}
+
 				if _, err := c.ExpectString("How do you want to set cadata?"); err != nil {
 					return err
 				}
@@ -839,6 +843,10 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 				}
 
 				if _, err := c.SendLine("abcd#@123"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("*********"); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
pipeline resource yamls stores password as plain text
but with cli it makes sense to show the password as ** on
console instead of plain text

this shows ** for the value of password but writes as plain
text in the resource struct

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
