### PR TITLE
Adding Timeout to tkn task start

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -39,6 +39,7 @@ like cat,foo,bar
   -p, --param stringArray        pass the param as key=value or key=value1,value2
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the task (default true)
+  -t, --timeout int              timeout for taskrun in seconds (default 3600)
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -55,6 +55,10 @@ Start tasks
 \fB\-\-showlog\fP[=true]
     show logs right after starting the task
 
+.PP
+\fB\-t\fP, \fB\-\-timeout\fP=3600
+    timeout for taskrun in seconds
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -660,7 +660,7 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 		t.Error("Expecting an error but it's empty")
 	}
 
-	expectedOut := "Task still running ...\n"
+	expectedOut := ""
 	test.AssertOutput(t, expectedOut, output)
 
 	expectedErr := "task output-task create failed or has not started yet or pod for task not yet available"


### PR DESCRIPTION
Closes #433 

This pull request adds a timeout option for `tkn task start`. The unit of time for the option is specified in seconds, and the default is 3600 seconds (i.e. an hour). 0 can be used to not specify a taskrun.

It also cleans up error messaging from taskrun logging. 

I have not found the best way to test this at this time, but am open to suggestions. It may be worthwhile to cover this with e2e testing as opposed to unit tests. 

This will conflict with #469, but I can resolve based on whichever goes through first. 

# Changes

The `--timeout` or `-t` option is converted into seconds and set as part of the taskrun spec. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Set timeout option for taskrun with tkn task start
```
