### PR TITLE
Generate windows binary release files as zip file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,9 @@ archives:
     windows: Windows
     386: i386
     amd64: x86_64
+  format_overrides:
+    - goos: windows
+      format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Closes #397

## Release ChangeLog:

```
Windows binary are now provided as zip file
```