### PR TITLE
Add Installation instruction when compiling from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,15 @@ Download the latest binary executable for your operating system:
   dnf install tektoncd-cli
   ```
 
-If you have [go](https://golang.org/) installed, `GO111MODULE="on" go get github.com/tektoncd/cli@v0.5.0` is all you need!
+* Source install
+
+  If you have [go](https://golang.org/) installed, and you want to compile the CLI from source you can checkout the [Git repository](https://github.com/tektoncd/cli) and run the following commands:
+
+```shell
+export GO111MODULE=on
+make bin/tkn
+```
+  This will output the `tkn` binary in `bin/tkn`
 
 ### `tkn` as a `kubectl` plugin
 


### PR DESCRIPTION
# Changes

And remove the `go get` installation due of some shortcomming of `go get`
installation method with go modules.

/cc @vdemeester @hrishin @sthaha @danielhelfand 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [-] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [-] Run the code checkers with `make check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
The installation method with go get is not supported anymore. Use the
compilation from source methode as documented in README if you want to install
the CLI from sources.
```