### PR TITLE
Show Status of Steps with TaskRun Describe

### DIFF
--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -90,9 +90,10 @@ Steps
 {{- $l := len .TaskRun.Status.Steps }}{{ if eq $l 0 }}
 No steps
 {{- else }}
-NAME
-{{- range $steps := .TaskRun.Status.Steps }}
-{{ $steps.Name }}
+NAME	STATUS
+{{- range $step := .TaskRun.Status.Steps }}
+{{- $reason := stepReasonExists $step }}
+{{ $step.Name }}	{{ $reason }}
 {{- end }}
 {{- end }}
 `
@@ -156,11 +157,12 @@ func printTaskRunDescription(s *cli.Stream, trName string, p cli.Params) error {
 	}
 
 	funcMap := template.FuncMap{
-		"formatAge":       formatted.Age,
-		"formatDuration":  formatted.Duration,
-		"formatCondition": formatted.Condition,
-		"hasFailed":       hasFailed,
-		"taskRefExists":   validate.TaskRefExists,
+		"formatAge":        formatted.Age,
+		"formatDuration":   formatted.Duration,
+		"formatCondition":  formatted.Condition,
+		"hasFailed":        hasFailed,
+		"taskRefExists":    validate.TaskRefExists,
+		"stepReasonExists": validate.StepReasonExists,
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/helper/validate/validate.go
+++ b/pkg/helper/validate/validate.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	fieldNotPresent = ""
+	pendingState    = "---"
 )
 
 type params interface {
@@ -55,4 +56,23 @@ func TaskRefExists(spec v1alpha1.TaskRunSpec) string {
 	}
 
 	return spec.TaskRef.Name
+}
+
+// Check if step is in waiting, running, or terminated state by checking StepState of the step.
+func StepReasonExists(state v1alpha1.StepState) string {
+
+	if state.Waiting == nil {
+
+		if state.Running != nil {
+			return "Running"
+		}
+
+		if state.Terminated != nil {
+			return state.Terminated.Reason
+		}
+
+		return pendingState
+	}
+
+	return state.Waiting.Reason
 }

--- a/pkg/helper/validate/validate_test.go
+++ b/pkg/helper/validate/validate_test.go
@@ -16,6 +16,7 @@ package validate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -73,4 +74,52 @@ func TestTaskRefExists_Not_Present(t *testing.T) {
 
 	output := TaskRefExists(spec)
 	test.AssertOutput(t, "", output)
+}
+
+func TestStepReasonExists_Terminated_Not_Present(t *testing.T) {
+	state := v1alpha1.StepState{}
+
+	output := StepReasonExists(state)
+	test.AssertOutput(t, "---", output)
+}
+
+func TestStepReasonExists_Terminated_Present(t *testing.T) {
+	state := v1alpha1.StepState{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Completed",
+			},
+		},
+	}
+
+	output := StepReasonExists(state)
+	test.AssertOutput(t, "Completed", output)
+}
+
+func TestStepReasonExists_Running_Present(t *testing.T) {
+	state := v1alpha1.StepState{
+		ContainerState: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{
+				StartedAt: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+		},
+	}
+
+	output := StepReasonExists(state)
+	test.AssertOutput(t, "Running", output)
+}
+
+func TestStepReasonExists_Waiting_Present(t *testing.T) {
+	state := v1alpha1.StepState{
+		ContainerState: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{
+				Reason: "PodInitializing",
+			},
+		},
+	}
+
+	output := StepReasonExists(state)
+	test.AssertOutput(t, "PodInitializing", output)
 }


### PR DESCRIPTION
Closes #440 

This pull request adds the ability to see the status of a step with `tkn tr describe`. 

Possible values are `Completed` and `Error` for a step from `Terminated`. `Completed` does not always imply the step ran successfully. It represents that no error occurred for the step, or the step never ran due to a previous step failure.

`PodInitializing` will appear when the step is in a `Waiting` state. 

`Running` will appear when the step is actually executing and also when the pod has been initialized for the step. I am open to suggestions on if there's a better message that could be displayed to end users.

`STATUS` is mapped to the property `Reason` on the `StepState` from `Terminated` or `Waiting`, but will be `Running` if the `Running` property on the `StepState` isn't `nil`.

Limitation of approach in this pr is that steps are not ordered by start time. It may take some planning around how to deal with `StartedAt` not always being present for a step.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Show step status with taskrun describe
```
