### PR TITLE
Add cloudEvent resource support to start command

### DIFF
--- a/pkg/cmd/pipelineresource/list.go
+++ b/pkg/cmd/pipelineresource/list.go
@@ -166,7 +166,8 @@ func details(pre v1alpha1.PipelineResource) string {
 	var key = "url"
 	if pre.Spec.Type == v1alpha1.PipelineResourceTypeStorage {
 		key = "location"
-	} else if pre.Spec.Type == v1alpha1.PipelineResourceTypeCloudEvent {
+	}
+	if pre.Spec.Type == v1alpha1.PipelineResourceTypeCloudEvent {
 		key = "targeturi"
 	}
 


### PR DESCRIPTION
This will add the support of cloudEvent resource
in interactive pipeline start command

Fix #451 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
