### PR TITLE
Change for release and tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ ifneq (,$(wildcard ./VERSION))
 LDFLAGS := -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=`cat VERSION`"
 endif
 
+ifneq ($(RELEASE_VERSION),)
+LDFLAGS := -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(RELEASE_VERSION)"
+endif
+
 all: bin/tkn test
 
 FORCE:


### PR DESCRIPTION

# Changes

In order to release binary often we need to tag the build with
the release version. Right now tagging the release version if part of RPM spec
file. Such functionality may be required by other users and other tools/processes.

This patch adds `RELEASE_VERSION` env var or aergument to build process. So
any tool or process can make the release with respective make * targets.




<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Can add release version to make build targets
e.g.
RELEASE_VERSION=v0.1.0.0 make cross
```
