### PR TITLE
Add Check in PipelineRun Logs for if Condition Available

### DIFF
--- a/pkg/cmd/pipelinerun/log_reader.go
+++ b/pkg/cmd/pipelinerun/log_reader.go
@@ -95,10 +95,8 @@ func (lr *LogReader) readLiveLogs(pr *v1alpha1.PipelineRun) (<-chan Log, <-chan 
 
 		wg.Wait()
 
-		if pr.Status.Conditions != nil {
-			if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
-				errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
-			}
+		if !empty(pr.Status) && pr.Status.Conditions[0].Status == corev1.ConditionFalse {
+			errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
 		}
 	}()
 
@@ -134,7 +132,8 @@ func (lr *LogReader) readAvailableLogs(pr *v1alpha1.PipelineRun) (<-chan Log, <-
 
 			pipeLogs(logC, errC, tlr)
 		}
-		if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
+
+		if !empty(pr.Status) && pr.Status.Conditions[0].Status == corev1.ConditionFalse {
 			errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
 		}
 	}()
@@ -213,5 +212,10 @@ func pipeLogs(logC chan<- Log, errC chan<- error, tlr *taskrun.LogReader) {
 }
 
 func empty(status v1alpha1.PipelineRunStatus) bool {
+
+	if status.Conditions == nil {
+		return true
+	}
+
 	return len(status.Conditions) == 0
 }


### PR DESCRIPTION
Closes #470 

This pull request adds checks for if the conditions are available in the logs of a pipeline run to help prevent the index from being out of range.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Check if conditions are available in pipelinerun logs to prevent index from condition list from being out of range
```
