### PR TITLE
Clean Up Pipeline Start Test and Correct Task Start Namespace Check

### DIFF
--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -91,7 +91,7 @@ func Test_start_invalid_namespace(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
 	c := Command(&test.Params{Tekton: cs.Pipeline, Kube: cs.Kube})
 
-	_, err := test.ExecuteCommand(c, "start", "task", "-n", "invalid")
+	_, err := test.ExecuteCommand(c, "start", "pipeline", "-n", "invalid")
 
 	if err == nil {
 		t.Error("Expected an error for invalid namespace")

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -54,6 +54,10 @@ func NameArg(args []string, p cli.Params) error {
 		return errNoTask
 	}
 
+	if err := validate.NamespaceExists(p); err != nil {
+		return err
+	}
+
 	c, err := p.Clients()
 	if err != nil {
 		return err
@@ -98,10 +102,6 @@ like cat,foo,bar
 			opt.stream = &cli.Stream{
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
-			}
-
-			if err := validate.NamespaceExists(p); err != nil {
-				return err
 			}
 
 			return startTask(opt, args[0])

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -76,6 +76,20 @@ func newPipelineClient(objs ...runtime.Object) *fakepipelineclientset.Clientset 
 	return c
 }
 
+func Test_start_invalid_namespace(t *testing.T) {
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
+	c := Command(&test.Params{Tekton: cs.Pipeline, Kube: cs.Kube})
+
+	_, err := test.ExecuteCommand(c, "start", "task", "-n", "invalid")
+
+	if err == nil {
+		t.Error("Expected an error for invalid namespace")
+	}
+
+	test.AssertOutput(t, "namespaces \"invalid\" not found", err.Error())
+}
+
 func Test_start_has_task_arg(t *testing.T) {
 	c := Command(&test.Params{})
 


### PR DESCRIPTION
Closes #311 

This pull request adds a test for checking for an invalid namespace as part of the `tkn task start` command, which also requires a change to where the validation takes place for the command. The check has been moved to the `NameArg` function. 

This pull request also changes a typo in `tkn pipeline start` tests by changing the name of the pipeline used in a command from `task` to `pipeline`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

N/A