### PR TITLE
Add Namespace Check to PipelineRun List Command

### DIFF
--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	prhsort "github.com/tektoncd/cli/pkg/helper/pipelinerun/sort"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/cli/pkg/printer"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,6 +65,10 @@ tkn pr list -n foo
 
 			if len(args) > 0 {
 				pipeline = args[0]
+			}
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
 			}
 
 			if opts.Limit < 0 {


### PR DESCRIPTION
Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn pr list` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn pr ls command when a namespace does not exist
```
