### PR TITLE
Change NFPM package name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,7 +59,7 @@ brews:
       (zsh_completion/"_tkn").write output
       prefix.install_metafiles
 nfpms:
-  - file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  - file_name_template: "tektoncd-cli-{{.Version}}_{{.Os}}-{{.Arch}}"
     homepage: https://github.com/tektoncd/cli/
     description: A command line interface for interacting with Tekton
     maintainer: Tekton Developers <tekton@tekton.dev>


### PR DESCRIPTION
CHange NFPM package name producted from something like :

cli_0.6.0_Linux-64bit.rpm

to

tektoncd-cli-0.6.0_Linux-64bit.rpm

which is more standard,

we would need to change the README links at the next release but that should not
affect the user.



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```