### PR TITLE
Change way of question for "insecure" parameter

### DIFF
--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -284,17 +284,18 @@ func (res *resource) askClusterParams() error {
 		res.pipelineResource.Spec.Params = append(res.pipelineResource.Spec.Params, usernameParam)
 	}
 
-	insecureParam, err := askParam("insecure", res.askOpts)
+	secure, err := askToSelect("Is the cluster secure?", []string{"yes", "no"}, res.askOpts)
 	if err != nil {
 		return err
 	}
-	if insecureParam.Name != "" {
-		res.pipelineResource.Spec.Params = append(res.pipelineResource.Spec.Params, insecureParam)
+	insecureParam := v1alpha1.ResourceParam{}
+	insecureParam.Name = "insecure"
+	if secure == "yes" {
+		insecureParam.Value = "false"
+	} else {
+		insecureParam.Value = "true"
 	}
-	secure := true
-	if insecureParam.Name == "insecure" && insecureParam.Value == "true" {
-		secure = false
-	}
+	res.pipelineResource.Spec.Params = append(res.pipelineResource.Spec.Params, insecureParam)
 
 	qs := "Which authentication technique you want to use?"
 	qsOpts := []string{
@@ -314,7 +315,7 @@ func (res *resource) askClusterParams() error {
 		if passwordParam.Name != "" {
 			res.pipelineResource.Spec.Params = append(res.pipelineResource.Spec.Params, passwordParam)
 		}
-		if secure {
+		if secure == "yes" {
 			qs := "How do you want to set cadata?"
 			qsOpts := []string{
 				"Passing plain text as parameters",
@@ -367,7 +368,7 @@ func (res *resource) askClusterParams() error {
 			if tokenParam.Name != "" {
 				res.pipelineResource.Spec.Params = append(res.pipelineResource.Spec.Params, tokenParam)
 			}
-			if secure {
+			if secure == "yes" {
 				cadataParam, err := askParam("cadata", res.askOpts)
 				if err != nil {
 					return err
@@ -389,7 +390,7 @@ func (res *resource) askClusterParams() error {
 			}
 			res.pipelineResource.Spec.SecretParams = append(res.pipelineResource.Spec.SecretParams, secret)
 
-			if secure {
+			if secure == "yes" {
 				secret, err := askSecret("cadata", res.askOpts)
 				if err != nil {
 					return err

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -367,11 +367,15 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 					return err
 				}
 
-				if _, err := c.ExpectString("Enter a value for insecure :"); err != nil {
+				if _, err := c.ExpectString("Is the cluster secure?"); err != nil {
 					return err
 				}
 
-				if _, err := c.SendLine("false"); err != nil {
+				if _, err := c.ExpectString("yes"); err != nil {
+					return err
+				}
+
+				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
 					return err
 				}
 
@@ -501,11 +505,15 @@ func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T)
 					return err
 				}
 
-				if _, err := c.ExpectString("Enter a value for insecure :"); err != nil {
+				if _, err := c.ExpectString("Is the cluster secure?"); err != nil {
 					return err
 				}
 
-				if _, err := c.SendLine("false"); err != nil {
+				if _, err := c.ExpectString("yes"); err != nil {
+					return err
+				}
+
+				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
 					return err
 				}
 
@@ -822,11 +830,15 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 					return err
 				}
 
-				if _, err := c.ExpectString("Enter a value for insecure :"); err != nil {
+				if _, err := c.ExpectString("Is the cluster secure?"); err != nil {
 					return err
 				}
 
-				if _, err := c.SendLine("false"); err != nil {
+				if _, err := c.ExpectString("yes"); err != nil {
+					return err
+				}
+
+				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
 					return err
 				}
 
@@ -972,11 +984,15 @@ func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.
 					return err
 				}
 
-				if _, err := c.ExpectString("Enter a value for insecure :"); err != nil {
+				if _, err := c.ExpectString("Is the cluster secure?"); err != nil {
 					return err
 				}
 
-				if _, err := c.SendLine("false"); err != nil {
+				if _, err := c.ExpectString("yes"); err != nil {
+					return err
+				}
+
+				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
cluster pipielineresource creation uses a parameter insecure
for which the question asked is "Enter a value for insecure param"
and user needed to type true or false
now question is changed to "Is your cluster secure?" and user can
choose between yes or no from the options provided on console
which is internally mapped to true/false

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
