### PR TITLE
Add Namespace Check to Condition List Command

### DIFF
--- a/pkg/cmd/condition/list.go
+++ b/pkg/cmd/condition/list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/cli/pkg/printer"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -49,6 +50,10 @@ func listCommand(p cli.Params) *cobra.Command {
 			stream := &cli.Stream{
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
+			}
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")


### PR DESCRIPTION
Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn condition list` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn condition list command when a namespace does not exist
```
