### PR TITLE
Remove Namespace Check for Clustertask Commands

### DIFF
--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/helper/options"
-	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -52,10 +51,6 @@ or
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
-			}
-
-			if err := validate.NamespaceExists(p); err != nil {
-				return err
 			}
 
 			if err := opts.CheckOptions(s, args[0]); err != nil {

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -26,27 +26,17 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestClusterTaskDelete(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-
-	ns := []*corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns",
-			},
-		},
-	}
 
 	seeds := make([]pipelinetest.Clients, 0)
 	for i := 0; i < 3; i++ {
 		clustertasks := []*v1alpha1.ClusterTask{
 			tb.ClusterTask("tomatoes", cb.ClusterTaskCreationTime(clock.Now().Add(-1*time.Minute))),
 		}
-		cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks, Namespaces: ns})
+		cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks})
 		seeds = append(seeds, cs)
 	}
 
@@ -59,16 +49,8 @@ func TestClusterTaskDelete(t *testing.T) {
 		want        string
 	}{
 		{
-			name:        "Invalid namespace",
-			command:     []string{"rm", "tomatoes", "-n", "invalid"},
-			input:       seeds[0],
-			inputStream: nil,
-			wantError:   true,
-			want:        "namespaces \"invalid\" not found",
-		},
-		{
 			name:        "With force delete flag (shorthand)",
-			command:     []string{"rm", "tomatoes", "-f", "-n", "ns"},
+			command:     []string{"rm", "tomatoes", "-f"},
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
@@ -110,7 +92,7 @@ func TestClusterTaskDelete(t *testing.T) {
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			p := &test.Params{Tekton: tp.input.Pipeline, Kube: tp.input.Kube}
+			p := &test.Params{Tekton: tp.input.Pipeline}
 			clustertask := Command(p)
 
 			if tp.inputStream != nil {

--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	"github.com/tektoncd/cli/pkg/printer"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -49,10 +48,6 @@ func listCommand(p cli.Params) *cobra.Command {
 			"commandType": "main",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if err := validate.NamespaceExists(p); err != nil {
-				return err
-			}
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {

--- a/pkg/cmd/clustertask/list_test.go
+++ b/pkg/cmd/clustertask/list_test.go
@@ -26,49 +26,15 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestClusterTaskList_Inavlid_Namespace(t *testing.T) {
-	ns := []*corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
-			},
-		},
-	}
-
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		Namespaces: ns,
-	})
-	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
-
-	clustertask := Command(p)
-	output, err := test.ExecuteCommand(clustertask, "list", "-n", "invalid")
-	if err == nil {
-		t.Errorf("Expected error for invalid namespace")
-	}
-
-	test.AssertOutput(t, "Error: namespaces \"invalid\" not found\n", output)
-}
-
 func TestClusterTaskList_Empty(t *testing.T) {
-	ns := []*corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
-			},
-		},
-	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		Namespaces: ns,
-	})
-	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
+	p := &test.Params{Tekton: cs.Pipeline}
 
 	clustertask := Command(p)
-	output, err := test.ExecuteCommand(clustertask, "list", "-n", "foo")
+	output, err := test.ExecuteCommand(clustertask, "list")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -85,16 +51,8 @@ func TestClusterTaskListOnlyClusterTasks(t *testing.T) {
 		tb.ClusterTask("pineapple", cb.ClusterTaskCreationTime(clock.Now().Add(-512*time.Hour))),
 	}
 
-	ns := []*corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
-			},
-		},
-	}
-
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks, Namespaces: ns})
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock}
 
 	clustertask := Command(p)
 	output, err := test.ExecuteCommand(clustertask, "list")


### PR DESCRIPTION
Closes #546 

We don't need to check for whether a namespace exists for a clustertask, so this pull request removes the check from both `list` and `delete` `clustertask` subcommands.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Remove namespace check from clustertask subcommands
```
