### PR TITLE
Show Cancelled Instead of Failed for PipelineRun and TaskRun Describe

### DIFF
--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -21,7 +21,7 @@ Manage pipelineruns
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn pipelinerun cancel](tkn_pipelinerun_cancel.md)	 - Cancel the PipelineRun
+* [tkn pipelinerun cancel](tkn_pipelinerun_cancel.md)	 - Cancel a PipelineRun in a namespace
 * [tkn pipelinerun delete](tkn_pipelinerun_delete.md)	 - Delete a pipelinerun in a namespace
 * [tkn pipelinerun describe](tkn_pipelinerun_describe.md)	 - Describe a pipelinerun in a namespace
 * [tkn pipelinerun list](tkn_pipelinerun_list.md)	 - Lists pipelineruns in a namespace

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -1,16 +1,16 @@
 ## tkn pipelinerun cancel
 
-Cancel the PipelineRun
+Cancel a PipelineRun in a namespace
 
 ### Usage
 
 ```
-tkn pipelinerun cancel pipelinerunName
+tkn pipelinerun cancel
 ```
 
 ### Synopsis
 
-Cancel the PipelineRun
+Cancel a PipelineRun in a namespace
 
 ### Examples
 

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -21,7 +21,7 @@ Manage taskruns
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn taskrun cancel](tkn_taskrun_cancel.md)	 - Cancel a taskrun in a namespace
+* [tkn taskrun cancel](tkn_taskrun_cancel.md)	 - Cancel a TaskRun in a namespace
 * [tkn taskrun delete](tkn_taskrun_delete.md)	 - Delete a taskrun in a namespace
 * [tkn taskrun describe](tkn_taskrun_describe.md)	 - Describe a taskrun in a namespace
 * [tkn taskrun list](tkn_taskrun_list.md)	 - Lists TaskRuns in a namespace

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -1,6 +1,6 @@
 ## tkn taskrun cancel
 
-Cancel a taskrun in a namespace
+Cancel a TaskRun in a namespace
 
 ### Usage
 
@@ -10,11 +10,11 @@ tkn taskrun cancel
 
 ### Synopsis
 
-Cancel a taskrun in a namespace
+Cancel a TaskRun in a namespace
 
 ### Examples
 
-Cancel the TaskRun named 'foo' from the namespace 'bar':
+Cancel the TaskRun named 'foo' from namespace 'bar':
 
     tkn taskrun cancel foo -n bar
 

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -5,17 +5,17 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun\-cancel \- Cancel the PipelineRun
+tkn\-pipelinerun\-cancel \- Cancel a PipelineRun in a namespace
 
 
 .SH SYNOPSIS
 .PP
-\fBtkn pipelinerun cancel pipelinerunName\fP
+\fBtkn pipelinerun cancel\fP
 
 
 .SH DESCRIPTION
 .PP
-Cancel the PipelineRun
+Cancel a PipelineRun in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-taskrun-cancel.1
+++ b/docs/man/man1/tkn-taskrun-cancel.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun\-cancel \- Cancel a taskrun in a namespace
+tkn\-taskrun\-cancel \- Cancel a TaskRun in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-taskrun\-cancel \- Cancel a taskrun in a namespace
 
 .SH DESCRIPTION
 .PP
-Cancel a taskrun in a namespace
+Cancel a TaskRun in a namespace
 
 
 .SH OPTIONS
@@ -44,7 +44,7 @@ Cancel a taskrun in a namespace
 
 .SH EXAMPLE
 .PP
-Cancel the TaskRun named 'foo' from the namespace 'bar':
+Cancel the TaskRun named 'foo' from namespace 'bar':
 
 .PP
 .RS

