### PR TITLE
Set default to False for Show Logs on TaskRun and PipelineRun

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -42,7 +42,7 @@ two parameters (foo and bar)
   -p, --param stringArray             pass the param as key=value or key=value1,value2
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name
-      --showlog                       show logs right after starting the pipeline (default true)
+      --showlog                       show logs right after starting the pipeline
       --task-serviceaccount strings   pass the service account corresponding to the task
 ```
 

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -38,7 +38,7 @@ like cat,foo,bar
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value or key=value1,value2
   -s, --serviceaccount string    pass the serviceaccount name
-      --showlog                  show logs right after starting the task (default true)
+      --showlog                  show logs right after starting the task
   -t, --timeout int              timeout for taskrun in seconds (default 3600)
 ```
 

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -52,7 +52,7 @@ Parameters, at least those that have no default value
     pass the serviceaccount name
 
 .PP
-\fB\-\-showlog\fP[=true]
+\fB\-\-showlog\fP[=false]
     show logs right after starting the pipeline
 
 .PP

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -52,7 +52,7 @@ Start tasks
     pass the serviceaccount name
 
 .PP
-\fB\-\-showlog\fP[=true]
+\fB\-\-showlog\fP[=false]
     show logs right after starting the task
 
 .PP

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -139,7 +139,7 @@ like cat,foo,bar
 		},
 	}
 
-	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", true, "show logs right after starting the pipeline")
+	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the pipeline")
 	c.Flags().StringSliceVarP(&opt.Resources, "resource", "r", []string{}, "pass the resource name and ref as name=ref")
 	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value or key=value1,value2")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -176,7 +176,6 @@ func Test_start_pipeline(t *testing.T) {
 
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"-r=source=scaffold-git",
-		"--showlog=false",
 		"-p=pipeline-param=value1",
 		"-p=rev-param=cat,foo,bar",
 		"-l=jemange=desfrites",
@@ -243,7 +242,6 @@ func Test_start_pipeline_showlogs_false(t *testing.T) {
 		"-r=source=scaffold-git",
 		"-p=pipeline-param=value1",
 		"-l=jemange=desfrites",
-		"--showlog=false",
 		"-s=svc1",
 		"-n", "ns")
 
@@ -411,7 +409,6 @@ func Test_start_pipeline_last(t *testing.T) {
 		"-r=git-repo=scaffold-git",
 		"-p=rev-param=revision2",
 		"-s=svc1",
-		"--showlog=false",
 		"--task-serviceaccount=task3=task3svc3",
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
@@ -497,7 +494,6 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
-		"--showlog=false",
 		"-n", "ns")
 
 	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
@@ -584,7 +580,6 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
-		"--showlog=false",
 		"-s=svc1",
 		"-r=git-repo=scaffold-git",
 		"-p=rev-param=revision2",
@@ -657,7 +652,6 @@ func Test_start_pipeline_allkindparam(t *testing.T) {
 
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"-r=source=scaffold-git",
-		"--showlog=false",
 		"-p=pipeline-param=value1",
 		"-p=rev-param=cat,foo,bar",
 		"-p=rev-param-new=help",
@@ -739,7 +733,6 @@ func Test_start_pipeline_last_no_pipelineruns(t *testing.T) {
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
 		"-s=svc1",
-		"--showlog=false",
 		"-r=git-repo=scaffold-git",
 		"-p=rev-param=revision2",
 		"--task-serviceaccount=task3=task3svc3",
@@ -789,7 +782,6 @@ func Test_start_pipeline_last_list_err(t *testing.T) {
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"--last",
 		"-s=svc1",
-		"--showlog=false",
 		"-r=git-repo=scaffold-git",
 		"-p=rev-param=revision2",
 		"--task-serviceaccount=task3=task3svc3",
@@ -832,7 +824,6 @@ func Test_start_pipeline_wrong_param_err(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"-s=svc1",
-		"--showlog=false",
 		"-r=git-repo=scaffold-git",
 		"-p=rev-parm=revision2",
 		"-n", "ns")
@@ -874,7 +865,6 @@ func Test_start_pipeline_client_error(t *testing.T) {
 
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
-		"--showlog=false",
 		"-s=svc1",
 		"-n=namespace")
 
@@ -916,7 +906,6 @@ func Test_start_pipeline_res_err(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"-s=svc1",
-		"--showlog=false",
 		"-r=git-reposcaffold-git",
 		"-p=rev-param=revision2",
 		"--task-serviceaccount=task3=task3svc3",
@@ -961,7 +950,6 @@ func Test_start_pipeline_param_err(t *testing.T) {
 	pipeline := Command(p)
 	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
 		"-s=svc1",
-		"--showlog=false",
 		"-r=git-repo=scaffold-git",
 		"-p=rev-paramrevision2",
 		"--task-serviceaccount=task3=task3svc3",

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -137,7 +137,7 @@ like cat,foo,bar
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the task using last taskrun values")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
-	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", true, "show logs right after starting the task")
+	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the task")
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "filename containing a task definition")
 	c.Flags().Int64VarP(&opt.TimeOut, "timeout", "t", 3600, "timeout for taskrun in seconds")
 

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -111,7 +111,7 @@ func Test_start_has_task_filename(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
 	c := Command(&test.Params{Tekton: cs.Pipeline, Kube: cs.Kube})
 
-	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task.yaml", "--showlog=false")
+	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task.yaml")
 	if err != nil {
 		t.Errorf("Not expecting an error, but got %s", err.Error())
 	}
@@ -195,7 +195,6 @@ func Test_start_task(t *testing.T) {
 		"-l=key=value",
 		"-o=code-image=output-image",
 		"-s=svc1",
-		"--showlog=false",
 		"-n=ns")
 
 	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
@@ -300,7 +299,6 @@ func Test_start_task_last(t *testing.T) {
 	task := Command(p)
 	got, _ := test.ExecuteCommand(task, "start", "task",
 		"--last",
-		"--showlog=false",
 		"-n=ns")
 
 	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
@@ -398,7 +396,6 @@ func Test_start_task_last_with_inputs(t *testing.T) {
 		"-o=code-image=output-image",
 		"-s=svc1",
 		"-n=ns",
-		"--showlog=false",
 		"--last")
 
 	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
@@ -708,7 +705,6 @@ func Test_start_task_allkindparam(t *testing.T) {
 		"-l=key=value",
 		"-o=code-image=output-image",
 		"-s=svc1",
-		"--showlog=false",
 		"-n=ns")
 
 	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
@@ -801,7 +797,6 @@ func Test_start_task_wrong_param(t *testing.T) {
 		"-l=key=value",
 		"-o=code-image=output-image",
 		"-s=svc1",
-		"--showlog=false",
 		"-n=ns")
 
 	expected := "Error: param 'myar' not present in spec\n"


### PR DESCRIPTION
Closes #455

```
We do not show the logs anymore right after starting the pipeline, use
--showlog to see it
```