### PR TITLE
Show params in pipeline describe command

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -42,6 +42,24 @@ NAME	TYPE
 {{- end }}
 {{- end }}
 
+Params
+{{- $l := len .Pipeline.Spec.Params }}{{ if eq $l 0 }}
+No params
+{{- else }}
+NAME	TYPE	DEFAULT_VALUE
+{{- range $i, $p := .Pipeline.Spec.Params }}
+{{- if not $p.Default }}
+{{ $p.Name }}	{{ $p.Type }}	{{ "" }}
+{{- else }}
+{{- if eq $p.Type "string" }}
+{{ $p.Name }}	{{ $p.Type }}	{{ $p.Default.StringVal }}
+{{- else }}
+{{ $p.Name }}	{{ $p.Type }}	{{ $p.Default.ArrayVal }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 Tasks
 {{- $tl := len .Pipeline.Spec.Tasks }}{{ if eq $tl 0 }}
 No tasks

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -97,6 +97,8 @@ func TestPipelinesDescribe_empty(t *testing.T) {
 		"Name:   pipeline",
 		"\nResources",
 		"No resources\n",
+		"Params",
+		"No params\n",
 		"Tasks",
 		"No tasks\n",
 		"Pipelineruns",
@@ -164,6 +166,8 @@ func TestPipelinesDescribe_with_run(t *testing.T) {
 		"Name:   pipeline",
 		"\nResources",
 		"No resources\n",
+		"Params",
+		"No params\n",
 		"Tasks",
 		"No tasks\n",
 		"Pipelineruns",
@@ -236,6 +240,8 @@ func TestPipelinesDescribe_with_task_run(t *testing.T) {
 		"Name:   pipeline",
 		"\nResources",
 		"No resources\n",
+		"Params",
+		"No params\n",
 		"Tasks",
 		"NAME   TASKREF   RUNAFTER",
 		"task   taskref   [one two]\n",
@@ -250,7 +256,7 @@ func TestPipelinesDescribe_with_task_run(t *testing.T) {
 	}
 }
 
-func TestPipelinesDescribe_with_resource_task_run(t *testing.T) {
+func TestPipelinesDescribe_with_resource_param_task_run(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
@@ -263,6 +269,7 @@ func TestPipelinesDescribe_with_resource_task_run(t *testing.T) {
 						tb.RunAfter("one", "two"),
 					),
 					tb.PipelineDeclaredResource("name", v1alpha1.PipelineResourceTypeGit),
+					tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
 				),
 			),
 		},
@@ -312,6 +319,9 @@ func TestPipelinesDescribe_with_resource_task_run(t *testing.T) {
 		"\nResources",
 		"NAME   TYPE",
 		"name   git\n",
+		"Params",
+		"NAME             TYPE     DEFAULT_VALUE",
+		"pipeline-param   string   somethingdifferent\n",
 		"Tasks",
 		"NAME   TASKREF   RUNAFTER",
 		"task   taskref   [one two]\n",
@@ -326,7 +336,7 @@ func TestPipelinesDescribe_with_resource_task_run(t *testing.T) {
 	}
 }
 
-func TestPipelinesDescribe_with_multiple_resource_task_run(t *testing.T) {
+func TestPipelinesDescribe_with_multiple_resource_param_task_run(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
@@ -343,6 +353,10 @@ func TestPipelinesDescribe_with_multiple_resource_task_run(t *testing.T) {
 					tb.PipelineDeclaredResource("code-image", v1alpha1.PipelineResourceTypeImage),
 					tb.PipelineDeclaredResource("artifact-image", v1alpha1.PipelineResourceTypeImage),
 					tb.PipelineDeclaredResource("repo", v1alpha1.PipelineResourceTypeGit),
+					tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
+					tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("booms", "booms", "booms")),
+					tb.PipelineParamSpec("pipeline-param2", v1alpha1.ParamTypeString),
+					tb.PipelineParamSpec("rev-param2", v1alpha1.ParamTypeArray),
 				),
 			),
 		},
@@ -396,6 +410,12 @@ func TestPipelinesDescribe_with_multiple_resource_task_run(t *testing.T) {
 		"repo             git",
 		"artifact-image   image",
 		"code-image       image\n",
+		"Params",
+		"NAME              TYPE     DEFAULT_VALUE",
+		"pipeline-param    string   somethingdifferent",
+		"rev-param         array    [booms booms booms]",
+		"pipeline-param2   string   ",
+		"rev-param2        array    \n",
 		"Tasks",
 		"NAME   TASKREF   RUNAFTER",
 		"task   taskref   [one two]\n",


### PR DESCRIPTION
This will fix the issue of not info about params in
pipeline describe

It will show the param name, type and default value
In case of no default value, it will show empty

Add tests

Fixes #438

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