--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -28,7 +28,7 @@ import (
 const (
 	succeeded   = "Succeeded"
 	failed      = "Failed"
-	prCancelled = "Failed(PipelineRunCancelled)"
+	prCancelled = "Cancelled(PipelineRunCancelled)"
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
@@ -38,8 +38,8 @@ func cancelCommand(p cli.Params) *cobra.Command {
 `
 
 	c := &cobra.Command{
-		Use:          "cancel pipelinerunName",
-		Short:        "Cancel the PipelineRun",
+		Use:          "cancel",
+		Short:        "Cancel a PipelineRun in a namespace",
 		Example:      eg,
 		SilenceUsage: true,
 		Annotations: map[string]string{

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -730,3 +730,82 @@ tr-1   t-1         8 minutes ago   3 minutes   Succeeded
 
 	test.AssertOutput(t, expected, actual)
 }
+
+func TestPipelineRunDescribe_cancelled_pipelinerun(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun("tr-1", "ns",
+			tb.TaskRunStatus(
+				tb.TaskRunStartTime(clock.Now().Add(2*time.Minute)),
+				cb.TaskRunCompletionTime(clock.Now().Add(5*time.Minute)),
+				tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}),
+			),
+		),
+	}
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		PipelineRuns: []*v1alpha1.PipelineRun{
+			tb.PipelineRun("pipeline-run", "ns",
+				cb.PipelineRunCreationTimestamp(clock.Now()),
+				tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
+				tb.PipelineRunSpec("pipeline"),
+				tb.PipelineRunStatus(
+					tb.PipelineRunTaskRunsStatus("tr-1", &v1alpha1.PipelineRunTaskRunStatus{
+						PipelineTaskName: "t-1",
+						Status:           &trs[0].Status,
+					}),
+					tb.PipelineRunStatusCondition(apis.Condition{
+						Status:  corev1.ConditionFalse,
+						Reason:  "PipelineRunCancelled",
+						Message: "PipelineRun \"pipeline-run\" was cancelled",
+					}),
+					tb.PipelineRunStartTime(clock.Now()),
+					cb.PipelineRunCompletionTime(clock.Now().Add(5*time.Minute)),
+				),
+			),
+		},
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
+	})
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+
+	pipelinerun := Command(p)
+	clock.Advance(10 * time.Minute)
+	actual, err := test.ExecuteCommand(pipelinerun, "desc", "pipeline-run", "-n", "ns")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected := `Name:           pipeline-run
+Namespace:      ns
+Pipeline Ref:   pipeline
+
+Status
+STARTED          DURATION    STATUS
+10 minutes ago   5 minutes   Cancelled(PipelineRunCancelled)
+
+Message
+PipelineRun "pipeline-run" was cancelled
+
+Resources
+No resources
+
+Params
+No params
+
+Taskruns
+NAME   TASK NAME   STARTED         DURATION    STATUS
+tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+`
+
+	test.AssertOutput(t, expected, actual)
+}

--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -28,18 +28,18 @@ import (
 const (
 	succeeded     = "Succeeded"
 	failed        = "Failed"
-	taskCancelled = "Failed(TaskRunCancelled)"
+	taskCancelled = "Cancelled(TaskRunCancelled)"
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
-	eg := `Cancel the TaskRun named 'foo' from the namespace 'bar':
+	eg := `Cancel the TaskRun named 'foo' from namespace 'bar':
 
     tkn taskrun cancel foo -n bar
 `
 
 	c := &cobra.Command{
 		Use:          "cancel",
-		Short:        "Cancel a taskrun in a namespace",
+		Short:        "Cancel a TaskRun in a namespace",
 		Example:      eg,
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -714,3 +714,65 @@ step2   Running
 
 	test.AssertOutput(t, expected, actual)
 }
+
+func TestTaskRunDescribe_cancel_taskrun(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun("tr-1", "ns",
+			tb.TaskRunStatus(
+				tb.TaskRunStartTime(clock.Now().Add(2*time.Minute)),
+				cb.TaskRunCompletionTime(clock.Now().Add(5*time.Minute)),
+				tb.StatusCondition(apis.Condition{
+					Status:  corev1.ConditionFalse,
+					Reason:  "TaskRunCancelled",
+					Message: "TaskRun \"tr-1\" was cancelled",
+				}),
+			),
+		),
+	}
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		TaskRuns: trs,
+		Namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			},
+		},
+	})
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+
+	taskrun := Command(p)
+	clock.Advance(10 * time.Minute)
+	actual, err := test.ExecuteCommand(taskrun, "desc", "tr-1", "-n", "ns")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected := `Name:        tr-1
+Namespace:   ns
+
+Status
+STARTED         DURATION    STATUS
+8 minutes ago   3 minutes   Cancelled(TaskRunCancelled)
+
+Message
+TaskRun "tr-1" was cancelled
+
+Input Resources
+No resources
+
+Output Resources
+No resources
+
+Params
+No params
+
+Steps
+No steps
+`
+
+	test.AssertOutput(t, expected, actual)
+}

--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -37,7 +37,12 @@ func Condition(c v1beta1.Conditions) string {
 	}
 
 	if c[0].Reason != "" && c[0].Reason != status {
-		status = status + "(" + c[0].Reason + ")"
+
+		if c[0].Reason == "PipelineRunCancelled" || c[0].Reason == "TaskRunCancelled" {
+			status = "Cancelled" + "(" + c[0].Reason + ")"
+		} else {
+			status = status + "(" + c[0].Reason + ")"
+		}
 	}
 
 	return status


### PR DESCRIPTION
Closes #490 

Added a check on pipelinerun/taskrun reason to check if either was cancelled. If the pipelinerun or taskrun was cancelled, `status` is will use `Cancelled` instead of `Failed` for the status format. A user will now see `Cancelled(PipelineRunCancelled)` or `Cancelled(TaskRunCancelled)` when using `tkn pr desc` or `tkn tr desc` on a cancelled run.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
tkn pr desc and tkn tr desc will show a status of cancelled for cancelled pipelineruns and taskruns
```
