### PR TITLE
Show logs after task start

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -34,6 +34,7 @@ like cat,foo,bar
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value or key=value1,value2
   -s, --serviceaccount string    pass the serviceaccount name
+      --showlog                  show logs right after starting the task (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -47,6 +47,10 @@ Start tasks
 \fB\-s\fP, \fB\-\-serviceaccount\fP=""
     pass the serviceaccount name
 
+.PP
+\fB\-\-showlog\fP[=true]
+    show logs right after starting the task
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -406,6 +406,7 @@ func (opt *startOptions) startPipeline(pName string) error {
 		Stream:          opt.stream,
 		Follow:          true,
 		Params:          opt.cliparams,
+		AllSteps:        false,
 	}
 	return runLogOpts.Run()
 }

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -19,10 +19,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tektoncd/cli/pkg/cmd/taskrun"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/flags"
 	"github.com/tektoncd/cli/pkg/helper/labels"
 	"github.com/tektoncd/cli/pkg/helper/params"

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -176,6 +176,7 @@ func Test_start_task(t *testing.T) {
 		"-l=key=value",
 		"-o=code-image=output-image",
 		"-s=svc1",
+		"--showlog=false",
 		"-n=ns")
 
 	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
@@ -278,6 +279,7 @@ func Test_start_task_last(t *testing.T) {
 	task := Command(p)
 	got, _ := test.ExecuteCommand(task, "start", "task",
 		"--last",
+		"--showlog=false",
 		"-n=ns")
 
 	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
@@ -373,6 +375,7 @@ func Test_start_task_last_with_inputs(t *testing.T) {
 		"-o=code-image=output-image",
 		"-s=svc1",
 		"-n=ns",
+		"--showlog=false",
 		"--last")
 
 	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"

--- a/pkg/cmd/taskrun/log_writer.go
+++ b/pkg/cmd/taskrun/log_writer.go
@@ -53,7 +53,7 @@ func (lw *LogWriter) Write(s *cli.Stream, logC <-chan Log, errC <-chan error) {
 				errC = nil
 				continue
 			}
-			lw.fmt.Error(s.Out, "%s\n", e)
+			lw.fmt.Error(s.Err, "%s\n", e)
 		}
 	}
 }

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -68,8 +68,6 @@ tkn taskrun logs -f foo -n bar
 				return err
 			}
 
-			opts.Streamer = pods.NewStream
-
 			return opts.Run()
 		},
 	}
@@ -83,7 +81,12 @@ tkn taskrun logs -f foo -n bar
 
 func (lo *LogOptions) Run() error {
 	if lo.TaskrunName == "" {
-		return fmt.Errorf("missing mandatory argument taskrun")
+		return fmt.Errorf("missing mandatory argument taskrun name")
+	}
+
+	streamer := pods.NewStream
+	if lo.Streamer != nil {
+		streamer = lo.Streamer
 	}
 
 	cs, err := lo.Params.Clients()
@@ -95,7 +98,8 @@ func (lo *LogOptions) Run() error {
 		Run:      lo.TaskrunName,
 		Ns:       lo.Params.Namespace(),
 		Clients:  cs,
-		Streamer: lo.Streamer,
+		Streamer: streamer,
+		Stream:   lo.Stream,
 		Follow:   lo.Follow,
 		AllSteps: lo.AllSteps,
 	}

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -31,16 +31,16 @@ const (
 // LogOptions provides options on what logs to fetch. An empty LogOptions
 // implies fetching all logs including init steps
 type LogOptions struct {
-	taskrunName string
-	allSteps    bool
-	follow      bool
-	stream      *cli.Stream
-	params      cli.Params
-	streamer    stream.NewStreamerFunc
+	TaskrunName string
+	AllSteps    bool
+	Follow      bool
+	Stream      *cli.Stream
+	Params      cli.Params
+	Streamer    stream.NewStreamerFunc
 }
 
 func logCommand(p cli.Params) *cobra.Command {
-	opts := LogOptions{params: p}
+	opts := LogOptions{Params: p}
 	eg := `
 # show the logs of TaskRun named "foo" from the namespace "bar"
 tkn taskrun logs foo -n bar
@@ -58,8 +58,8 @@ tkn taskrun logs -f foo -n bar
 		},
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.taskrunName = args[0]
-			opts.stream = &cli.Stream{
+			opts.TaskrunName = args[0]
+			opts.Stream = &cli.Stream{
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
@@ -68,36 +68,36 @@ tkn taskrun logs -f foo -n bar
 				return err
 			}
 
-			opts.streamer = pods.NewStream
+			opts.Streamer = pods.NewStream
 
-			return opts.run()
+			return opts.Run()
 		},
 	}
 
-	c.Flags().BoolVarP(&opts.allSteps, "all", "a", false, "show all logs including init steps injected by tekton")
-	c.Flags().BoolVarP(&opts.follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
+	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_taskrun")
 	return c
 }
 
-func (lo *LogOptions) run() error {
-	if lo.taskrunName == "" {
+func (lo *LogOptions) Run() error {
+	if lo.TaskrunName == "" {
 		return fmt.Errorf("missing mandatory argument taskrun")
 	}
 
-	cs, err := lo.params.Clients()
+	cs, err := lo.Params.Clients()
 	if err != nil {
 		return err
 	}
 
 	lr := &LogReader{
-		Run:      lo.taskrunName,
-		Ns:       lo.params.Namespace(),
+		Run:      lo.TaskrunName,
+		Ns:       lo.Params.Namespace(),
 		Clients:  cs,
-		Streamer: lo.streamer,
-		Follow:   lo.follow,
-		AllSteps: lo.allSteps,
+		Streamer: lo.Streamer,
+		Follow:   lo.Follow,
+		AllSteps: lo.AllSteps,
 	}
 
 	logC, errC, err := lr.Read()
@@ -105,6 +105,6 @@ func (lo *LogOptions) run() error {
 		return err
 	}
 
-	NewLogWriter().Write(lo.stream, logC, errC)
+	NewLogWriter().Write(lo.Stream, logC, errC)
 	return nil
 }

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -349,19 +349,19 @@ func logOpts(run, ns string, cs pipelinetest.Clients, streamer stream.NewStreame
 	p.SetNamespace(ns)
 
 	return &LogOptions{
-		taskrunName: run,
-		allSteps:    allSteps,
-		follow:      follow,
-		params:      &p,
-		streamer:    streamer,
+		TaskrunName: run,
+		AllSteps:    allSteps,
+		Follow:      follow,
+		Params:      &p,
+		Streamer:    streamer,
 	}
 }
 
 func fetchLogs(lo *LogOptions) (string, error) {
 	out := new(bytes.Buffer)
-	lo.stream = &cli.Stream{Out: out, Err: out}
+	lo.Stream = &cli.Stream{Out: out, Err: out}
 
-	err := lo.run()
+	err := lo.Run()
 
 	return out.String(), err
 }


### PR DESCRIPTION
This will add the feature of showing logs after
starting the task by default

Adds aa flag to disable it

Add docs and refactoring

Fixes #368

This will fix the issue of taskrun log
throwing error if the pod name is
not yet available in status

This will wait for pod name to be
available in status for follow mode
till 10 secs

And in case of non follow mode it
will check whether pod name is there
or not

Adds test for the scenarios

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
