### PR TITLE
Fix resource creation failure in case of multiple

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -210,7 +210,7 @@ func (opt *startOptions) getInputResources(resources resourceOptionsFilter, pipe
 			}
 			fmt.Printf("resource status %s\n\n", newres.Status)
 			opt.Resources = append(opt.Resources, res.Name+"="+newres.Name)
-			return nil
+			continue
 		}
 
 		// shows create option in the resource list


### PR DESCRIPTION
This will fix the issue of resource creation
failure in case of creating multiple
resources on fly while executing
tkn pipeline start command

Add tests

fix #456

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._