### PR TITLE
Test for tkn task start --filename

### DIFF
--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -146,8 +146,7 @@ like cat,foo,bar
 	return c
 }
 
-// Setting as var for stubbing in tests
-var parseTask = func(p string) (*v1alpha1.Task, error) {
+func parseTask(p string) (*v1alpha1.Task, error) {
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -111,17 +111,13 @@ func Test_start_has_task_filename(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
 	c := Command(&test.Params{Tekton: cs.Pipeline, Kube: cs.Kube})
 
-	oldParseTask := parseTask
-	defer func() {
-		parseTask = oldParseTask
-	}()
-	parseTask = func(p string) (*v1alpha1.Task, error) {
-		return tb.Task("task", "ns"), nil
-	}
-	_, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=foo", "--showlog=false")
+	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task.yaml", "--showlog=false")
 	if err != nil {
-		t.Errorf("Not expecting an error, but got %s", err)
+		t.Errorf("Not expecting an error, but got %s", err.Error())
 	}
+
+	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	test.AssertOutput(t, expected, got)
 }
 
 func Test_start_task_not_found(t *testing.T) {


### PR DESCRIPTION
Closes #489 

With `testdata/task.yaml` available for `tkn task` commands, we should have a unit test that works with the actual code we use in the CLI for our testing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

N/A
