### PR TITLE
removes complexity of read timeout from test

### DIFF
--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -1138,7 +1138,7 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.SendLine("	https://github.com/wizzbangcorp/wizzbang/pulls/1"); err != nil {
+				if _, err := c.SendLine("https://github.com/wizzbangcorp/wizzbang/pulls/1"); err != nil {
 					return err
 				}
 

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -1138,7 +1138,7 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.SendLine("https://github.com/wizzbangcorp/wizzbang/pulls/1"); err != nil {
+				if _, err := c.SendLine("https://github.com/tektoncd/cli/pull/1"); err != nil {
 					return err
 				}
 
@@ -1487,47 +1487,6 @@ func TestPipelineResource_create_buildGCSstorageResource(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			res.RunPromptTest(t, test)
-		})
-	}
-}
-
-func TestPipelineResource_interrupt(t *testing.T) {
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		PipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("res", "namespace",
-				tb.PipelineResourceSpec("git",
-					tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
-				)),
-		},
-	})
-
-	tests := []promptTest{
-		{
-			name: "no input for name",
-
-			procedure: func(c *expect.Console) error {
-				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
-					return err
-				}
-
-				if _, err := c.Send(string(terminal.KeyInterrupt)); err != nil {
-					return err
-				}
-
-				if _, err := c.ExpectEOF(); err != nil {
-					return err
-				}
-
-				return nil
-			},
-		},
-	}
-
-	res := resOpts("namespace", cs)
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			res.RunPromptTest(t, test)
-
 		})
 	}
 }

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -17,7 +17,6 @@ package pipelineresource
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -56,7 +55,7 @@ func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) erro
 
 	// Multiplex output to a buffer as well for the raw bytes.
 	buf := new(bytes.Buffer)
-	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf), expect.WithDefaultTimeout(1*time.Minute))
+	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf))
 	require.Nil(t, err)
 	defer c.Close()
 

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -36,7 +36,7 @@ func (res *resource) RunPromptTest(t *testing.T, test promptTest) {
 		res.askOpts = WithStdio(stdio)
 		err = res.create()
 		if err != nil {
-			if err.Error() == "resource already exist" || err.Error() == "interrupt" {
+			if err.Error() == "resource already exist" {
 				return nil
 			}
 			return err


### PR DESCRIPTION
it was observed that inroduction of read timeout for interactive
test showed some failures on ci
hence removing the read timeout for "expect" statement in test

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
