### PR TITLE
Uses vendored deps while building the binary in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,26 +20,26 @@ cross: amd64 386 arm arm64 ## build cross platform binaries
 
 .PHONY: amd64
 amd64:
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/tkn-linux-amd64 ./cmd/tkn
-	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/tkn-windows-amd64 ./cmd/tkn
-	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/tkn-darwin-amd64 ./cmd/tkn
+	GOOS=linux GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-amd64 ./cmd/tkn
+	GOOS=windows GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-windows-amd64 ./cmd/tkn
+	GOOS=darwin GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-darwin-amd64 ./cmd/tkn
 
 .PHONY: 386
 386:
-	GOOS=linux GOARCH=386 go build $(LDFLAGS) -o bin/tkn-linux-386 ./cmd/tkn
-	GOOS=windows GOARCH=386 go build $(LDFLAGS) -o bin/tkn-windows-386 ./cmd/tkn
-	GOOS=darwin GOARCH=386 go build $(LDFLAGS) -o bin/tkn-darwin-386 ./cmd/tkn
+	GOOS=linux GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-386 ./cmd/tkn
+	GOOS=windows GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-windows-386 ./cmd/tkn
+	GOOS=darwin GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-darwin-386 ./cmd/tkn
 
 .PHONY: arm
 arm:
-	GOOS=linux GOARCH=arm go build $(LDFLAGS) -o bin/tkn-linux-arm ./cmd/tkn
+	GOOS=linux GOARCH=arm go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-arm ./cmd/tkn
 
 .PHONY: arm64
 arm64:
-	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bin/tkn-linux-arm64 ./cmd/tkn
+	GOOS=linux GOARCH=arm64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-arm64 ./cmd/tkn
 
 bin/%: cmd/% FORCE
-	go build $(LDFLAGS) -v -o $@ ./$<
+	go build -mod=vendor $(LDFLAGS) -v -o $@ ./$<
 
 check: lint test
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
 - Since we already vendor the deps in the source repo, go build uses that
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
