### PR TITLE
Use serviceAccountName instead of serviceAccount

### DIFF
--- a/test/resources/output-pipelinerun.yaml
+++ b/test/resources/output-pipelinerun.yaml
@@ -109,7 +109,7 @@ metadata:
 spec:
   pipelineRef:
     name: output-pipeline
-  serviceAccount: 'default'
+  serviceAccountName: 'default'
   resources:
   - name: source-repo
     resourceRef:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`serviceAccount` is not working anmore since 0.9.x let's rename it to `serviceAccountName` as it should be™️

Closes #494

Related proper long term detection of those failures: #496 


/cc @vdemeester @hrishin @sthaha @danielhelfand