### PR TITLE
Add Namespace Check to Pipeline Describe Command

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -75,6 +76,11 @@ func describeCommand(p cli.Params) *cobra.Command {
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
+			}
+
 			return printPipelineDescription(cmd.OutOrStdout(), p, args[0])
 		},
 	}

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -28,12 +28,33 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
-func TestPipelineDescribe_invalid_pipeline(t *testing.T) {
+func TestPipelineDescribe_invalid_namespace(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
-	p := &test.Params{Tekton: cs.Pipeline}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	pipeline := Command(p)
+	_, err := test.ExecuteCommand(pipeline, "desc", "bar", "-n", "invalid")
+	if err == nil {
+		t.Errorf("Error expected here for invalid namespace")
+	}
+	expected := "namespaces \"invalid\" not found"
+	test.AssertOutput(t, expected, err.Error())
+}
+
+func TestPipelineDescribe_invalid_pipeline(t *testing.T) {
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	pipeline := Command(p)
 	_, err := test.ExecuteCommand(pipeline, "desc", "bar")
@@ -55,9 +76,16 @@ func TestPipelinesDescribe_empty(t *testing.T) {
 			),
 		},
 		PipelineRuns: []*v1alpha1.PipelineRun{},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 	pipeline := Command(p)
 
 	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
@@ -109,9 +137,16 @@ func TestPipelinesDescribe_with_run(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 	pipeline := Command(p)
 
 	// -5 : pipeline created
@@ -174,9 +209,16 @@ func TestPipelinesDescribe_with_task_run(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 	pipeline := Command(p)
 
 	// -5 : pipeline created
@@ -242,9 +284,16 @@ func TestPipelinesDescribe_with_resource_task_run(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 	pipeline := Command(p)
 
 	// -5 : pipeline created
@@ -315,9 +364,16 @@ func TestPipelinesDescribe_with_multiple_resource_task_run(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
 	pipeline := Command(p)
 
 	// -5 : pipeline created


### PR DESCRIPTION
Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn pipeline describe` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn pipeline describe when a namespace does not exist
```
