### PR TITLE
Add Namespace Check to Resource Delete Command

### DIFF
--- a/pkg/cmd/pipelineresource/delete.go
+++ b/pkg/cmd/pipelineresource/delete.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	validateinput "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -54,6 +55,10 @@ tkn res rm foo -n bar
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
+			}
+
+			if err := validateinput.NamespaceExists(p); err != nil {
+				return err
 			}
 
 			if err := checkOptions(opts, s, p, args[0]); err != nil {


### PR DESCRIPTION
Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn resource delete` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn resource delete command when a namespace does not exist
```
