### PR TITLE
Add tkn resource create -f Option

### DIFF
--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -21,7 +21,7 @@ Manage pipeline resources
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn resource create](tkn_resource_create.md)	 - Creates pipeline resource
+* [tkn resource create](tkn_resource_create.md)	 - Create a pipeline resource in a namespace
 * [tkn resource delete](tkn_resource_delete.md)	 - Delete a pipeline resource in a namespace
 * [tkn resource describe](tkn_resource_describe.md)	 - Describes a pipeline resource in a namespace
 * [tkn resource list](tkn_resource_list.md)	 - Lists pipeline resources in a namespace

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -1,6 +1,6 @@
 ## tkn resource create
 
-Creates pipeline resource
+Create a pipeline resource in a namespace
 
 ### Usage
 
@@ -10,20 +10,25 @@ tkn resource create
 
 ### Synopsis
 
-Creates pipeline resource
+Create a pipeline resource in a namespace
 
 ### Examples
 
 
-  # creates new resource as per the given input
-    tkn resource create -n namespace
-
-   
+  # Creates new PipelineResource as per the given input
+	tkn resource create -n namespace
+	
+  # Create a PipelineResource defined by foo.yaml in namespace 'bar'
+	tkn resource create -f foo.yaml -n bar
 
 ### Options
 
 ```
-  -h, --help   help for create
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -f, --from string                   local or remote filename to use to create the pipeline resource
+  -h, --help                          help for create
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-resource-create.1
+++ b/docs/man/man1/tkn-resource-create.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-resource\-create \- Creates pipeline resource
+tkn\-resource\-create \- Create a pipeline resource in a namespace
 
 
 .SH SYNOPSIS
@@ -15,13 +15,30 @@ tkn\-resource\-create \- Creates pipeline resource
 
 .SH DESCRIPTION
 .PP
-Creates pipeline resource
+Create a pipeline resource in a namespace
 
 
 .SH OPTIONS
 .PP
+\fB\-\-allow\-missing\-template\-keys\fP[=true]
+    If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
+
+.PP
+\fB\-f\fP, \fB\-\-from\fP=""
+    local or remote filename to use to create the pipeline resource
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for create
+
+.PP
+\fB\-o\fP, \fB\-\-output\fP=""
+    Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
+
+.PP
+\fB\-\-template\fP=""
+    Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
+\[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -44,8 +61,12 @@ Creates pipeline resource
 
 .SH EXAMPLE
 .PP
-# creates new resource as per the given input
+# Creates new PipelineResource as per the given input
     tkn resource create \-n namespace
+
+.PP
+# Create a PipelineResource defined by foo.yaml in namespace 'bar'
+    tkn resource create \-f foo.yaml \-n bar
 
 
 .SH SEE ALSO

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -17,6 +17,7 @@ package pipelineresource
 import (
 	"bytes"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/core"
@@ -1606,6 +1607,98 @@ func TestPipelineResource_create_buildGCSstorageResource(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			res.RunPromptTest(t, test)
+		})
+	}
+}
+
+func Test_Pipeline_Resource_Create(t *testing.T) {
+
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	seeds := make([]pipelinetest.Clients, 0)
+	for i := 0; i < 1; i++ {
+		cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+		seeds = append(seeds, cs)
+	}
+
+	testParams := []struct {
+		name        string
+		command     []string
+		input       pipelinetest.Clients
+		inputStream io.Reader
+		wantError   bool
+		want        string
+	}{
+		{
+			name:        "Create pipeline resource successfully",
+			command:     []string{"create", "--from", "./testdata/pipelineresource.yaml", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   false,
+			want:        "PipelineResource created: test-resource\n",
+		},
+		{
+			name:        "Filename does not exist",
+			command:     []string{"create", "-f", "./testdata/notexist.yaml", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "open ./testdata/notexist.yaml: no such file or directory",
+		},
+		{
+			name:        "Unsupported file type",
+			command:     []string{"create", "-f", "./testdata/pipelineresource.txt", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "inavlid file format for ./testdata/pipelineresource.txt: .yaml or .yml file extension and format required",
+		},
+		{
+			name:        "Mismatched resource file",
+			command:     []string{"create", "-f", "./testdata/pipelinerun.yaml", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "provided kind PipelineRun instead of kind PipelineResource",
+		},
+		{
+			name:        "Existing pipeline",
+			command:     []string{"create", "-f", "./testdata/pipelineresource.yaml", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "failed to create pipeline resource \"test-resource\": pipelineresources.tekton.dev \"test-resource\" already exists",
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			p := &test.Params{Tekton: tp.input.Pipeline, Kube: tp.input.Kube}
+			resource := Command(p)
+
+			if tp.inputStream != nil {
+				resource.SetIn(tp.inputStream)
+			}
+
+			out, err := test.ExecuteCommand(resource, tp.command...)
+			if tp.wantError {
+				if err == nil {
+					t.Errorf("Error expected here")
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error")
+				}
+				test.AssertOutput(t, tp.want, out)
+			}
 		})
 	}
 }

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -32,9 +32,8 @@ type promptTest struct {
 
 func (res *Resource) RunPromptTest(t *testing.T, test promptTest) {
 	test.runTest(t, test.procedure, func(stdio terminal.Stdio) error {
-		var err error
 		res.AskOpts = WithStdio(stdio)
-		err = res.create()
+		err := res.createInteractive()
 		if err != nil {
 			if err.Error() == "resource already exist" {
 				return nil

--- a/pkg/cmd/pipelineresource/testdata/pipelineresource.yaml
+++ b/pkg/cmd/pipelineresource/testdata/pipelineresource.yaml
@@ -1,0 +1,24 @@
+# Copyright © 2019 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: test-resource
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/GoogleContainerTools/skaffold

--- a/pkg/cmd/pipelineresource/testdata/pipelinerun.yaml
+++ b/pkg/cmd/pipelineresource/testdata/pipelinerun.yaml
@@ -1,0 +1,28 @@
+# Copyright © 2019 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: tutorial-pipeline-run-1
+spec:
+  serviceAccountName: tutorial-service
+  pipelineRef:
+    name: tutorial-pipeline
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: skaffold-git
+    - name: web-image
+      resourceRef:
+        name: skaffold-image-leeroy-web


### PR DESCRIPTION
Closes #192 

This pull request adds a `tkn resource create -f` option to create pipeline resources via a file definition. It draws a lot of its design from #265 and #492 and #502. 

This implementation only supports YAML. It can create a pipeline resource via a definition defined in a local or remote file. 

Usage:

Local file:
`tkn resource create -f localfile.yaml`

Remote file:
`tkn resource create -f https://foo.com/remotefile.yaml`

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adding tkn resource create -f option to create pipeline resources
```
