### PR TITLE
Fix make lint warning

### DIFF
--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Netflix/go-expect"
+	goexpect "github.com/Netflix/go-expect"
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
@@ -243,7 +243,7 @@ func TestLogs_interactive_get_all_inputs(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Select pipeline :"); err != nil {
 					return err
 				}
@@ -362,7 +362,7 @@ func TestLogs_interactive_ask_runs(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{pipelineName},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Select pipelinerun :"); err != nil {
 					return err
 				}
@@ -456,7 +456,7 @@ func TestLogs_interactive_limit_2(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{pipelineName},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("output-pipeline"); err != nil {
 					return err
 				}
@@ -558,7 +558,7 @@ func TestLogs_interactive_limit_1(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{pipelineName},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("output-pipeline"); err != nil {
 					return err
 				}
@@ -652,7 +652,7 @@ func TestLogs_interactive_ask_all_last_run(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Select pipeline :"); err != nil {
 					return err
 				}
@@ -747,7 +747,7 @@ func TestLogs_interactive_ask_run_last_run(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{pipelineName},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("output-pipeline"); err == nil {
 					return errors.New("unexpected error")
 				}
@@ -872,7 +872,7 @@ func TestLogs_have_one_get_one(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{pipelineName},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("output-pipeline"); err == nil {
 					return errors.New("unexpected error")
 				}

--- a/pkg/cmd/pipeline/logs_testutil.go
+++ b/pkg/cmd/pipeline/logs_testutil.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Netflix/go-expect"
+	goexpect "github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/require"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -29,7 +29,7 @@ import (
 type promptTest struct {
 	name      string
 	cmdArgs   []string
-	procedure func(*expect.Console) error
+	procedure func(*goexpect.Console) error
 }
 
 func (opts *logOptions) RunPromptTest(t *testing.T, test promptTest) {
@@ -64,16 +64,16 @@ func (opts *startOptions) RunPromptTest(t *testing.T, test promptTest) {
 	})
 }
 
-func stdio(c *expect.Console) terminal.Stdio {
+func stdio(c *goexpect.Console) terminal.Stdio {
 	return terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()}
 }
 
-func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) error, test func(terminal.Stdio) error) {
+func (pt *promptTest) runTest(t *testing.T, procedure func(*goexpect.Console) error, test func(terminal.Stdio) error) {
 	t.Parallel()
 
 	// Multiplex output to a buffer as well for the raw bytes.
 	buf := new(bytes.Buffer)
-	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf))
+	c, state, err := vt10x.NewVT10XConsole(goexpect.WithStdout(buf))
 	require.Nil(t, err)
 	defer c.Close()
 
@@ -96,7 +96,7 @@ func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) erro
 	t.Logf("Raw output: %q", buf.String())
 
 	// Dump the terminal's screen.
-	t.Logf("\n%s", expect.StripTrailingEmptyLines(state.String()))
+	t.Logf("\n%s", goexpect.StripTrailingEmptyLines(state.String()))
 }
 
 // WithStdio helps to test interactive command

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Netflix/go-expect"
+	goexpect "github.com/Netflix/go-expect"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -289,7 +289,7 @@ func Test_start_pipeline_interactive(t *testing.T) {
 			name:    "basic interaction",
 			cmdArgs: []string{pipelineName},
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Choose the git resource to use for git-repo:"); err != nil {
 					return err
 				}

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Netflix/go-expect"
+	goexpect "github.com/Netflix/go-expect"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -57,7 +57,7 @@ func TestPipelineResource_resource_noName(t *testing.T) {
 		{
 			name: "no input for name",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -125,7 +125,7 @@ func TestPipelineResource_resource_already_exist(t *testing.T) {
 		{
 			name: "pre-existing-resource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -175,7 +175,7 @@ func TestPipelineResource_allResourceType(t *testing.T) {
 		{
 			name: "check all type of resource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -283,7 +283,7 @@ func TestPipelineResource_create_cloudEventResource(t *testing.T) {
 		{
 			name: "create-cloudEventResource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -353,7 +353,7 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 		{
 			name: "clusterResource-securePasswordText",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -499,7 +499,7 @@ func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T)
 		{
 			name: "clusterResource-secureTokenText",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -649,7 +649,7 @@ func TestPipelineResource_create_gitResource(t *testing.T) {
 		{
 			name: "gitResource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -746,7 +746,7 @@ func TestPipelineResource_create_imageResource(t *testing.T) {
 		{
 			name: "imageResource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -848,7 +848,7 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 		{
 			name: "clusterResource-securePasswordSecrets",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -1010,7 +1010,7 @@ func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.
 		{
 			name: "clusterResource-secureTokenSecrets",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -1184,7 +1184,7 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 		{
 			name: "pullRequestResource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -1313,7 +1313,7 @@ func TestPipelineResource_create_gcsStorageResource(t *testing.T) {
 		{
 			name: "gcsStorageResource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}
@@ -1455,7 +1455,7 @@ func TestPipelineResource_create_buildGCSstorageResource(t *testing.T) {
 		{
 			name: "buildGCSstorageResource",
 
-			procedure: func(c *expect.Console) error {
+			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
 				}

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -20,14 +20,14 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Netflix/go-expect"
+	goexpect "github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/require"
 )
 
 type promptTest struct {
 	name      string
-	procedure func(*expect.Console) error
+	procedure func(*goexpect.Console) error
 }
 
 func (res *resource) RunPromptTest(t *testing.T, test promptTest) {
@@ -46,16 +46,16 @@ func (res *resource) RunPromptTest(t *testing.T, test promptTest) {
 	})
 }
 
-func stdio(c *expect.Console) terminal.Stdio {
+func stdio(c *goexpect.Console) terminal.Stdio {
 	return terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()}
 }
 
-func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) error, test func(terminal.Stdio) error) {
+func (pt *promptTest) runTest(t *testing.T, procedure func(*goexpect.Console) error, test func(terminal.Stdio) error) {
 	t.Parallel()
 
 	// Multiplex output to a buffer as well for the raw bytes.
 	buf := new(bytes.Buffer)
-	c, state, err := vt10x.NewVT10XConsole(expect.WithStdout(buf))
+	c, state, err := vt10x.NewVT10XConsole(goexpect.WithStdout(buf))
 	require.Nil(t, err)
 	defer c.Close()
 
@@ -78,7 +78,7 @@ func (pt *promptTest) runTest(t *testing.T, procedure func(*expect.Console) erro
 	t.Logf("Raw output: %q", buf.String())
 
 	// Dump the terminal's screen.
-	t.Logf("\n%s", expect.StripTrailingEmptyLines(state.String()))
+	t.Logf("\n%s", goexpect.StripTrailingEmptyLines(state.String()))
 }
 
 // WithStdio helps to test interactive command


### PR DESCRIPTION
This will fix the warnings issued by
make lint command

Fixes https://github.com/tektoncd/cli/issues/422

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
