### PR TITLE
Making taskrun logs interactive.

### DIFF
--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -25,9 +25,10 @@ tkn taskrun logs -f foo -n bar
 ### Options
 
 ```
-  -a, --all      show all logs including init steps injected by tekton
-  -f, --follow   stream live logs
-  -h, --help     help for logs
+  -a, --all         show all logs including init steps injected by tekton
+  -f, --follow      stream live logs
+  -h, --help        help for logs
+      --limit int   lists number of taskruns (default 5)
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -31,6 +31,10 @@ Show taskruns logs
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for logs
 
+.PP
+\fB\-\-limit\fP=5
+    lists number of taskruns
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -245,7 +245,7 @@ func TestLogs_interactive_get_all_inputs(t *testing.T) {
 			cmdArgs: []string{},
 
 			procedure: func(c *goexpect.Console) error {
-				if _, err := c.ExpectString("Select pipeline :"); err != nil {
+				if _, err := c.ExpectString("Select pipeline:"); err != nil {
 					return err
 				}
 
@@ -261,7 +261,7 @@ func TestLogs_interactive_get_all_inputs(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Select pipelinerun :"); err != nil {
+				if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
 					return err
 				}
 
@@ -364,7 +364,7 @@ func TestLogs_interactive_ask_runs(t *testing.T) {
 			cmdArgs: []string{pipelineName},
 
 			procedure: func(c *goexpect.Console) error {
-				if _, err := c.ExpectString("Select pipelinerun :"); err != nil {
+				if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
 					return err
 				}
 
@@ -466,7 +466,7 @@ func TestLogs_interactive_limit_2(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Select pipelinerun :"); err != nil {
+				if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
 					return err
 				}
 
@@ -568,7 +568,7 @@ func TestLogs_interactive_limit_1(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Select pipelinerun :"); err != nil {
+				if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
 					return err
 				}
 
@@ -654,7 +654,7 @@ func TestLogs_interactive_ask_all_last_run(t *testing.T) {
 			cmdArgs: []string{},
 
 			procedure: func(c *goexpect.Console) error {
-				if _, err := c.ExpectString("Select pipeline :"); err != nil {
+				if _, err := c.ExpectString("Select pipeline:"); err != nil {
 					return err
 				}
 
@@ -670,7 +670,7 @@ func TestLogs_interactive_ask_all_last_run(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Select pipelinerun :"); err == nil {
+				if _, err := c.ExpectString("Select pipelinerun:"); err == nil {
 					return errors.New("unexpected error")
 				}
 

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -129,5 +129,5 @@ func askRunName(opts *options.LogOptions) error {
 		return nil
 	}
 
-	return opts.Ask("pipelinerun", prs)
+	return opts.Ask(options.ResourceNamePipelineRun, prs)
 }

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/flags"
 	"github.com/tektoncd/cli/pkg/helper/labels"
+	"github.com/tektoncd/cli/pkg/helper/options"
 	"github.com/tektoncd/cli/pkg/helper/params"
 	"github.com/tektoncd/cli/pkg/helper/task"
 	validate "github.com/tektoncd/cli/pkg/helper/validate"
@@ -244,14 +245,14 @@ func startTask(opt startOptions, args []string) error {
 	}
 
 	fmt.Fprintf(opt.stream.Out, "Waiting for logs to be available...\n")
-	runLogOpts := &taskrun.LogOptions{
+	runLogOpts := &options.LogOptions{
 		TaskrunName: trCreated.Name,
 		Stream:      opt.stream,
 		Follow:      true,
 		Params:      opt.cliparams,
 		AllSteps:    false,
 	}
-	return runLogOpts.Run()
+	return taskrun.Run(runLogOpts)
 }
 
 func mergeRes(r []v1alpha1.TaskResourceBinding, optRes []string) ([]v1alpha1.TaskResourceBinding, error) {

--- a/pkg/helper/options/logs.go
+++ b/pkg/helper/options/logs.go
@@ -28,6 +28,7 @@ import (
 const (
 	ResourceNamePipeline    = "pipeline"
 	ResourceNamePipelineRun = "pipelinerun"
+	ResourceNameTaskRun     = "taskrun"
 )
 
 type LogOptions struct {
@@ -36,6 +37,7 @@ type LogOptions struct {
 	Params          cli.Params
 	PipelineName    string
 	PipelineRunName string
+	TaskrunName     string
 	Stream          *cli.Stream
 	Streamer        stream.NewStreamerFunc
 	Tasks           []string
@@ -85,6 +87,8 @@ func (opts *LogOptions) Ask(resource string, options []string) error {
 		opts.PipelineName = ans
 	case ResourceNamePipelineRun:
 		opts.PipelineRunName = strings.Fields(ans)[0]
+	case ResourceNameTaskRun:
+		opts.TaskrunName = strings.Fields(ans)[0]
 	}
 
 	return nil

--- a/pkg/helper/options/logs.go
+++ b/pkg/helper/options/logs.go
@@ -72,7 +72,7 @@ func (opts *LogOptions) Ask(resource string, options []string) error {
 		{
 			Name: resource,
 			Prompt: &survey.Select{
-				Message: fmt.Sprintf("Select %s :", resource),
+				Message: fmt.Sprintf("Select %s:", resource),
 				Options: options,
 			},
 		},

--- a/pkg/helper/options/logs_test.go
+++ b/pkg/helper/options/logs_test.go
@@ -54,12 +54,12 @@ func TestLogOptions_ValidateOpts(t *testing.T) {
 			err := opts.ValidateOpts()
 			if tp.wantError {
 				if err == nil {
-					t.Errorf("error expected here")
+					t.Errorf("Error expected here")
 				}
 				test.AssertOutput(t, tp.want, err.Error())
 			} else {
 				if err != nil {
-					t.Errorf("unexpected Error")
+					t.Errorf("Unexpected error")
 				}
 			}
 		})
@@ -97,7 +97,7 @@ func TestLogOptions_Ask(t *testing.T) {
 			prompt: htest.PromptTest{
 				CmdArgs: []string{},
 				Procedure: func(c *goexpect.Console) error {
-					if _, err := c.ExpectString("Select pipeline :"); err != nil {
+					if _, err := c.ExpectString("Select pipeline:"); err != nil {
 						return err
 					}
 					if _, err := c.SendLine(options[0]); err != nil {
@@ -119,7 +119,7 @@ func TestLogOptions_Ask(t *testing.T) {
 			prompt: htest.PromptTest{
 				CmdArgs: []string{},
 				Procedure: func(c *goexpect.Console) error {
-					if _, err := c.ExpectString("Select pipelinerun :"); err != nil {
+					if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
 						return err
 					}
 					if _, err := c.SendLine(options2[0]); err != nil {
@@ -141,7 +141,7 @@ func TestLogOptions_Ask(t *testing.T) {
 			prompt: htest.PromptTest{
 				CmdArgs: []string{},
 				Procedure: func(c *goexpect.Console) error {
-					if _, err := c.ExpectString("Select taskrun :"); err != nil {
+					if _, err := c.ExpectString("Select taskrun:"); err != nil {
 						return err
 					}
 					if _, err := c.SendLine(options3[0]); err != nil {
@@ -167,13 +167,13 @@ func TestLogOptions_Ask(t *testing.T) {
 				return opts.Ask(tp.resource, tp.options)
 			})
 			if opts.PipelineName != tp.want.PipelineName {
-				t.Errorf("unexpected PipelineName")
+				t.Errorf("Unexpected Pipeline Name")
 			}
 			if opts.PipelineRunName != tp.want.PipelineRunName {
-				t.Errorf("unexpected PipelineRunName")
+				t.Errorf("Unexpected PipelineRun Name")
 			}
 			if opts.TaskrunName != tp.want.TaskrunName {
-				t.Errorf("unexpected TaskRunName")
+				t.Errorf("Unexpected TaskRun Name")
 			}
 		})
 	}

--- a/pkg/helper/options/logs_test.go
+++ b/pkg/helper/options/logs_test.go
@@ -78,6 +78,11 @@ func TestLogOptions_Ask(t *testing.T) {
 		"sample-pipeline-run2 started 2 minutes ago",
 		"sample-pipeline-run3 started 3 minutes ago",
 	}
+	options3 := []string{
+		"sample-task-run1 started 1 minutes ago",
+		"sample-task-run2 started 2 minutes ago",
+		"sample-task-run3 started 3 minutes ago",
+	}
 
 	testParams := []struct {
 		name     string
@@ -105,6 +110,7 @@ func TestLogOptions_Ask(t *testing.T) {
 			want: LogOptions{
 				PipelineName:    "pipeline1",
 				PipelineRunName: "",
+				TaskrunName:     "",
 			},
 		},
 		{
@@ -126,6 +132,29 @@ func TestLogOptions_Ask(t *testing.T) {
 			want: LogOptions{
 				PipelineName:    "",
 				PipelineRunName: "sample-pipeline-run1",
+				TaskrunName:     "",
+			},
+		},
+		{
+			name:     "select taskrun name",
+			resource: ResourceNameTaskRun,
+			prompt: htest.PromptTest{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select taskrun :"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options3[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options3,
+			want: LogOptions{
+				PipelineName:    "",
+				PipelineRunName: "",
+				TaskrunName:     "sample-task-run1",
 			},
 		},
 	}
@@ -142,6 +171,9 @@ func TestLogOptions_Ask(t *testing.T) {
 			}
 			if opts.PipelineRunName != tp.want.PipelineRunName {
 				t.Errorf("unexpected PipelineRunName")
+			}
+			if opts.TaskrunName != tp.want.TaskrunName {
+				t.Errorf("unexpected TaskRunName")
 			}
 		})
 	}

--- a/pkg/helper/taskrun/list/list.go
+++ b/pkg/helper/taskrun/list/list.go
@@ -1,0 +1,51 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/formatted"
+	trsort "github.com/tektoncd/cli/pkg/helper/taskrun/sort"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetAllTaskRuns(p cli.Params, opts metav1.ListOptions, limit int) ([]string, error) {
+	cs, err := p.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	runs, err := cs.Tekton.TektonV1alpha1().TaskRuns(p.Namespace()).List(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	runslen := len(runs.Items)
+	if runslen > 1 {
+		runs.Items = trsort.SortTaskRunsByStartTime(runs.Items)
+	}
+
+	if limit > runslen {
+		limit = runslen
+	}
+
+	ret := []string{}
+	for i, run := range runs.Items {
+		if i < limit {
+			ret = append(ret, run.ObjectMeta.Name+" started "+formatted.Age(run.Status.StartTime, p.Time()))
+		}
+	}
+	return ret, nil
+}

--- a/pkg/helper/taskrun/list/list_test.go
+++ b/pkg/helper/taskrun/list/list_test.go
@@ -104,7 +104,7 @@ func TestPipelinesList_GetAllTaskRuns(t *testing.T) {
 		t.Run(tp.name, func(t *testing.T) {
 			got, err := GetAllTaskRuns(tp.params, metav1.ListOptions{}, 5)
 			if err != nil {
-				t.Errorf("unexpected Error")
+				t.Errorf("Unexpected error")
 			}
 			test.AssertOutput(t, tp.want, got)
 		})

--- a/pkg/helper/taskrun/list/list_test.go
+++ b/pkg/helper/taskrun/list/list_test.go
@@ -1,0 +1,118 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinetest "github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+func TestPipelinesList_GetAllTaskRuns(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	trStarted := clock.Now().Add(10 * time.Second)
+	runDuration1 := 1 * time.Minute
+	runDuration2 := 1 * time.Minute
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		TaskRuns: []*v1alpha1.TaskRun{
+			tb.TaskRun("taskrun1", "ns",
+				tb.TaskRunLabel("tekton.dev/task", "task"),
+				tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
+				tb.TaskRunStatus(
+					tb.StatusCondition(apis.Condition{
+						Status: corev1.ConditionTrue,
+						Reason: resources.ReasonSucceeded,
+					}),
+					tb.TaskRunStartTime(trStarted),
+					taskRunCompletionTime(trStarted.Add(runDuration1)),
+				),
+			),
+			tb.TaskRun("taskrun2", "ns",
+				tb.TaskRunLabel("tekton.dev/task", "task"),
+				tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
+				tb.TaskRunStatus(
+					tb.StatusCondition(apis.Condition{
+						Status: corev1.ConditionTrue,
+						Reason: resources.ReasonSucceeded,
+					}),
+					tb.TaskRunStartTime(trStarted),
+					taskRunCompletionTime(trStarted.Add(runDuration2)),
+				),
+			),
+		},
+	})
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	p2 := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	p2.SetNamespace("unknown")
+
+	testParams := []struct {
+		name        string
+		params      *test.Params
+		listOptions metav1.ListOptions
+		want        []string
+	}{
+		{
+			name:        "Specify related task",
+			params:      p,
+			listOptions: metav1.ListOptions{LabelSelector: "tekton.dev/task=task"},
+			want: []string{
+				"taskrun1 started -10 seconds ago",
+				"taskrun2 started -10 seconds ago",
+			},
+		},
+		{
+			name:        "Not specify related task",
+			params:      p,
+			listOptions: metav1.ListOptions{},
+			want: []string{
+				"taskrun1 started -10 seconds ago",
+				"taskrun2 started -10 seconds ago",
+			},
+		},
+		{
+			name:        "Specify unknown namespace",
+			params:      p2,
+			listOptions: metav1.ListOptions{},
+			want:        []string{},
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			got, err := GetAllTaskRuns(tp.params, metav1.ListOptions{}, 5)
+			if err != nil {
+				t.Errorf("unexpected Error")
+			}
+			test.AssertOutput(t, tp.want, got)
+		})
+	}
+}
+
+func taskRunCompletionTime(ct time.Time) tb.TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.CompletionTime = &metav1.Time{Time: ct}
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related issue is https://github.com/tektoncd/cli/issues/263

adding interactive menu to taskrun logs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
taskrun logs will be interactive
```
