### PR TITLE
Set current k8s context via tkn 

### DIFF
--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -11,6 +11,7 @@ Manage clustertasks
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertask
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -36,6 +36,7 @@ tkn ct rm foo
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -26,6 +26,7 @@ Lists clustertasks in a namespace
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_condition.md
+++ b/docs/cmd/tkn_condition.md
@@ -11,6 +11,7 @@ Manage conditions
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for condition
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -36,6 +36,7 @@ tkn cond rm foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_condition_list.md
+++ b/docs/cmd/tkn_condition_list.md
@@ -26,6 +26,7 @@ Lists conditions in a namespace
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -11,6 +11,7 @@ Manage pipelines
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for pipeline
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -37,6 +37,7 @@ tkn p rm foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -26,6 +26,7 @@ Describes a pipeline in a namespace
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -26,6 +26,7 @@ Lists pipelines in a namespace
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -42,6 +42,7 @@ Show pipeline logs
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -49,6 +49,7 @@ two parameters (foo and bar)
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -11,6 +11,7 @@ Manage pipelineruns
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for pipelinerun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -28,6 +28,7 @@ Cancel the PipelineRun
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -36,6 +36,7 @@ tkn pr rm foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -35,6 +35,7 @@ tkn pr desc foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -37,6 +37,7 @@ tkn pr list -n foo
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -39,6 +39,7 @@ Show the logs of PipelineRun
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -11,6 +11,7 @@ Manage pipeline resources
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for resource
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -29,6 +29,7 @@ Creates pipeline resource
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -36,6 +36,7 @@ tkn res rm foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_resource_describe.md
+++ b/docs/cmd/tkn_resource_describe.md
@@ -35,6 +35,7 @@ tkn res desc foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -34,6 +34,7 @@ tkn pre list -n foo
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -11,6 +11,7 @@ Manage tasks
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for task
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -37,6 +37,7 @@ tkn t rm foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_task_describe.md
+++ b/docs/cmd/tkn_task_describe.md
@@ -35,6 +35,7 @@ tkn t desc foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -26,6 +26,7 @@ Lists tasks in a namespace
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -45,6 +45,7 @@ like cat,foo,bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -11,6 +11,7 @@ Manage taskruns
 ### Options
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for taskrun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -28,6 +28,7 @@ tkn taskrun cancel foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -36,6 +36,7 @@ tkn tr rm foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -35,6 +35,7 @@ tkn tr desc foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -37,6 +37,7 @@ tkn taskrun list foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -33,6 +33,7 @@ tkn taskrun logs -f foo -n bar
 ### Options inherited from parent commands
 
 ```
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -43,6 +43,10 @@ Delete a clustertask resource in a cluster
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -39,6 +39,10 @@ Lists clustertasks in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-clustertask.1
+++ b/docs/man/man1/tkn-clustertask.1
@@ -20,6 +20,10 @@ Manage clustertasks
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for clustertask
 

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -43,6 +43,10 @@ Delete a condition in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-condition-list.1
+++ b/docs/man/man1/tkn-condition-list.1
@@ -39,6 +39,10 @@ Lists conditions in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-condition.1
+++ b/docs/man/man1/tkn-condition.1
@@ -20,6 +20,10 @@ Manage conditions
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for condition
 

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -47,6 +47,10 @@ Delete a pipeline in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipeline-describe.1
+++ b/docs/man/man1/tkn-pipeline-describe.1
@@ -39,6 +39,10 @@ Describes a pipeline in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipeline-list.1
+++ b/docs/man/man1/tkn-pipeline-list.1
@@ -39,6 +39,10 @@ Lists pipelines in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -42,6 +42,10 @@ Show pipeline logs
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -62,6 +62,10 @@ Parameters, at least those that have no default value
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipeline.1
+++ b/docs/man/man1/tkn-pipeline.1
@@ -20,6 +20,10 @@ Manage pipelines
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for pipeline
 

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -26,6 +26,10 @@ Cancel the PipelineRun
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -43,6 +43,10 @@ Delete a pipelinerun in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -39,6 +39,10 @@ Describe a pipelinerun in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -43,6 +43,10 @@ Lists pipelineruns in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -42,6 +42,10 @@ Show the logs of PipelineRun
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-pipelinerun.1
+++ b/docs/man/man1/tkn-pipelinerun.1
@@ -20,6 +20,10 @@ Manage pipelineruns
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for pipelinerun
 

--- a/docs/man/man1/tkn-resource-create.1
+++ b/docs/man/man1/tkn-resource-create.1
@@ -26,6 +26,10 @@ Creates pipeline resource
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -43,6 +43,10 @@ Delete a pipeline resource in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-resource-describe.1
+++ b/docs/man/man1/tkn-resource-describe.1
@@ -39,6 +39,10 @@ Describes a pipeline resource in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-resource-list.1
+++ b/docs/man/man1/tkn-resource-list.1
@@ -43,6 +43,10 @@ Lists pipeline resources in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-resource.1
+++ b/docs/man/man1/tkn-resource.1
@@ -20,6 +20,10 @@ Manage pipeline resources
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for resource
 

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -47,6 +47,10 @@ Delete a task resource in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-task-describe.1
+++ b/docs/man/man1/tkn-task-describe.1
@@ -39,6 +39,10 @@ Describes a task in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-task-list.1
+++ b/docs/man/man1/tkn-task-list.1
@@ -39,6 +39,10 @@ Lists tasks in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -62,6 +62,10 @@ Start tasks
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-task.1
+++ b/docs/man/man1/tkn-task.1
@@ -20,6 +20,10 @@ Manage tasks
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for task
 

--- a/docs/man/man1/tkn-taskrun-cancel.1
+++ b/docs/man/man1/tkn-taskrun-cancel.1
@@ -26,6 +26,10 @@ Cancel a taskrun in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -43,6 +43,10 @@ Delete a taskrun in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -39,6 +39,10 @@ Describe a taskrun in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -43,6 +43,10 @@ Lists taskruns in a namespace
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -34,6 +34,10 @@ Show taskruns logs
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-k\fP, \fB\-\-kubeconfig\fP=""
     kubectl config file (default: $HOME/.kube/config)
 

--- a/docs/man/man1/tkn-taskrun.1
+++ b/docs/man/man1/tkn-taskrun.1
@@ -20,6 +20,10 @@ Manage taskruns
 
 .SH OPTIONS
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for taskrun
 

--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -38,6 +38,9 @@ type Params interface {
 	// SetKubeConfigPath uses the kubeconfig path to instantiate tekton
 	// returned by Clientset function
 	SetKubeConfigPath(string)
+	// SetKubeContext extends the specificity of the above SetKubeConfigPath
+	// by using a context other than the default context in the given kubeconfig
+	SetKubeContext(string)
 	Clients() (*Clients, error)
 	KubeClient() (k8s.Interface, error)
 

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -28,6 +28,7 @@ import (
 type TektonParams struct {
 	clients        *Clients
 	kubeConfigPath string
+	kubeContext    string
 	namespace      string
 }
 
@@ -36,6 +37,10 @@ var _ Params = (*TektonParams)(nil)
 
 func (p *TektonParams) SetKubeConfigPath(path string) {
 	p.kubeConfigPath = path
+}
+
+func (p *TektonParams) SetKubeContext(context string) {
+	p.kubeContext = context
 }
 
 func (p *TektonParams) tektonClient(config *rest.Config) (versioned.Interface, error) {
@@ -108,6 +113,9 @@ func (p *TektonParams) config() (*rest.Config, error) {
 		loadingRules.ExplicitPath = p.kubeConfigPath
 	}
 	configOverrides := &clientcmd.ConfigOverrides{}
+	if p.kubeContext != "" {
+		configOverrides.CurrentContext = p.kubeContext
+	}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	if p.namespace == "" {
 		namespace, _, err := kubeConfig.Namespace()

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	kubeConfig = "kubeconfig"
+	context    = "context"
 	namespace  = "namespace"
 	nocolour   = "nocolour"
 )
@@ -32,6 +33,10 @@ func AddTektonOptions(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP(
 		kubeConfig, "k", "",
 		"kubectl config file (default: $HOME/.kube/config)")
+
+	cmd.PersistentFlags().StringP(
+		context, "c", "",
+		"name of the kubeconfig context to use (default: kubectl config current-context)")
 
 	cmd.PersistentFlags().StringP(
 		namespace, "n", "",
@@ -60,6 +65,12 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 		return err
 	}
 	p.SetKubeConfigPath(kcPath)
+
+	kContext, err := cmd.Flags().GetString(context)
+	if err != nil {
+		return err
+	}
+	p.SetKubeContext(kContext)
 
 	// ensure that the config is valid by creating a client
 	if _, err := p.Clients(); err != nil {

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -22,11 +22,11 @@ import (
 )
 
 type Params struct {
-	ns, kc string
-	Tekton versioned.Interface
-	Kube   k8s.Interface
-	Clock  clockwork.Clock
-	Cls    *cli.Clients
+	ns, kConfig, kContext string
+	Tekton                versioned.Interface
+	Kube                  k8s.Interface
+	Clock                 clockwork.Clock
+	Cls                   *cli.Clients
 }
 
 var _ cli.Params = &Params{}
@@ -42,11 +42,15 @@ func (p *Params) SetNoColour(b bool) {
 }
 
 func (p *Params) SetKubeConfigPath(path string) {
-	p.kc = path
+	p.kConfig = path
+}
+
+func (p *Params) SetKubeContext(context string) {
+	p.kContext = context
 }
 
 func (p *Params) KubeConfigPath() string {
-	return p.kc
+	return p.kConfig
 }
 
 func (p *Params) tektonClient() (versioned.Interface, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes https://github.com/tektoncd/cli/issues/477
Allows the user to specify the kubecontext they would like to use the tekton cli in, given as an argument to the `--context` flag or its alias `-c`.
eg:
```
tkn pipelinerun yolo start --context homekube/kube:admin
tkn pipelinerun yolo start -c homekube/kube:admin

```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```