### PR TITLE
Attempt to fix formatting of examples

### DIFF
--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -16,11 +16,13 @@ Delete a clustertask resource in a cluster
 
 ### Examples
 
+Delete a ClusterTask of name 'foo':
 
-# Delete a ClusterTask of name 'foo'
-tkn clustertask delete foo
+    tkn clustertask delete foo
 
-tkn ct rm foo
+or
+
+    tkn ct rm foo
 
 
 ### Options

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -16,11 +16,13 @@ Delete a condition in a namespace
 
 ### Examples
 
+Delete a Condition of name 'foo' in namespace 'bar':
 
-# Delete a Condition of name 'foo' in namespace 'bar'
-tkn condition delete foo -n bar
+    tkn condition delete foo -n bar
 
-tkn cond rm foo -n bar
+or
+
+    tkn cond rm foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_pipeline_create.md
+++ b/docs/cmd/tkn_pipeline_create.md
@@ -14,9 +14,9 @@ Create a pipeline in a namespace
 
 ### Examples
 
+Create a Pipeline defined by foo.yaml in namespace 'bar':
 
-# Create a Pipeline defined by foo.yaml in namespace 'bar'
-tkn pipeline create -f foo.yaml -n bar
+    tkn pipeline create -f foo.yaml -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -16,11 +16,13 @@ Delete a pipeline in a namespace
 
 ### Examples
 
+Delete a Pipeline of name 'foo' in namespace 'bar'
 
-# Delete a Pipeline of name 'foo' in namespace 'bar'
-tkn pipeline delete foo -n bar
+    tkn pipeline delete foo -n bar
 
-tkn p rm foo -n bar
+or
+
+    tkn p rm foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -15,19 +15,22 @@ Show pipeline logs
 ### Examples
 
 
-  # interactive mode: shows logs of the selected pipeline run
+Interactive mode: shows logs of the selected pipelinerun:
+
     tkn pipeline logs -n namespace
 
-  # interactive mode: shows logs of the selected pipelinerun of the given pipeline
+Interactive mode: shows logs of the selected pipelinerun of the given pipeline:
+
     tkn pipeline logs pipeline -n namespace
 
-  # show logs of given pipeline for last run
+Show logs of given pipeline for last run:
+
     tkn pipeline logs pipeline -n namespace --last
 
-  # show logs for given pipeline and pipelinerun
+Show logs for given pipeline and pipelinerun:
+
     tkn pipeline logs pipeline run -n namespace
 
-   
 
 ### Options
 

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -14,10 +14,10 @@ Cancel the PipelineRun
 
 ### Examples
 
+Cancel the PipelineRun named 'foo' from namespace 'bar':
 
-  # cancel the PipelineRun named "foo" from the namespace "bar"
     tkn pipelinerun cancel foo -n bar
-   
+
 
 ### Options
 

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -16,11 +16,13 @@ Delete a pipelinerun in a namespace
 
 ### Examples
 
+Delete a PipelineRun of name 'foo' in namespace 'bar':
 
-# Delete a PipelineRun of name 'foo' in namespace 'bar'
-tkn pipelinerun delete foo -n bar
+    tkn pipelinerun delete foo -n bar
 
-tkn pr rm foo -n bar
+or
+
+    tkn pr rm foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -16,11 +16,13 @@ Describe a pipelinerun in a namespace
 
 ### Examples
 
+Describe a PipelineRun of name 'foo' in namespace 'bar':
 
-# Describe a PipelineRun of name 'foo' in namespace 'bar'
-tkn pipelinerun describe foo -n bar
+    tkn pipelinerun describe foo -n bar
 
-tkn pr desc foo -n bar
+or
+
+    tkn pr desc foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -16,12 +16,13 @@ Lists pipelineruns in a namespace
 
 ### Examples
 
+List all PipelineRuns of Pipeline 'foo':
 
-# List all PipelineRuns of Pipeline name 'foo'
-tkn pipelinerun list foo -n bar
+    tkn pipelinerun list foo -n bar
 
-# List all pipelineruns in a namespaces 'foo'
-tkn pr list -n foo
+List all PipelineRuns in a namespace 'foo':
+
+    tkn pr list -n foo
 
 
 ### Options

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -14,15 +14,16 @@ Show the logs of PipelineRun
 
 ### Examples
 
+Show the logs of PipelineRun named 'foo' from namespace 'bar':
 
-  # show the logs of PipelineRun named "foo" from the namesspace "bar"
     tkn pipelinerun logs foo -n bar
 
-  # show the logs of PipelineRun named "microservice-1" for task "build" only, from the namespace "bar"
+Show the logs of PipelineRun named 'microservice-1' for task 'build' only from namespace 'bar':
+
     tkn pr logs microservice-1 -t build -n bar
 
-  # show the logs of PipelineRun named "microservice-1" for all tasks and steps (including init steps),
-    from the namespace "foo"
+Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (including init steps) from namespace 'foo':
+
     tkn pr logs microservice-1 -a -n foo
    
 

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -14,12 +14,14 @@ Create a pipeline resource in a namespace
 
 ### Examples
 
