### PR TITLE
Fix interactive input params on pipeline start

### DIFF
--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -260,6 +260,7 @@ func Test_start_pipeline_interactive(t *testing.T) {
 					tb.PipelineDeclaredResource("git-repo", "git"),
 					tb.PipelineParamSpec("pipeline-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent")),
 					tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
+					tb.PipelineParamSpec("array-param", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("revision1", "revision2")),
 					tb.PipelineTask("unit-test-1", "unit-test-task",
 						tb.PipelineTaskInputResource("workspace", "git-repo"),
 						tb.PipelineTaskOutputResource("image-to-use", "best-image"),
@@ -302,7 +303,7 @@ func Test_start_pipeline_interactive(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Value of param `pipeline-param` ?"); err != nil {
+				if _, err := c.ExpectString("Value for param `pipeline-param` of type `string`? (Default is `somethingdifferent`)"); err != nil {
 					return err
 				}
 
@@ -310,11 +311,19 @@ func Test_start_pipeline_interactive(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Value of param `rev-param` ?"); err != nil {
+				if _, err := c.ExpectString("Value for param `rev-param` of type `string`? (Default is `revision`)"); err != nil {
 					return err
 				}
 
-				if _, err := c.SendLine("test2"); err != nil {
+				if _, err := c.SendLine("test1"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Value for param `array-param` of type `array`? (Default is `revision1,revision2`)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("test2, test3"); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
This will fix pipeline start throwing
error on interactive input params if
the params is of type array or string
without default value

Also fix array param with default input
as the question was incorrectly asked

Fix #465

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._