### PR TITLE
Add validation for check if the task create success

### DIFF
--- a/pkg/cmd/taskrun/log_reader.go
+++ b/pkg/cmd/taskrun/log_reader.go
@@ -98,6 +98,10 @@ func (lr *LogReader) readLiveLogs(tr *v1alpha1.TaskRun) (<-chan Log, <-chan erro
 		kube    = lr.Clients.Kube
 	)
 
+	if podName == "" {
+		return nil, nil, fmt.Errorf("task %s create failed or has not started yet", lr.Task)
+	}
+
 	p := pods.New(podName, lr.Ns, kube, lr.Streamer)
 	pod, err := p.Wait()
 	if err != nil {
@@ -115,8 +119,12 @@ func (lr *LogReader) readAvailableLogs(tr *v1alpha1.TaskRun) (<-chan Log, <-chan
 		podName = tr.Status.PodName
 	)
 
+	if podName == "" {
+		return nil, nil, fmt.Errorf("task %s create failed or has not started yet", lr.Task)
+	}
+
 	if !tr.HasStarted() {
-		return nil, nil, fmt.Errorf("task %s has not hasStarted yet", lr.Task)
+		return nil, nil, fmt.Errorf("task %s has not started yet", lr.Task)
 	}
 
 	p := pods.New(podName, lr.Ns, kube, lr.Streamer)


### PR DESCRIPTION
Fix issue: https://github.com/tektoncd/pipeline/issues/1507

If `Task`/`Pod` create failed (should be many reasons, for example the `serviceaccount` is not found), based on current implements, there is no checking, in such scenario, the `Podname` in `taskrun/status` is a null string, since no checking, the null string will be used as parameter of `Restclient`, then `resource name may not be empty` will be raised by `client-go`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
