### PR TITLE
Include TaskRun Failure Message in Logs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -379,6 +379,7 @@ k8s.io/kubernetes v1.13.3 h1:46t44D87wKtdKFgr/lXM60K8xPrW0wO67Woof3Vsv6E=
 k8s.io/kubernetes v1.13.3/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 knative.dev/pkg v0.0.0-20190719141030-e4bc08cc8ded h1:CHn7mNgIE5GHMJqfNPFLBLcZlCdaTdQmAA8Uu6XLOKc=
 knative.dev/pkg v0.0.0-20190719141030-e4bc08cc8ded/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
+knative.dev/pkg v0.0.0-20191121191108-8c1fb5fe0446 h1:29XUTvB++mEHuZxVgx8+Wh3wqkzEspgfzMwsHPgw9Tk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -184,5 +184,6 @@ func hasFailed(tr *v1alpha1.TaskRun) string {
 	if tr.Status.Conditions[0].Status == corev1.ConditionFalse {
 		return tr.Status.Conditions[0].Message
 	}
+
 	return ""
 }

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
@@ -477,7 +478,7 @@ func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 		t.Error("Expecting an error but it's empty")
 	}
 
-	expected := "task output-task create failed or has not started yet or pod for task not yet available"
+	expected := "task output-task create has not started yet or pod for task not yet available"
 	test.AssertOutput(t, expected, err.Error())
 }
 
@@ -660,11 +661,91 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 		t.Error("Expecting an error but it's empty")
 	}
 
-	expectedOut := "Task still running ...\n"
+	expectedOut := ""
 	test.AssertOutput(t, expectedOut, output)
 
-	expectedErr := "task output-task create failed or has not started yet or pod for task not yet available"
+	expectedErr := "task output-task create has not started yet or pod for task not yet available"
 	test.AssertOutput(t, expectedErr, err.Error())
+}
+
+func TestLog_taskrun_follow_mode_no_output_provided(t *testing.T) {
+	var (
+		prstart     = clockwork.NewFakeClock()
+		ns          = "namespace"
+		taskName    = "output-task"
+		trName      = "output-task-run"
+		trStartTime = prstart.Now().Add(20 * time.Second)
+		trPod       = "output-task-pod-123456"
+		trStep1Name = "writefile-step"
+		trInitStep1 = "credential-initializer-mdzbr"
+		trInitStep2 = "place-tools"
+		nopStep     = "nop"
+	)
+
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun(trName, ns,
+			tb.TaskRunStatus(
+				tb.TaskRunStartTime(trStartTime),
+				tb.StatusCondition(apis.Condition{
+					Type:    resources.ReasonFailed,
+					Status:  corev1.ConditionFalse,
+					Message: "invalid output resources: TaskRun's declared resources didn't match usage in Task: Didn't provide required values: [builtImage]",
+				}),
+				tb.StepState(
+					cb.StepName(trStep1Name),
+					tb.StateTerminated(0),
+				),
+				tb.StepState(
+					cb.StepName(nopStep),
+					tb.StateTerminated(0),
+				),
+			),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef(taskName),
+			),
+		),
+	}
+
+	nsList := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "namespace",
+			},
+		},
+	}
+
+	p := []*corev1.Pod{
+		tb.Pod(trPod, ns,
+			tb.PodSpec(
+				tb.PodInitContainer(trInitStep1, "override-with-creds:latest"),
+				tb.PodInitContainer(trInitStep2, "override-with-tools:latest"),
+				tb.PodContainer(trStep1Name, trStep1Name+":latest"),
+				tb.PodContainer(nopStep, "override-with-nop:latest"),
+			),
+			cb.PodStatus(
+				cb.PodPhase(corev1.PodSucceeded),
+				cb.PodInitContainerStatus(trInitStep1, "override-with-creds:latest"),
+				cb.PodInitContainerStatus(trInitStep2, "override-with-tools:latest"),
+			),
+		),
+	}
+
+	logs := fake.Logs(
+		fake.Task(trPod),
+	)
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
+	watcher := watch.NewRaceFreeFake()
+	cs.Pipeline.PrependWatchReactor("taskruns", k8stest.DefaultWatchReactor(watcher, nil))
+	trlo := logOpts(trName, ns, cs, fake.Streamer(logs), false, true)
+
+	_, err := fetchLogs(trlo)
+	if err == nil {
+		t.Errorf("Expected error but no error occurred ")
+	}
+
+	expected := "task output-task has failed: invalid output resources: TaskRun's declared resources didn't match usage in Task: Didn't provide required values: [builtImage]"
+	test.AssertOutput(t, expected, err.Error())
 }
 
 func logOpts(run, ns string, cs pipelinetest.Clients, streamer stream.NewStreamerFunc, allSteps bool, follow bool) *LogOptions {


### PR DESCRIPTION
Closes #467 

This pull request adds a check if the taskrun has failed while starting up and includes the failure message in the taskrun logs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Make error message for taskrun start up failure easier to find
```
