### PR TITLE
Add Namespace Check to Pipeline Logs Command

### DIFF
--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/helper/pipeline"
 	prhsort "github.com/tektoncd/cli/pkg/helper/pipelinerun/sort"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,6 +66,7 @@ func logCommand(p cli.Params) *cobra.Command {
 				Out: os.Stdout,
 				Err: os.Stderr,
 			}
+
 			return nil
 		},
 	}
@@ -103,6 +105,11 @@ func logCommand(p cli.Params) *cobra.Command {
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
+			}
+
 			return opts.run(args)
 		},
 	}

--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -31,6 +31,7 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -46,11 +47,43 @@ var (
 	ns           = "namespace"
 )
 
+func TestLogs_invalid_namespace(t *testing.T) {
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		Pipelines: []*v1alpha1.Pipeline{
+			tb.Pipeline(pipelineName, ns),
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
+	})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+	c := Command(p)
+	out, err := test.ExecuteCommand(c, "logs", "-n", "invalid")
+	if err == nil {
+		t.Errorf("Expected error for invalid namespace")
+	}
+
+	expected := "Error: namespaces \"invalid\" not found\n"
+	test.AssertOutput(t, expected, out)
+}
+
 func TestLogs_no_pipeline(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Pipelines: []*v1alpha1.Pipeline{
 			tb.Pipeline(pipelineName, ns),
-		}})
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
+	})
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	c := Command(p)
@@ -66,7 +99,15 @@ func TestLogs_no_runs(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Pipelines: []*v1alpha1.Pipeline{
 			tb.Pipeline(pipelineName, ns),
-		}})
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
+	})
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	c := Command(p)
@@ -82,7 +123,15 @@ func TestLogs_wrong_pipeline(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Pipelines: []*v1alpha1.Pipeline{
 			tb.Pipeline(pipelineName, ns),
-		}})
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
+	})
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	c := Command(p)
@@ -96,7 +145,15 @@ func TestLogs_wrong_run(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Pipelines: []*v1alpha1.Pipeline{
 			tb.Pipeline(pipelineName, ns),
-		}})
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
+	})
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	c := Command(p)
@@ -110,7 +167,15 @@ func TestLogs_negative_limit(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Pipelines: []*v1alpha1.Pipeline{
 			tb.Pipeline(pipelineName, ns),
-		}})
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
+	})
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
 
 	c := Command(p)
@@ -163,6 +228,13 @@ func TestLogs_interactive_get_all_inputs(t *testing.T) {
 					cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
 				),
 			),
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
 		},
 	})
 
@@ -276,6 +348,13 @@ func TestLogs_interactive_ask_runs(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
 	})
 
 	tests := []promptTest{
@@ -362,6 +441,13 @@ func TestLogs_interactive_limit_2(t *testing.T) {
 					cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
 				),
 			),
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
 		},
 	})
 
@@ -458,6 +544,13 @@ func TestLogs_interactive_limit_1(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
 	})
 
 	tests := []promptTest{
@@ -544,6 +637,13 @@ func TestLogs_interactive_ask_all_last_run(t *testing.T) {
 					cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
 				),
 			),
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
 		},
 	})
 
@@ -633,6 +733,13 @@ func TestLogs_interactive_ask_run_last_run(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
 	})
 
 	tests := []promptTest{
@@ -704,6 +811,13 @@ func TestLogs_last_run_diff_namespace(t *testing.T) {
 				),
 			),
 		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+		},
 	})
 
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
@@ -743,6 +857,13 @@ func TestLogs_have_one_get_one(t *testing.T) {
 					cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
 				),
 			),
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
 		},
 	})
 


### PR DESCRIPTION
Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn pipeline logs` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn pipeline logs when a namespace does not exist
```