+Creates new PipelineResource as per the given input:
 
-  # Creates new PipelineResource as per the given input
-	tkn resource create -n namespace
-	
-  # Create a PipelineResource defined by foo.yaml in namespace 'bar'
-	tkn resource create -f foo.yaml -n bar
+    tkn resource create -n namespace
+
+Create a PipelineResource defined by foo.yaml in namespace 'bar':
+
+    tkn resource create -f foo.yaml -n bar
+
 
 ### Options
 

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -16,11 +16,13 @@ Delete a pipeline resource in a namespace
 
 ### Examples
 
+Delete a PipelineResource of name 'foo' in namespace 'bar':
 
-# Delete a PipelineResource of name 'foo' in namespace 'bar'
-tkn resource delete foo -n bar
+    tkn resource delete foo -n bar
 
-tkn res rm foo -n bar
+or
+
+    tkn res rm foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_resource_describe.md
+++ b/docs/cmd/tkn_resource_describe.md
@@ -16,11 +16,13 @@ Describes a pipeline resource in a namespace
 
 ### Examples
 
+Describe a PipelineResource of name 'foo' in namespace 'bar':
 
-# Describe a PipelineResource of name 'foo' in namespace 'bar'
-tkn resource describe foo -n bar
+    tkn resource describe foo -n bar
 
-tkn res desc foo -n bar
+or
+
+    tkn res desc foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -16,9 +16,9 @@ Lists pipeline resources in a namespace
 
 ### Examples
 
+List all PipelineResources in a namespace 'foo':
 
-# List all PipelineResources in a namespaces 'foo'
-tkn pre list -n foo
+    tkn pre list -n foo
 
 
 ### Options

--- a/docs/cmd/tkn_task_create.md
+++ b/docs/cmd/tkn_task_create.md
@@ -14,9 +14,9 @@ Create a task in a namespace
 
 ### Examples
 
+Create a Task defined by foo.yaml in namespace 'bar':
 
-# Create a Task defined by foo.yaml in namespace 'bar'
-tkn task create -f foo.yaml -n bar
+    tkn task create -f foo.yaml -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -16,11 +16,13 @@ Delete a task resource in a namespace
 
 ### Examples
 
+Delete a Task of name 'foo' in namespace 'bar':
 
-# Delete a Task of name 'foo' in namespace 'bar'
-tkn task delete foo -n bar
+    tkn task delete foo -n bar
 
-tkn t rm foo -n bar
+or
+
+    tkn t rm foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_task_describe.md
+++ b/docs/cmd/tkn_task_describe.md
@@ -16,11 +16,13 @@ Describes a task in a namespace
 
 ### Examples
 
+Describe a Task of name 'foo' in namespace 'bar':
 
-# Describe a task of name 'foo' in namespace 'bar'
-tkn task describe foo -n bar
+    tkn task describe foo -n bar
 
-tkn t desc foo -n bar
+or
+
+   tkn t desc foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_task_logs.md
+++ b/docs/cmd/tkn_task_logs.md
@@ -14,20 +14,22 @@ Show task logs
 
 ### Examples
 
+Interactive mode: shows logs of the selected TaskRun:
 
-  # interactive mode: shows logs of the selected taskrun
     tkn task logs -n namespace
 
-  # interactive mode: shows logs of the selected taskrun of the given task
+Interactive mode: shows logs of the selected TaskRun of the given Task:
+
     tkn task logs task -n namespace
 
-  # show logs of given task for last taskrun
+Show logs of given Task for last TaskRun:
+
     tkn task logs task -n namespace --last
 
-  # show logs for given task and taskrun
+Show logs for given task and taskrun:
+
     tkn task logs task taskrun -n namespace
 
-   
 
 ### Options
 

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -16,11 +16,11 @@ Start tasks
 
 ### Examples
 
+Start Task foo by creating a TaskRun named "foo-run-xyz123" from namespace 'bar':
 
-# start task foo by creating a taskrun named "foo-run-xyz123" from the namespace "bar"
-tkn task start foo -s ServiceAccountName -n bar
+    tkn task start foo -s ServiceAccountName -n bar
 
-The task can either be specified by reference in a cluster using the positional argument
+The rask can either be specified by reference in a cluster using the positional argument
 or in a file using the --filename argument.
 
 For params value, if you want to provide multiple values, provide them comma separated

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -24,6 +24,6 @@ Manage taskruns
 * [tkn taskrun cancel](tkn_taskrun_cancel.md)	 - Cancel a taskrun in a namespace
 * [tkn taskrun delete](tkn_taskrun_delete.md)	 - Delete a taskrun in a namespace
 * [tkn taskrun describe](tkn_taskrun_describe.md)	 - Describe a taskrun in a namespace
