### PR TITLE
Remove Extra Space from TaskRun Not Found Error

### DIFF
--- a/pkg/cmd/taskrun/log_reader.go
+++ b/pkg/cmd/taskrun/log_reader.go
@@ -64,7 +64,7 @@ func (lr *LogReader) Read() (<-chan Log, <-chan error, error) {
 	tkn := lr.Clients.Tekton
 	tr, err := tkn.TektonV1alpha1().TaskRuns(lr.Ns).Get(lr.Run, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s : %s", msgTRNotFoundErr, err)
+		return nil, nil, fmt.Errorf("%s: %s", msgTRNotFoundErr, err)
 	}
 
 	lr.formTaskName(tr)

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -90,7 +90,7 @@ func TestLog_missing_taskrun(t *testing.T) {
 
 	c := Command(p)
 	got, _ := test.ExecuteCommand(c, "logs", "output-taskrun-2", "-n", "ns")
-	expected := "Error: " + msgTRNotFoundErr + " : taskruns.tekton.dev \"output-taskrun-2\" not found\n"
+	expected := "Error: " + msgTRNotFoundErr + ": taskruns.tekton.dev \"output-taskrun-2\" not found\n"
 	test.AssertOutput(t, expected, got)
 }
 


### PR DESCRIPTION
Removing unneeded space from taskrun logs.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

N/A
