### PR TITLE
Fix brew install from tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the latest binary executable for your operating system:
 
   ```shell
   brew tap tektoncd/tools
-  brew install tektoncd-cli
+  brew install tektoncd/tools/tektoncd-cli
   ```
 
   - Or by the [released tarball](https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Darwin_x86_64.tar.gz):


### PR DESCRIPTION
We have now tektoncd-cli in homebrew-core, but the tap is still the preferred
method, we need to tell people to install it from the tap or the homebrew-core
version will `shadow` it (since they have the same name)


# Release Notes

```
We have now tektoncd-cli in homebrew-core, but the tap is still the preferred
method, since both have the same name by default it will use the homebrew-core
version which could be slightly outdated, use `brew upgrade
tektoncd/tools/tektoncd-cli` to get the latest release version.
```