### PR TITLE
Fix input params are not respected

### DIFF
--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -195,6 +195,8 @@ func Test_start_pipeline(t *testing.T) {
 		t.Errorf("Error pipelinerun generated is different %+v", pr)
 	}
 
+	test.AssertOutput(t, 2, len(pr.Items[0].Spec.Params))
+
 	for _, v := range pr.Items[0].Spec.Params {
 		if v.Name == "rev-param" {
 			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeArray, ArrayVal: []string{"cat", "foo", "bar"}}, v.Value)
@@ -429,6 +431,7 @@ func Test_start_pipeline_last(t *testing.T) {
 		}
 	}
 
+	test.AssertOutput(t, 2, len(pr.Spec.Params))
 	for _, v := range pr.Spec.Params {
 		if v.Name == "rev-param" {
 			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: "revision2"}, v.Value)
@@ -511,6 +514,8 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 			test.AssertOutput(t, "some-repo", v.ResourceRef.Name)
 		}
 	}
+
+	test.AssertOutput(t, 2, len(pr.Spec.Params))
 
 	for _, v := range pr.Spec.Params {
 		if v.Name == "rev-param" {
@@ -602,6 +607,8 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 		}
 	}
 
+	test.AssertOutput(t, 2, len(pr.Spec.Params))
+
 	for _, v := range pr.Spec.Params {
 		if v.Name == "rev-param" {
 			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: "revision2"}, v.Value)
@@ -670,6 +677,7 @@ func Test_start_pipeline_allkindparam(t *testing.T) {
 		t.Errorf("Error pipelinerun generated is different %+v", pr)
 	}
 
+	test.AssertOutput(t, 3, len(pr.Items[0].Spec.Params))
 	for _, v := range pr.Items[0].Spec.Params {
 		if v.Name == "rev-param" {
 			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeArray, ArrayVal: []string{"cat", "foo", "bar"}}, v.Value)

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -224,6 +224,8 @@ func Test_start_task(t *testing.T) {
 		}
 	}
 
+	test.AssertOutput(t, 2, len(tr.Items[0].Spec.Inputs.Params))
+
 	for _, v := range tr.Items[0].Spec.Inputs.Params {
 		if v.Name == "my-arg" {
 			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: "value1"}, v.Value)
@@ -318,6 +320,8 @@ func Test_start_task_last(t *testing.T) {
 			test.AssertOutput(t, "git", v.ResourceRef.Name)
 		}
 	}
+
+	test.AssertOutput(t, 2, len(tr.Spec.Inputs.Params))
 
 	for _, v := range tr.Spec.Inputs.Params {
 		if v.Name == "my-arg" {
@@ -414,6 +418,8 @@ func Test_start_task_last_with_inputs(t *testing.T) {
 			test.AssertOutput(t, "git-new", v.ResourceRef.Name)
 		}
 	}
+
+	test.AssertOutput(t, 2, len(tr.Spec.Inputs.Params))
 
 	for _, v := range tr.Spec.Inputs.Params {
 		if v.Name == "my-arg" {
@@ -730,6 +736,8 @@ func Test_start_task_allkindparam(t *testing.T) {
 			test.AssertOutput(t, "image", v.ResourceRef.Name)
 		}
 	}
+
+	test.AssertOutput(t, 3, len(tr.Items[0].Spec.Inputs.Params))
 
 	for _, v := range tr.Items[0].Spec.Inputs.Params {
 		if v.Name == "my-arg" {

--- a/pkg/helper/params/mergeparams.go
+++ b/pkg/helper/params/mergeparams.go
@@ -43,6 +43,10 @@ func MergeParam(p []v1alpha1.Param, optPar []string) ([]v1alpha1.Param, error) {
 		}
 	}
 
+	for _, v := range params {
+		p = append(p, v)
+	}
+
 	return p, nil
 }
 


### PR DESCRIPTION
This will fix the issue of params not getting added
to taskrun or pipelinerun in case of task start
or pipeline start respectively.

We are looping through params to assert in test
but as they are empty not assert was performed
and test passes

Adds a check of param length also in tests

Fix #511

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
