### PR TITLE
Remove 386 and arm archs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,9 +16,7 @@ builds:
   - darwin
   - windows
   goarch:
-  - 386
   - amd64
-  - arm
   - arm64
   ldflags:
   - -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}


### PR DESCRIPTION
Feel free to convince otherwise that it may be used =)

It decrease CI times too and make it less confusing for users to know which one to choose,

```
Remove 386 and arm architectures from the binary release
```