### PR TITLE
Add Namespace Check to Pipeline Delete Command

### DIFF
--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -58,6 +59,10 @@ tkn p rm foo -n bar
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
+			}
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
 			}
 
 			if err := checkOptions(opts, s, p, args[0]); err != nil {

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -28,6 +28,7 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -75,6 +76,13 @@ func TestPipelineDelete(t *testing.T) {
 					),
 				),
 			},
+			Namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+					},
+				},
+			},
 		})
 		seeds = append(seeds, cs)
 	}
@@ -87,6 +95,14 @@ func TestPipelineDelete(t *testing.T) {
 		wantError   bool
 		want        string
 	}{
+		{
+			name:        "Invalid namespace",
+			command:     []string{"rm", "pipeline", "-n", "invalid"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "namespaces \"invalid\" not found",
+		},
 		{
 			name:        "With force delete flag (shorthand)",
 			command:     []string{"rm", "pipeline", "-n", "ns", "-f"},
@@ -147,7 +163,7 @@ func TestPipelineDelete(t *testing.T) {
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			p := &test.Params{Tekton: tp.input.Pipeline}
+			p := &test.Params{Tekton: tp.input.Pipeline, Kube: tp.input.Kube}
 			pipeline := Command(p)
 
 			if tp.inputStream != nil {


### PR DESCRIPTION
Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn pipeline delete` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn pipeline delete when a namespace does not exist
```
