### PR TITLE
Updating Release Notes for tkn

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,14 +1,15 @@
-# TektonCD CLI release process
+# TektonCD CLI Release Process
 
-- You need to be a member of tektoncd-cli [OWNERS](OWNERS) to be able to push the new branch.
+- You need to be a member of tektoncd-cli [OWNERS](OWNERS) and be a member of the [CLI maintainers team](https://github.com/orgs/tektoncd/teams/cli-maintainers) to be able to push a new branch for the release and update the CLI Homebrew formula. 
 
-- You need to have your own tekton cluster under `minikube`, `gcp` or other means.
+- You will need to have a [GPG key set up](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) with your git account to push the release branch.
+
+- You need to have your own Kubernetes cluster with Tekton installed under `minikube`, `gcp`, or other means.
 
 - Start reading this [README](tekton/README.md), and you can start a new release
   with the [release.sh](tekton/release.sh) script.
 
-- Update the main [README.md](README.md), and change the version number in there (i.e: `v0.5.0`)
-  to the version you are releasing. Make a PR and get it merged ASAP.
+- Update the version numbers in the main [README.md](README.md) to the version you are releasing by opening a pull request to the master branch of this repository. Do not worry about updating the README for the release branch.
 
 - When the release is done in https://github.com/tektoncd/cli/releases, edit the
   release and change it from pre-release as released.
@@ -42,9 +43,11 @@ dnf upgrade tektoncd-cli
 
   https://github.com/Homebrew/homebrew-core/pull/46492
 
-- Make an update to the `test-runner` image in the [plumbing](https://github.com/tektoncd/plumbing/) repo (the image where we run the CI on pipeline which uses `tkn`) to increase the version here:
+- Make an update to the `test-runner` and `tkn` image in the [plumbing](https://github.com/tektoncd/plumbing/) repo. The test-runner image is where we run the CI on pipeline which uses `tkn`:
 
-  https://github.com/tektoncd/plumbing/blob/master/tekton/images/test-runner/Dockerfile#L51
+  * [test-runner image](https://github.com/tektoncd/plumbing/blob/master/tekton/images/test-runner/Dockerfile#L51)
+
+  * [tkn image](https://github.com/tektoncd/plumbing/blob/master/tekton/images/tkn/Dockerfile#L17)
 
 - Announce and spread the love on twitter. Make sure you tag
   [@tektoncd](https://twitter.com/tektoncd) account so you get retweeted and

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,47 +1,47 @@
-# Tekton cli Repo CI/CD
+# Tekton CLI Repo CI/CD
 
-We dogfood our project by using Tekton Pipelines to build, test and
+We dogfood our project by using Tekton Pipelines to build, test, and
 release the Tekton Pipelines cli!
 
 This directory contains the
 [`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md) and
 [`Pipelines`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md)
-that we (will) use for the release and the pull-requests.
+that we use for releases and pull requests.
 
 TODO(tektoncd/pipeline#538): In tektoncd/pipeline#538 or tektoncd/pipeline#537 we will update
 [Prow](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#pull-request-process)
-to invoke these `Pipelines` automatically, but for now we will have to invoke
-them manually.
+to invoke these `Pipelines` automatically, but, for now, we invoke them manually.
 
 ## Release Pipeline
 
-You can use the script [`./release.sh`](release.sh) that would do everything
-that needs to be done for the release.
+You can use the script [`./release.sh`](release.sh) that will do everything
+that needs to be done for the release. In order to run `release.sh`, you will 
+need [these tools](https://github.com/tektoncd/cli/blob/master/tekton/release.sh#L13y) installed locally.
 
-The first argument if not provided is the release version you want to do, it
-need to respect a format like `v1.2.3` which is basically SEMVER.
+The first argument to `release.sh` is the release version. It
+needs to be in a format like `v1.2.3`, which is basically SEMVER.
 
-If it detects that you are doing a minor release it would ask you for some
-commits to be cherry-picked in this release. Alternatively you can provide the
-commits separed by a space to the second argument of the script. You do need to
-make sure to provide them in order from the oldest to the newest (as listed).
+If it detects that you are doing a minor release, it will ask you for some
+commits to be cherry-picked in this release. Alternatively, you can provide the
+commits separated by a space to the second argument of the script. You do need to
+make sure to provide them in order from the oldest to the newest.
 
-If you give the `*` argument for the commits to pick up it would apply all the new
+If you give the `*` argument for the commits to pick up, it would apply all the new
 commits.
 
-It will them use your TektonCD cluster and apply what needs to be done for
+It will them use your Kubernetes cluster with Tekton and apply what needs to be done for
 running the release.
 
-And finally it will launch the `tkn`  cli to show the logs.
+Finally it will launch the `tkn` cli that you have installed locally to show the logs.
 
-Make sure we have a nice ChangeLog before doign the release, listing `features`
-and `bugs` and be thankful to the contributors by listing them.
+Make sure we have a nice ChangeLog before doing the release, listing `features`
+and `bugs` and be thankful to the contributors by listing them. An example is shown [here](https://github.com/tektoncd/cli/releases/tag/v0.6.0).
 
 ## Debugging
 
-You can define the env variable `PUSH_REMOTE` to push to your own remote (i.e:
-which pont to your username on github),
+You can define the env variable `PUSH_REMOTE` to push to your own remote (i.e
+which point to your username on github).
 
-You need to be **careful** if you have write access to the `homebrew` repository, it
-would do a release there. Until we can find a proper fix I would generate a
-commit which remove the brews data and cherry-pick it in the script.
+You need to be **careful** if you have write access to the `Homebrew` repository since it
+will do a release there. Until we can find a proper fix, `release.sh` generates a commit that 
+removes the brews data and cherry-picks it in the script.

--- a/tekton/rpmbuild/README.md
+++ b/tekton/rpmbuild/README.md
@@ -1,64 +1,63 @@
 Tekton CLI RPM Build
 ====================
 
-This is a tekton task to run a rpm build on copr
+This is a Tekton task to run an rpm build on copr.
 
-It only supports the latest release as released on github. It queries the github
-api to get the latest one.
+It only supports the latest release as released on GitHub. It queries the GitHub
+api to get the latest release.
 
-It uses the docker image from `quay.io/chmouel/rpmbuild`, the Dockerfile is in
+It uses the docker image from `quay.io/chmouel/rpmbuild`. The Dockerfile is located in
 this directory.
 
-It uploads it to
+The task uploads the release to
 `https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/`. The distros
-supported are :
+supported are:
 
 * Epel for CentOS 7
 * Fedora 30/31
 * RHEL8
 
-You simply have to run this to get it installed
+You simply have to run this to get it installed:
 
 ```
 dnf copr enable chmouel/tektoncd-cli
 dnf install tektoncd-cli
 ```
 
-
-
 USAGE
 =====
 
-Same as when you use the [release.pipeline.yaml](../release-pipeline.yml) you
+Same as when you use the [release.pipeline.yaml](../release-pipeline.yml), you
 need to have a PipelineResource for your git repository. See
 [here](../release-pipeline-run.yml) for an example.
 
-* You need to have your user added to the `https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/` request it by goign to [here ](https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/permissions/) and ask for admin access.
+* You need to have your user added to the `https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/` request it by going [here](https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/permissions/) and asking for admin access.
 
-* You  need to get your API file from https://copr.fedorainfracloud.org/api/ and have it saved to `~/.config/copr`
+* You need to get your API file from https://copr.fedorainfracloud.org/api/ and have it saved to `~/.config/copr`. You will need to change the 
+`username` field to `chmouel` since the copr repo is currently `/chmouel/tektoncd-cli/`.
 
-* You create the secret from that copr config file :
+* You create the secret from that copr config file:
 
 ```
 kubectl create secret generic copr-cli-config --from-file=copr=${HOME}/.config/copr
 ```
 
-* And then you should be able create the task with :
+* You should be able create the task with:
 
 ```
 kubectl create -f rpmbuild.yml
 ```
 
-and  run it with :
+And run it with:
 
 ```
 kubectl create -f rpmbuild-run.yml
 ```
 
-* Use `tkn tr ls` to make sure it didn't fails on validation and
+* Use `tkn tr desc rpmbuild-taskrun` to make sure the taskrun didn't fail on validation 
+
+And use the following command to get the logs of the taskrun: 
 
 ```
-oc logs --all-containers=true $(oc get pod -l "tekton.dev/taskRun=rpmbuild-pipeline-run" -o name) --follow
+tkn tr logs rpmbuild-taskrun -f
 ```
-
-to get the output

--- a/tekton/rpmbuild/rpmbuild-run.yml
+++ b/tekton/rpmbuild/rpmbuild-run.yml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun
 metadata:
-  name: rpmbuild-pipeline-run
+  name: rpmbuild-taskrun
 spec:
   taskRef:
     name: rpmbuild


### PR DESCRIPTION
This pull request adds details to the release process notes that I encountered during the `v0.6.0` release. It also touches up some typos and updates `rpmbuild-run.yml` to be named `rpmbuild-taskrun` instead of `rpmbuild-pipeline-run` since it is a taskrun.

# Changes

* Added notes that you need to be a member of cli.maintainers/homebrew.maintainers teams
* Added note on needing a GPG key set up
* Added note to also update `tkn` image in plumbing, not just test-runner image
* Added note for copr build that username must be chmouel in `~/.config/copr`
* Removed `oc logs --all-containers=true $(oc get pod -l "tekton.dev/taskRun=rpmbuild-pipeline-run" -o name) --follow` and replaced with `tkn taskrun logs` command

# Release Notes

```
Updating release process documentation
```