-* [tkn taskrun list](tkn_taskrun_list.md)	 - Lists taskruns in a namespace
+* [tkn taskrun list](tkn_taskrun_list.md)	 - Lists TaskRuns in a namespace
 * [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show taskruns logs
 

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -14,9 +14,9 @@ Cancel a taskrun in a namespace
 
 ### Examples
 
+Cancel the TaskRun named 'foo' from the namespace 'bar':
 
-# Cancel the TaskRun named "foo" from the namespace "bar"
-tkn taskrun cancel foo -n bar
+    tkn taskrun cancel foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -16,11 +16,13 @@ Delete a taskrun in a namespace
 
 ### Examples
 
+Delete a TaskRun of name 'foo' in namespace 'bar':
 
-# Delete a TaskRun of name 'foo' in namespace 'bar'
-tkn taskrun delete foo -n bar
+    tkn taskrun delete foo -n bar
 
-tkn tr rm foo -n bar
+or
+
+    tkn tr rm foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -16,11 +16,13 @@ Describe a taskrun in a namespace
 
 ### Examples
 
+Describe a TaskRun of name 'foo' in namespace 'bar':
 
-# Describe a TaskRun of name 'foo' in namespace 'bar'
-tkn taskrun describe foo -n bar
+    tkn taskrun describe foo -n bar
 
-tkn tr desc foo -n bar
+or
+
+    tkn tr desc foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -1,6 +1,6 @@
 ## tkn taskrun list
 
-Lists taskruns in a namespace
+Lists TaskRuns in a namespace
 
 ***Aliases**: ls*
 
@@ -12,16 +12,17 @@ tkn taskrun list
 
 ### Synopsis
 
-Lists taskruns in a namespace
+Lists TaskRuns in a namespace
 
 ### Examples
 
+List all TaskRuns in namespace 'bar':
 
-# List all taskruns in namespace 'bar'
-tkn tr list -n bar
+    tkn tr list -n bar
 
-# List all taskruns of task 'foo' in namespace 'bar'
-tkn taskrun list foo -n bar
+List all TaskRuns of Task 'foo' in namespace 'bar':
+
+    tkn taskrun list foo -n bar
 
 
 ### Options

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -14,12 +14,13 @@ Show taskruns logs
 
 ### Examples
 
+Show the logs of TaskRun named 'foo' from the namespace 'bar':
 
-# show the logs of TaskRun named "foo" from the namespace "bar"
-tkn taskrun logs foo -n bar
+    tkn taskrun logs foo -n bar
 
-# show the live logs of TaskRun named "foo" from the namespace "bar"
-tkn taskrun logs -f foo -n bar
+Show the live logs of TaskRun named 'foo' from namespace 'bar':
+
+    tkn taskrun logs -f foo -n bar
 
 
 ### Options

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -60,13 +60,29 @@ Delete a clustertask resource in a cluster
 
 
 .SH EXAMPLE
-
-.SH Delete a ClusterTask of name 'foo'
 .PP
+Delete a ClusterTask of name 'foo':
+
+.PP
+.RS
+
+.nf
 tkn clustertask delete foo
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn ct rm foo
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -60,13 +60,29 @@ Delete a condition in a namespace
 
 
 .SH EXAMPLE
-
-.SH Delete a Condition of name 'foo' in namespace 'bar'
 .PP
+Delete a Condition of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn condition delete foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn cond rm foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-create.1
+++ b/docs/man/man1/tkn-pipeline-create.1
@@ -60,10 +60,17 @@ Create a pipeline in a namespace
 
 
 .SH EXAMPLE
-
-.SH Create a Pipeline defined by foo.yaml in namespace 'bar'
 .PP
+Create a Pipeline defined by foo.yaml in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn pipeline create \-f foo.yaml \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -64,13 +64,29 @@ Delete a pipeline in a namespace
 
 
 .SH EXAMPLE
-
-.SH Delete a Pipeline of name 'foo' in namespace 'bar'
 .PP
+Delete a Pipeline of name 'foo' in namespace 'bar'
+
+.PP
+.RS
+
+.nf
 tkn pipeline delete foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn p rm foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -60,20 +60,52 @@ Show pipeline logs
 
 .SH EXAMPLE
 .PP
-# interactive mode: shows logs of the selected pipeline run
-    tkn pipeline logs \-n namespace
+Interactive mode: shows logs of the selected pipelinerun:
 
 .PP
-# interactive mode: shows logs of the selected pipelinerun of the given pipeline
-    tkn pipeline logs pipeline \-n namespace
+.RS
+
+.nf
+tkn pipeline logs \-n namespace
+
+.fi
+.RE
 
 .PP
-# show logs of given pipeline for last run
-    tkn pipeline logs pipeline \-n namespace \-\-last
+Interactive mode: shows logs of the selected pipelinerun of the given pipeline:
 
 .PP
-# show logs for given pipeline and pipelinerun
-    tkn pipeline logs pipeline run \-n namespace
+.RS
+
+.nf
+tkn pipeline logs pipeline \-n namespace
+
+.fi
+.RE
+
+.PP
+Show logs of given pipeline for last run:
+
+.PP
+.RS
+
+.nf
+tkn pipeline logs pipeline \-n namespace \-\-last
+
+.fi
+.RE
+
+.PP
+Show logs for given pipeline and pipelinerun:
+
+.PP
+.RS
+
+.nf
+tkn pipeline logs pipeline run \-n namespace
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -44,8 +44,16 @@ Cancel the PipelineRun
 
 .SH EXAMPLE
 .PP
-# cancel the PipelineRun named "foo" from the namespace "bar"
-    tkn pipelinerun cancel foo \-n bar
+Cancel the PipelineRun named 'foo' from namespace 'bar':
+
+.PP
+.RS
+
+.nf
+tkn pipelinerun cancel foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -60,13 +60,29 @@ Delete a pipelinerun in a namespace
 
 
 .SH EXAMPLE
-
-.SH Delete a PipelineRun of name 'foo' in namespace 'bar'
 .PP
+Delete a PipelineRun of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn pipelinerun delete foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn pr rm foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -56,13 +56,29 @@ Describe a pipelinerun in a namespace
 
 
 .SH EXAMPLE
-
-.SH Describe a PipelineRun of name 'foo' in namespace 'bar'
 .PP
+Describe a PipelineRun of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn pipelinerun describe foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn pr desc foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -60,15 +60,29 @@ Lists pipelineruns in a namespace
 
 
 .SH EXAMPLE
-
-.SH List all PipelineRuns of Pipeline name 'foo'
 .PP
+List all PipelineRuns of Pipeline 'foo':
+
+.PP
+.RS
+
+.nf
 tkn pipelinerun list foo \-n bar
 
+.fi
+.RE
 
-.SH List all pipelineruns in a namespaces 'foo'
 .PP
+List all PipelineRuns in a namespace 'foo':
+
+.PP
+.RS
+
+.nf
 tkn pr list \-n foo
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -60,17 +60,40 @@ Show the logs of PipelineRun
 
 .SH EXAMPLE
 .PP
-# show the logs of PipelineRun named "foo" from the namesspace "bar"
-    tkn pipelinerun logs foo \-n bar
+Show the logs of PipelineRun named 'foo' from namespace 'bar':
 
 .PP
-# show the logs of PipelineRun named "microservice\-1" for task "build" only, from the namespace "bar"
-    tkn pr logs microservice\-1 \-t build \-n bar
+.RS
+
+.nf
+tkn pipelinerun logs foo \-n bar
+
+.fi
+.RE
 
 .PP
-# show the logs of PipelineRun named "microservice\-1" for all tasks and steps (including init steps),
-    from the namespace "foo"
-    tkn pr logs microservice\-1 \-a \-n foo
+Show the logs of PipelineRun named 'microservice\-1' for task 'build' only from namespace 'bar':
+
+.PP
+.RS
+
+.nf
+tkn pr logs microservice\-1 \-t build \-n bar
+
+.fi
+.RE
+
+.PP
+Show the logs of PipelineRun named 'microservice\-1' for all tasks and steps (including init steps) from namespace 'foo':
+
+.PP
+.RS
+
+.nf
+tkn pr logs microservice\-1 \-a \-n foo
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-resource-create.1
+++ b/docs/man/man1/tkn-resource-create.1
@@ -61,12 +61,28 @@ Create a pipeline resource in a namespace
 
 .SH EXAMPLE
 .PP
-# Creates new PipelineResource as per the given input
-    tkn resource create \-n namespace
+Creates new PipelineResource as per the given input:
 
 .PP
-# Create a PipelineResource defined by foo.yaml in namespace 'bar'
-    tkn resource create \-f foo.yaml \-n bar
+.RS
+
+.nf
+tkn resource create \-n namespace
+
+.fi
+.RE
+
+.PP
+Create a PipelineResource defined by foo.yaml in namespace 'bar':
+
+.PP
+.RS
+
+.nf
+tkn resource create \-f foo.yaml \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -60,13 +60,29 @@ Delete a pipeline resource in a namespace
 
 
 .SH EXAMPLE
-
-.SH Delete a PipelineResource of name 'foo' in namespace 'bar'
 .PP
+Delete a PipelineResource of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn resource delete foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn res rm foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-resource-describe.1
+++ b/docs/man/man1/tkn-resource-describe.1
@@ -56,13 +56,29 @@ Describes a pipeline resource in a namespace
 
 
 .SH EXAMPLE
-
-.SH Describe a PipelineResource of name 'foo' in namespace 'bar'
 .PP
+Describe a PipelineResource of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn resource describe foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn res desc foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-resource-list.1
+++ b/docs/man/man1/tkn-resource-list.1
@@ -60,10 +60,17 @@ Lists pipeline resources in a namespace
 
 
 .SH EXAMPLE
-
-.SH List all PipelineResources in a namespaces 'foo'
 .PP
+List all PipelineResources in a namespace 'foo':
+
+.PP
+.RS
+
+.nf
 tkn pre list \-n foo
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-create.1
+++ b/docs/man/man1/tkn-task-create.1
@@ -60,10 +60,17 @@ Create a task in a namespace
 
 
 .SH EXAMPLE
-
-.SH Create a Task defined by foo.yaml in namespace 'bar'
 .PP
+Create a Task defined by foo.yaml in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn task create \-f foo.yaml \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -64,13 +64,29 @@ Delete a task resource in a namespace
 
 
 .SH EXAMPLE
-
-.SH Delete a Task of name 'foo' in namespace 'bar'
 .PP
+Delete a Task of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn task delete foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn t rm foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-describe.1
+++ b/docs/man/man1/tkn-task-describe.1
@@ -56,10 +56,20 @@ Describes a task in a namespace
 
 
 .SH EXAMPLE
-
-.SH Describe a task of name 'foo' in namespace 'bar'
 .PP
+Describe a Task of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn task describe foo \-n bar
+
+.fi
+.RE
+
+.PP
+or
 
 .PP
 tkn t desc foo \-n bar

--- a/docs/man/man1/tkn-task-logs.1
+++ b/docs/man/man1/tkn-task-logs.1
@@ -60,20 +60,52 @@ Show task logs
 
 .SH EXAMPLE
 .PP
-# interactive mode: shows logs of the selected taskrun
-    tkn task logs \-n namespace
+Interactive mode: shows logs of the selected TaskRun:
 
 .PP
-# interactive mode: shows logs of the selected taskrun of the given task
-    tkn task logs task \-n namespace
+.RS
+
+.nf
+tkn task logs \-n namespace
+
+.fi
+.RE
 
 .PP
-# show logs of given task for last taskrun
-    tkn task logs task \-n namespace \-\-last
+Interactive mode: shows logs of the selected TaskRun of the given Task:
 
 .PP
-# show logs for given task and taskrun
-    tkn task logs task taskrun \-n namespace
+.RS
+
+.nf
+tkn task logs task \-n namespace
+
+.fi
+.RE
+
+.PP
+Show logs of given Task for last TaskRun:
+
+.PP
+.RS
+
+.nf
+tkn task logs task \-n namespace \-\-last
+
+.fi
+.RE
+
+.PP
+Show logs for given task and taskrun:
+
+.PP
+.RS
+
+.nf
+tkn task logs task taskrun \-n namespace
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -79,13 +79,20 @@ Start tasks
 
 
 .SH EXAMPLE
-
-.SH start task foo by creating a taskrun named "foo\-run\-xyz123" from the namespace "bar"
 .PP
+Start Task foo by creating a TaskRun named "foo\-run\-xyz123" from namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn task start foo \-s ServiceAccountName \-n bar
 
+.fi
+.RE
+
 .PP
-The task can either be specified by reference in a cluster using the positional argument
+The rask can either be specified by reference in a cluster using the positional argument
 or in a file using the \-\-filename argument.
 
 .PP

--- a/docs/man/man1/tkn-taskrun-cancel.1
+++ b/docs/man/man1/tkn-taskrun-cancel.1
@@ -43,10 +43,17 @@ Cancel a taskrun in a namespace
 
 
 .SH EXAMPLE
-
-.SH Cancel the TaskRun named "foo" from the namespace "bar"
 .PP
+Cancel the TaskRun named 'foo' from the namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn taskrun cancel foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -60,13 +60,29 @@ Delete a taskrun in a namespace
 
 
 .SH EXAMPLE
-
-.SH Delete a TaskRun of name 'foo' in namespace 'bar'
 .PP
+Delete a TaskRun of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn taskrun delete foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn tr rm foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -56,13 +56,29 @@ Describe a taskrun in a namespace
 
 
 .SH EXAMPLE
-
-.SH Describe a TaskRun of name 'foo' in namespace 'bar'
 .PP
+Describe a TaskRun of name 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn taskrun describe foo \-n bar
 
+.fi
+.RE
+
 .PP
+or
+
+.PP
+.RS
+
+.nf
 tkn tr desc foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun\-list \- Lists taskruns in a namespace
+tkn\-taskrun\-list \- Lists TaskRuns in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-taskrun\-list \- Lists taskruns in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists taskruns in a namespace
+Lists TaskRuns in a namespace
 
 
 .SH OPTIONS
@@ -60,15 +60,29 @@ Lists taskruns in a namespace
 
 
 .SH EXAMPLE
-
-.SH List all taskruns in namespace 'bar'
 .PP
+List all TaskRuns in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn tr list \-n bar
 
+.fi
+.RE
 
-.SH List all taskruns of task 'foo' in namespace 'bar'
 .PP
+List all TaskRuns of Task 'foo' in namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn taskrun list foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -55,15 +55,29 @@ Show taskruns logs
 
 
 .SH EXAMPLE
-
-.SH show the logs of TaskRun named "foo" from the namespace "bar"
 .PP
+Show the logs of TaskRun named 'foo' from the namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn taskrun logs foo \-n bar
 
+.fi
+.RE
 
-.SH show the live logs of TaskRun named "foo" from the namespace "bar"
 .PP
+Show the live logs of TaskRun named 'foo' from namespace 'bar':
+
+.PP
+.RS
+
+.nf
 tkn taskrun logs \-f foo \-n bar
+
+.fi
+.RE
 
 
 .SH SEE ALSO

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "clustertask", ForceDelete: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a ClusterTask of name 'foo'
-tkn clustertask delete foo
+	eg := `Delete a ClusterTask of name 'foo':
 
-tkn ct rm foo
+    tkn clustertask delete foo
+
+or
+
+    tkn ct rm foo
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/condition/delete.go
+++ b/pkg/cmd/condition/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "condition", ForceDelete: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a Condition of name 'foo' in namespace 'bar'
-tkn condition delete foo -n bar
+	eg := `Delete a Condition of name 'foo' in namespace 'bar':
 
-tkn cond rm foo -n bar
+    tkn condition delete foo -n bar
+
+or
+
+    tkn cond rm foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipeline/create.go
+++ b/pkg/cmd/pipeline/create.go
@@ -33,9 +33,9 @@ type createOptions struct {
 func createCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("create")
 	opts := &createOptions{from: ""}
-	eg := `
-# Create a Pipeline defined by foo.yaml in namespace 'bar'
-tkn pipeline create -f foo.yaml -n bar
+	eg := `Create a Pipeline defined by foo.yaml in namespace 'bar':
+
+    tkn pipeline create -f foo.yaml -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteAll: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a Pipeline of name 'foo' in namespace 'bar'
-tkn pipeline delete foo -n bar
+	eg := `Delete a Pipeline of name 'foo' in namespace 'bar'
 
-tkn p rm foo -n bar
+    tkn pipeline delete foo -n bar
+
+or
+
+    tkn p rm foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -48,19 +48,22 @@ func logCommand(p cli.Params) *cobra.Command {
 	opts := options.NewLogOptions(p)
 
 	eg := `
-  # interactive mode: shows logs of the selected pipeline run
+Interactive mode: shows logs of the selected pipelinerun:
+
     tkn pipeline logs -n namespace
 
-  # interactive mode: shows logs of the selected pipelinerun of the given pipeline
+Interactive mode: shows logs of the selected pipelinerun of the given pipeline:
+
     tkn pipeline logs pipeline -n namespace
 
-  # show logs of given pipeline for last run
+Show logs of given pipeline for last run:
+
     tkn pipeline logs pipeline -n namespace --last
 
-  # show logs for given pipeline and pipelinerun
-    tkn pipeline logs pipeline run -n namespace
+Show logs for given pipeline and pipelinerun:
 
-   `
+    tkn pipeline logs pipeline run -n namespace
+`
 	c := &cobra.Command{
 		Use:                   "logs",
 		DisableFlagsInUseLine: true,

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -114,9 +114,9 @@ func startCommand(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		Example: `
-# start pipeline foo by creating a pipelinerun named "foo-run-xyz123" from the namespace "bar"
-tkn pipeline start foo -s ServiceAccountName -n bar
+		Example: `Start Pipeline foo by creating a PipelineRun named "foo-run-xyz123" from namespace 'bar':
+
+    tkn pipeline start foo -s ServiceAccountName -n bar
 
 For params value, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -53,12 +53,14 @@ func createCommand(p cli.Params) *cobra.Command {
 	}
 	f := cliopts.NewPrintFlags("create")
 	opts := &Resource{from: ""}
-	eg := `
-  # Creates new PipelineResource as per the given input
-	tkn resource create -n namespace
-	
-  # Create a PipelineResource defined by foo.yaml in namespace 'bar'
-	tkn resource create -f foo.yaml -n bar`
+	eg := `Creates new PipelineResource as per the given input:
+
+    tkn resource create -n namespace
+
+Create a PipelineResource defined by foo.yaml in namespace 'bar':
+
+    tkn resource create -f foo.yaml -n bar
+`
 
 	c := &cobra.Command{
 		Use:                   "create",

--- a/pkg/cmd/pipelineresource/delete.go
+++ b/pkg/cmd/pipelineresource/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "pipelineresource", ForceDelete: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a PipelineResource of name 'foo' in namespace 'bar'
-tkn resource delete foo -n bar
+	eg := `Delete a PipelineResource of name 'foo' in namespace 'bar':
 
-tkn res rm foo -n bar
+    tkn resource delete foo -n bar
+
+or
+
+    tkn res rm foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelineresource/describe.go
+++ b/pkg/cmd/pipelineresource/describe.go
@@ -54,11 +54,13 @@ FIELDNAME	SECRETNAME
 
 func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
-	eg := `
-# Describe a PipelineResource of name 'foo' in namespace 'bar'
-tkn resource describe foo -n bar
+	eg := `Describe a PipelineResource of name 'foo' in namespace 'bar':
 
-tkn res desc foo -n bar
+    tkn resource describe foo -n bar
+
+or
+
+    tkn res desc foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelineresource/list.go
+++ b/pkg/cmd/pipelineresource/list.go
@@ -44,9 +44,9 @@ func listCommand(p cli.Params) *cobra.Command {
 
 	opts := &ListOptions{Type: ""}
 	f := cliopts.NewPrintFlags("list")
-	eg := `
-# List all PipelineResources in a namespaces 'foo'
-tkn pre list -n foo
+	eg := `List all PipelineResources in a namespace 'foo':
+
+    tkn pre list -n foo
 `
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -32,10 +32,10 @@ const (
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
-	eg := `
-  # cancel the PipelineRun named "foo" from the namespace "bar"
+	eg := `Cancel the PipelineRun named 'foo' from namespace 'bar':
+
     tkn pipelinerun cancel foo -n bar
-   `
+`
 
 	c := &cobra.Command{
 		Use:          "cancel pipelinerunName",

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "pipelinerun", ForceDelete: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a PipelineRun of name 'foo' in namespace 'bar'
-tkn pipelinerun delete foo -n bar
+	eg := `Delete a PipelineRun of name 'foo' in namespace 'bar':
 
-tkn pr rm foo -n bar
+    tkn pipelinerun delete foo -n bar
+
+or
+
+    tkn pr rm foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -17,7 +17,6 @@ package pipelinerun
 import (
 	"fmt"
 	"sort"
-
 	"text/tabwriter"
 	"text/template"
 
@@ -91,11 +90,13 @@ NAME	TASK NAME	STARTED	DURATION	STATUS
 
 func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
-	eg := `
-# Describe a PipelineRun of name 'foo' in namespace 'bar'
-tkn pipelinerun describe foo -n bar
+	eg := `Describe a PipelineRun of name 'foo' in namespace 'bar':
 
-tkn pr desc foo -n bar
+    tkn pipelinerun describe foo -n bar
+
+or
+
+    tkn pr desc foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -44,12 +44,13 @@ func listCommand(p cli.Params) *cobra.Command {
 
 	opts := &ListOptions{Limit: 0}
 	f := cliopts.NewPrintFlags("list")
-	eg := `
-# List all PipelineRuns of Pipeline name 'foo'
-tkn pipelinerun list foo -n bar
+	eg := `List all PipelineRuns of Pipeline 'foo':
 
-# List all pipelineruns in a namespaces 'foo'
-tkn pr list -n foo
+    tkn pipelinerun list foo -n bar
+
+List all PipelineRuns in a namespace 'foo':
+
+    tkn pr list -n foo
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -29,15 +29,16 @@ import (
 
 func logCommand(p cli.Params) *cobra.Command {
 	opts := &options.LogOptions{Params: p}
-	eg := `
-  # show the logs of PipelineRun named "foo" from the namesspace "bar"
+	eg := `Show the logs of PipelineRun named 'foo' from namespace 'bar':
+
     tkn pipelinerun logs foo -n bar
 
-  # show the logs of PipelineRun named "microservice-1" for task "build" only, from the namespace "bar"
+Show the logs of PipelineRun named 'microservice-1' for task 'build' only from namespace 'bar':
+
     tkn pr logs microservice-1 -t build -n bar
 
-  # show the logs of PipelineRun named "microservice-1" for all tasks and steps (including init steps),
-    from the namespace "foo"
+Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (including init steps) from namespace 'foo':
+
     tkn pr logs microservice-1 -a -n foo
    `
 

--- a/pkg/cmd/task/create.go
+++ b/pkg/cmd/task/create.go
@@ -33,9 +33,9 @@ type createOptions struct {
 func createCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("create")
 	opts := &createOptions{from: ""}
-	eg := `
-# Create a Task defined by foo.yaml in namespace 'bar'
-tkn task create -f foo.yaml -n bar
+	eg := `Create a Task defined by foo.yaml in namespace 'bar':
+
+    tkn task create -f foo.yaml -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "task", ForceDelete: false, DeleteAll: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a Task of name 'foo' in namespace 'bar'
-tkn task delete foo -n bar
+	eg := `Delete a Task of name 'foo' in namespace 'bar':
 
-tkn t rm foo -n bar
+    tkn task delete foo -n bar
+
+or
+
+    tkn t rm foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -106,11 +106,13 @@ NAME	STARTED	DURATION	STATUS
 
 func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
-	eg := `
-# Describe a task of name 'foo' in namespace 'bar'
-tkn task describe foo -n bar
+	eg := `Describe a Task of name 'foo' in namespace 'bar':
 
-tkn t desc foo -n bar
+    tkn task describe foo -n bar
+
+or
+
+   tkn t desc foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/task/logs.go
+++ b/pkg/cmd/task/logs.go
@@ -46,20 +46,22 @@ func nameArg(args []string, p cli.Params) error {
 func logCommand(p cli.Params) *cobra.Command {
 	opts := options.NewLogOptions(p)
 
-	eg := `
-  # interactive mode: shows logs of the selected taskrun
+	eg := `Interactive mode: shows logs of the selected TaskRun:
+
     tkn task logs -n namespace
 
-  # interactive mode: shows logs of the selected taskrun of the given task
+Interactive mode: shows logs of the selected TaskRun of the given Task:
+
     tkn task logs task -n namespace
 
-  # show logs of given task for last taskrun
+Show logs of given Task for last TaskRun:
+
     tkn task logs task -n namespace --last
 
-  # show logs for given task and taskrun
-    tkn task logs task taskrun -n namespace
+Show logs for given task and taskrun:
 
-   `
+    tkn task logs task taskrun -n namespace
+`
 	c := &cobra.Command{
 		Use:                   "logs",
 		DisableFlagsInUseLine: true,

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
@@ -97,11 +96,11 @@ func startCommand(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		Example: `
-# start task foo by creating a taskrun named "foo-run-xyz123" from the namespace "bar"
-tkn task start foo -s ServiceAccountName -n bar
+		Example: `Start Task foo by creating a TaskRun named "foo-run-xyz123" from namespace 'bar':
 
-The task can either be specified by reference in a cluster using the positional argument
+    tkn task start foo -s ServiceAccountName -n bar
+
+The rask can either be specified by reference in a cluster using the positional argument
 or in a file using the --filename argument.
 
 For params value, if you want to provide multiple values, provide them comma separated

--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -32,9 +32,9 @@ const (
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
-	eg := `
-# Cancel the TaskRun named "foo" from the namespace "bar"
-tkn taskrun cancel foo -n bar
+	eg := `Cancel the TaskRun named 'foo' from the namespace 'bar':
+
+    tkn taskrun cancel foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -28,11 +28,13 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "taskrun", ForceDelete: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `
-# Delete a TaskRun of name 'foo' in namespace 'bar'
-tkn taskrun delete foo -n bar
+	eg := `Delete a TaskRun of name 'foo' in namespace 'bar':
 
-tkn tr rm foo -n bar
+    tkn taskrun delete foo -n bar
+
+or
+
+    tkn tr rm foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -16,7 +16,6 @@ package taskrun
 
 import (
 	"fmt"
-
 	"text/tabwriter"
 	"text/template"
 
@@ -105,11 +104,13 @@ NAME	STATUS
 
 func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
-	eg := `
-# Describe a TaskRun of name 'foo' in namespace 'bar'
-tkn taskrun describe foo -n bar
+	eg := `Describe a TaskRun of name 'foo' in namespace 'bar':
 
-tkn tr desc foo -n bar
+    tkn taskrun describe foo -n bar
+
+or
+
+    tkn tr desc foo -n bar
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	emptyMsg = "No taskruns found"
+	emptyMsg = "No TaskRuns found"
 )
 
 type ListOptions struct {
@@ -44,18 +44,19 @@ func listCommand(p cli.Params) *cobra.Command {
 
 	opts := &ListOptions{Limit: 0}
 	f := cliopts.NewPrintFlags("list")
-	eg := `
-# List all taskruns in namespace 'bar'
-tkn tr list -n bar
+	eg := `List all TaskRuns in namespace 'bar':
 
-# List all taskruns of task 'foo' in namespace 'bar'
-tkn taskrun list foo -n bar
+    tkn tr list -n bar
+
+List all TaskRuns of Task 'foo' in namespace 'bar':
+
+    tkn taskrun list foo -n bar
 `
 
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists taskruns in a namespace",
+		Short:   "Lists TaskRuns in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -33,12 +33,13 @@ const (
 
 func logCommand(p cli.Params) *cobra.Command {
 	opts := &options.LogOptions{Params: p}
-	eg := `
-# show the logs of TaskRun named "foo" from the namespace "bar"
-tkn taskrun logs foo -n bar
+	eg := `Show the logs of TaskRun named 'foo' from the namespace 'bar':
 
-# show the live logs of TaskRun named "foo" from the namespace "bar"
-tkn taskrun logs -f foo -n bar
+    tkn taskrun logs foo -n bar
+
+Show the live logs of TaskRun named 'foo' from namespace 'bar':
+
+    tkn taskrun logs -f foo -n bar
 `
 	c := &cobra.Command{
 		Use:          "logs",


### PR DESCRIPTION
Before this change: 
<img width="931" alt="Screen Shot 2019-12-17 at 2 40 51 PM" src="https://user-images.githubusercontent.com/210737/71028425-3e196600-20db-11ea-8e81-c2b92caaf149.png">

After this change:
https://github.com/ImJasonH/cli/blob/examples/docs/cmd/tkn_clustertask_delete.md

Also try to standardize on `'` instead of `"`, fix some typos, add some `:`s.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._