### PR TITLE
Fix panic on pipeline logs

### DIFF
--- a/pkg/cmd/pipelinerun/log_reader.go
+++ b/pkg/cmd/pipelinerun/log_reader.go
@@ -95,8 +95,10 @@ func (lr *LogReader) readLiveLogs(pr *v1alpha1.PipelineRun) (<-chan Log, <-chan 
 
 		wg.Wait()
 
-		if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
-			errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
+		if pr.Status.Conditions != nil {
+			if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
+				errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
+			}
 		}
 	}()
 

--- a/pkg/helper/taskrun/taskrun.go
+++ b/pkg/helper/taskrun/taskrun.go
@@ -51,7 +51,10 @@ func IsFiltered(tr Run, allowed []string) bool {
 }
 
 func HasScheduled(trs *v1alpha1.PipelineRunTaskRunStatus) bool {
-	return trs.Status.PodName != ""
+	if trs.Status != nil {
+		return trs.Status.PodName != ""
+	}
+	return false
 }
 
 func Filter(trs []Run, ts []string) []Run {


### PR DESCRIPTION
This will fix the issue of pipelinerun logs
panic in case of pod not yet ready or
taskruns not created

Fixes https://github.com/tektoncd/cli/issues/361