### PR TITLE
Add Namespace Check to Pipeline and Task Create Commands

### DIFF
--- a/pkg/cmd/pipeline/create.go
+++ b/pkg/cmd/pipeline/create.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/helper/file"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -51,6 +51,10 @@ tkn pipeline create -f foo.yaml -n bar
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
+			}
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
 			}
 
 			return createPipeline(s, p, opts.from)

--- a/pkg/cmd/pipeline/create_test.go
+++ b/pkg/cmd/pipeline/create_test.go
@@ -49,6 +49,14 @@ func Test_Pipeline_Create(t *testing.T) {
 		want        string
 	}{
 		{
+			name:        "Invalid namespace",
+			command:     []string{"create", "--from", "./testdata/pipeline.yaml", "-n", "invalid"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "namespaces \"invalid\" not found",
+		},
+		{
 			name:        "Create pipeline successfully",
 			command:     []string{"create", "--from", "./testdata/pipeline.yaml", "-n", "ns"},
 			input:       seeds[0],

--- a/pkg/cmd/task/create.go
+++ b/pkg/cmd/task/create.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/helper/file"
+	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -51,6 +51,10 @@ tkn task create -f foo.yaml -n bar
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
+			}
+
+			if err := validate.NamespaceExists(p); err != nil {
+				return err
 			}
 
 			return createTask(s, p, opts.from)

--- a/pkg/cmd/task/create_test.go
+++ b/pkg/cmd/task/create_test.go
@@ -49,6 +49,14 @@ func Test_Task_Create(t *testing.T) {
 		want        string
 	}{
 		{
+			name:        "Invalid namespace",
+			command:     []string{"create", "--from", "./testdata/task.yaml", "-n", "invalid"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   true,
+			want:        "namespaces \"invalid\" not found",
+		},
+		{
 			name:        "Create task successfully",
 			command:     []string{"create", "--from", "./testdata/task.yaml", "-n", "ns"},
 			input:       seeds[0],


### PR DESCRIPTION
Adding a check whether a namespace exists for pipeline and task create commands. They weren't introduced as part of #492 or #502 so adding them here.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add namespace check for tkn pipeline create -f and tkn task create -f
```
