### PR TITLE
Remove Unnecessary Space from Start Error Messages

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -42,7 +42,7 @@ var (
 )
 
 const (
-	invalidResource = "invalid input format for resource parameter : "
+	invalidResource = "invalid input format for resource parameter: "
 	invalidSvc      = "invalid service account parameter: "
 )
 

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -834,7 +834,7 @@ func Test_start_pipeline_res_err(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Error: invalid input format for resource parameter : git-reposcaffold-git\n"
+	expected := "Error: invalid input format for resource parameter: git-reposcaffold-git\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -879,7 +879,7 @@ func Test_start_pipeline_param_err(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Error: invalid input format for param parameter : rev-paramrevision2\n"
+	expected := "Error: invalid input format for param parameter: rev-paramrevision2\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -924,7 +924,7 @@ func Test_start_pipeline_label_err(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Error: invalid input format for label parameter : keyvalue\n"
+	expected := "Error: invalid input format for label parameter: keyvalue\n"
 	test.AssertOutput(t, expected, got)
 }
 

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -35,7 +35,7 @@ var (
 	errInvalidTask = "task name %s does not exist in namespace %s"
 )
 
-const invalidResource = "invalid input format for resource parameter : "
+const invalidResource = "invalid input format for resource parameter: "
 
 type startOptions struct {
 	cliparams          cli.Params

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -518,7 +518,7 @@ func Test_start_task_invalid_input_res(t *testing.T) {
 		"-i=my-repo git-repo",
 		"-n", "ns",
 	)
-	expected := "Error: invalid input format for resource parameter : my-repo git-repo\n"
+	expected := "Error: invalid input format for resource parameter: my-repo git-repo\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -557,7 +557,7 @@ func Test_start_task_invalid_output_res(t *testing.T) {
 		"-o", "code-image image-final",
 		"-n", "ns",
 	)
-	expected := "Error: invalid input format for resource parameter : code-image image-final\n"
+	expected := "Error: invalid input format for resource parameter: code-image image-final\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -596,7 +596,7 @@ func Test_start_task_invalid_param(t *testing.T) {
 		"-p", "myarg boom",
 		"-n", "ns",
 	)
-	expected := "Error: invalid input format for param parameter : myarg boom\n"
+	expected := "Error: invalid input format for param parameter: myarg boom\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -635,7 +635,7 @@ func Test_start_task_invalid_label(t *testing.T) {
 		"-l", "myarg boom",
 		"-n", "ns",
 	)
-	expected := "Error: invalid input format for label parameter : myarg boom\n"
+	expected := "Error: invalid input format for label parameter: myarg boom\n"
 	test.AssertOutput(t, expected, got)
 }
 

--- a/pkg/helper/labels/mergelabels.go
+++ b/pkg/helper/labels/mergelabels.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-const invalidLabel = "invalid input format for label parameter : "
+const invalidLabel = "invalid input format for label parameter: "
 
 func MergeLabels(l map[string]string, optLabel []string) (map[string]string, error) {
 	labels, err := parseLabels(optLabel)

--- a/pkg/helper/params/mergeparams.go
+++ b/pkg/helper/params/mergeparams.go
@@ -21,7 +21,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
-const invalidParam = "invalid input format for param parameter : "
+const invalidParam = "invalid input format for param parameter: "
 
 func MergeParam(p []v1alpha1.Param, optPar []string) ([]v1alpha1.Param, error) {
 	params, err := parseParam(optPar)


### PR DESCRIPTION
Removing unneeded spaces from taskrun/pipelinerun error messages for invalid resource parameter format.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Removing unneeded spaces from taskrun/pipelinerun error messages for invalid resource parameter format
```
