### PR TITLE
Refactor NamespaceExists

### DIFF
--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -39,6 +39,7 @@ type Params interface {
 	// returned by Clientset function
 	SetKubeConfigPath(string)
 	Clients() (*Clients, error)
+	KubeClient() (k8s.Interface, error)
 
 	// SetNamespace can be used to store the namespace parameter that is needed
 	// by most commands

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -47,13 +47,31 @@ func (p *TektonParams) tektonClient(config *rest.Config) (versioned.Interface, e
 	return cs, nil
 }
 
+// Set kube client based on config
 func (p *TektonParams) kubeClient(config *rest.Config) (k8s.Interface, error) {
 	k8scs, err := k8s.NewForConfig(config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create ks8 client from config")
+		return nil, errors.Wrapf(err, "Failed to create k8s client from config")
 	}
 
 	return k8scs, nil
+}
+
+// Only returns kube client, not tekton client
+func (p *TektonParams) KubeClient() (k8s.Interface, error) {
+
+	config, err := p.config()
+	if err != nil {
+		return nil, err
+	}
+
+	kube, err := p.kubeClient(config)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return kube, nil
 }
 
 func (p *TektonParams) Clients() (*Clients, error) {

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -61,12 +61,7 @@ tkn t rm foo -n bar
 				Err: cmd.OutOrStderr(),
 			}
 
-			cs, err := p.Clients()
-			if err != nil {
-				return fmt.Errorf("failed to create tekton client")
-			}
-
-			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+			if err := validate.NamespaceExists(p); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -121,12 +121,7 @@ tkn t desc foo -n bar
 				Err: cmd.OutOrStderr(),
 			}
 
-			cs, err := p.Clients()
-			if err != nil {
-				return fmt.Errorf("failed to create tekton client")
-			}
-
-			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+			if err := validate.NamespaceExists(p); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -49,12 +49,8 @@ func listCommand(p cli.Params) *cobra.Command {
 			"commandType": "main",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cs, err := p.Clients()
-			if err != nil {
-				return fmt.Errorf("failed to create tekton client")
-			}
 
-			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+			if err := validate.NamespaceExists(p); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -117,12 +117,7 @@ tkn tr desc foo -n bar
 				Err: cmd.OutOrStderr(),
 			}
 
-			cs, err := p.Clients()
-			if err != nil {
-				return fmt.Errorf("failed to create tekton client")
-			}
-
-			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+			if err := validate.NamespaceExists(p); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -67,12 +67,7 @@ tkn taskrun list foo -n bar
 				task = args[0]
 			}
 
-			cs, err := p.Clients()
-			if err != nil {
-				return fmt.Errorf("failed to create tekton client")
-			}
-
-			if err := validate.NamespaceExists(cs.Kube, p.Namespace()); err != nil {
+			if err := validate.NamespaceExists(p); err != nil {
 				return err
 			}
 

--- a/pkg/helper/validate/validate.go
+++ b/pkg/helper/validate/validate.go
@@ -15,15 +15,26 @@
 package validate
 
 import (
-	k8s "k8s.io/client-go/kubernetes"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
-// Check if namespace exists. Returns error if namespace specified with -n doesn't exist or if user doesn't have permissions to view.
-func NamespaceExists(kube k8s.Interface, ns string) error {
+type params interface {
+	KubeClient() (k8s.Interface, error)
+	Namespace() string
+}
 
-	_, err := kube.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+// Check if namespace exists. Returns error if namespace specified with -n doesn't exist or if user doesn't have permissions to view.
+func NamespaceExists(p params) error {
+
+	cs, err := p.KubeClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client")
+	}
+
+	_, err = cs.CoreV1().Namespaces().Get(p.Namespace(), metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/helper/validate/validate_test.go
+++ b/pkg/helper/validate/validate_test.go
@@ -33,8 +33,9 @@ func TestNamespaceExists_Invalid_Namespace(t *testing.T) {
 	}
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
 	p := &test.Params{Kube: cs.Kube}
+	p.SetNamespace("foo")
 
-	err := NamespaceExists(p.Kube, "foo")
+	err := NamespaceExists(p)
 	test.AssertOutput(t, "namespaces \"foo\" not found", err.Error())
 }
 
@@ -49,6 +50,6 @@ func TestNamespaceExists_Valid_Namespace(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
 	p := &test.Params{Kube: cs.Kube}
 
-	err := NamespaceExists(p.Kube, "default")
+	err := NamespaceExists(p)
 	test.AssertOutput(t, nil, err)
 }

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -53,7 +53,7 @@ func (p *Params) tektonClient() (versioned.Interface, error) {
 	return p.Tekton, nil
 }
 
-func (p *Params) kubeClient() (k8s.Interface, error) {
+func (p *Params) KubeClient() (k8s.Interface, error) {
 	return p.Kube, nil
 }
 
@@ -67,7 +67,7 @@ func (p *Params) Clients() (*cli.Clients, error) {
 		return nil, err
 	}
 
-	kube, err := p.kubeClient()
+	kube, err := p.KubeClient()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request changes the `NamespaceExists()` function in `validate.go` to create the `Kube` client and use the `Namespace()` value from `cli.Params`. This will remove the second error check of creating clients from each command that will be changed as part of #311.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

N/A