### PR TITLE
Fix failure in case of array param having single value

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -188,6 +188,7 @@ func (opt *startOptions) getInput(pname string) error {
 		}
 	}
 
+	params.FilterParamsByType(pipeline.Spec.Params)
 	if len(opt.Params) == 0 && !opt.Last {
 		if err = opt.getInputParams(pipeline); err != nil {
 			return err

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -72,9 +72,13 @@ func NameArg(args []string, p cli.Params) error {
 	}
 
 	name, ns := args[0], p.Namespace()
-	_, err = c.Tekton.TektonV1alpha1().Tasks(ns).Get(name, metav1.GetOptions{})
+	t, err := c.Tekton.TektonV1alpha1().Tasks(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf(errInvalidTask, name, ns)
+	}
+
+	if t.Spec.Inputs != nil {
+		params.FilterParamsByType(t.Spec.Inputs.Params)
 	}
 
 	return nil

--- a/pkg/helper/params/mergeparams.go
+++ b/pkg/helper/params/mergeparams.go
@@ -16,12 +16,15 @@ package params
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
 const invalidParam = "invalid input format for param parameter: "
+
+var paramByType = map[string]v1alpha1.ParamType{}
 
 func MergeParam(p []v1alpha1.Param, optPar []string) ([]v1alpha1.Param, error) {
 	params, err := parseParam(optPar)
@@ -40,10 +43,6 @@ func MergeParam(p []v1alpha1.Param, optPar []string) ([]v1alpha1.Param, error) {
 		}
 	}
 
-	for _, v := range params {
-		p = append(p, v)
-	}
-
 	return p, nil
 }
 
@@ -54,25 +53,36 @@ func parseParam(p []string) (map[string]v1alpha1.Param, error) {
 		if len(r) != 2 {
 			return nil, errors.New(invalidParam + v)
 		}
-		values := strings.Split(r[1], ",")
-		if len(values) == 1 {
-			params[r[0]] = v1alpha1.Param{
-				Name: r[0],
-				Value: v1alpha1.ArrayOrString{
-					Type:      v1alpha1.ParamTypeString,
-					StringVal: r[1],
-				},
-			}
+
+		if _, ok := paramByType[r[0]]; !ok {
+			return nil, fmt.Errorf("param '%s' not present in spec", r[0])
 		}
-		if len(values) > 1 {
-			params[r[0]] = v1alpha1.Param{
-				Name: r[0],
-				Value: v1alpha1.ArrayOrString{
-					Type:     v1alpha1.ParamTypeArray,
-					ArrayVal: values,
-				},
-			}
+
+		param := v1alpha1.Param{
+			Name: r[0],
+			Value: v1alpha1.ArrayOrString{
+				Type: paramByType[r[0]],
+			},
 		}
+
+		if paramByType[r[0]] == "string" {
+			param.Value.StringVal = r[1]
+		}
+
+		if paramByType[r[0]] == "array" {
+			param.Value.ArrayVal = strings.Split(r[1], ",")
+		}
+		params[r[0]] = param
 	}
 	return params, nil
+}
+
+func FilterParamsByType(params []v1alpha1.ParamSpec) {
+	for _, p := range params {
+		if p.Type == "string" {
+			paramByType[p.Name] = v1alpha1.ParamTypeString
+			continue
+		}
+		paramByType[p.Name] = v1alpha1.ParamTypeArray
+	}
 }


### PR DESCRIPTION
This will fix the issue of pipeline start or task start is
getting failed if the array type param is provided with one
value and string type value has comma in it

Also now it will throw error if the param not available in spec
will be passed

Add respective tests

Fix #468 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
