### PR TITLE
Add Namespace Check to Pipeline Start Command

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/cli/pkg/helper/labels"
 	"github.com/tektoncd/cli/pkg/helper/params"
 	"github.com/tektoncd/cli/pkg/helper/pipeline"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +71,10 @@ type resourceOptionsFilter struct {
 func NameArg(args []string, p cli.Params) error {
 	if len(args) == 0 {
 		return errNoPipeline
+	}
+
+	if err := validate.NamespaceExists(p); err != nil {
+		return err
 	}
 
 	c, err := p.Clients()
@@ -118,6 +123,7 @@ like cat,foo,bar
 			if err := flags.InitParams(p, cmd); err != nil {
 				return err
 			}
+
 			return NameArg(args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -125,6 +131,7 @@ like cat,foo,bar
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
+
 			return opt.run(args[0])
 		},
 	}


### PR DESCRIPTION
**Note:** This is the last pr needed to address #311 

Following similar approaches outlined for `tkn` commands, this pull request is part of addressing #311. An error message has been added for `tkn pipeline start` when a namespace doesn't exist on a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds error message to tkn pipeline start command when a namespace does not exist
```