### PR TITLE
Update all delete commands to support multiple arguments

### DIFF
--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -21,6 +21,6 @@ Manage clustertasks
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn clustertask delete](tkn_clustertask_delete.md)	 - Delete a clustertask resource in a cluster
+* [tkn clustertask delete](tkn_clustertask_delete.md)	 - Delete clustertask resources in a cluster
 * [tkn clustertask list](tkn_clustertask_list.md)	 - Lists clustertasks in a namespace
 

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -1,6 +1,6 @@
 ## tkn clustertask delete
 
-Delete a clustertask resource in a cluster
+Delete clustertask resources in a cluster
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn clustertask delete
 
 ### Synopsis
 
-Delete a clustertask resource in a cluster
+Delete clustertask resources in a cluster
 
 ### Examples
 
-Delete a ClusterTask of name 'foo':
+Delete ClusterTasks with names 'foo' and 'bar':
 
-    tkn clustertask delete foo
+    tkn clustertask delete foo bar
 
 or
 
-    tkn ct rm foo
+    tkn ct rm foo bar
 
 
 ### Options

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -16,13 +16,13 @@ Delete a condition in a namespace
 
 ### Examples
 
-Delete a Condition of name 'foo' in namespace 'bar':
+Delete Conditions with names 'foo' and 'bar' in namespace 'quux':
 
-    tkn condition delete foo -n bar
+    tkn condition delete foo bar -n quux
 
 or
 
-    tkn cond rm foo -n bar
+    tkn cond rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_eventlistener.md
+++ b/docs/cmd/tkn_eventlistener.md
@@ -21,6 +21,6 @@ Manage eventlisteners
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn eventlistener delete](tkn_eventlistener_delete.md)	 - Delete an EventListener in a namespace
+* [tkn eventlistener delete](tkn_eventlistener_delete.md)	 - Delete EventListeners in a namespace
 * [tkn eventlistener list](tkn_eventlistener_list.md)	 - Lists eventlisteners in a namespace
 

--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -1,6 +1,6 @@
 ## tkn eventlistener delete
 
-Delete an EventListener in a namespace
+Delete EventListeners in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn eventlistener delete
 
 ### Synopsis
 
-Delete an EventListener in a namespace
+Delete EventListeners in a namespace
 
 ### Examples
 
-Delete an EventListener of name 'foo' in namespace 'bar'
+Delete EventListeners with names 'foo' and 'bar' in namespace 'bar'
 
-    tkn eventlistener delete foo -n bar
+    tkn eventlistener delete foo bar -n quux
 
 or
 
-    tkn el rm foo -n bar
+    tkn el rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -22,7 +22,7 @@ Manage pipelines
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn pipeline create](tkn_pipeline_create.md)	 - Create a pipeline in a namespace
-* [tkn pipeline delete](tkn_pipeline_delete.md)	 - Delete a pipeline in a namespace
+* [tkn pipeline delete](tkn_pipeline_delete.md)	 - Delete pipelines in a namespace
 * [tkn pipeline describe](tkn_pipeline_describe.md)	 - Describes a pipeline in a namespace
 * [tkn pipeline list](tkn_pipeline_list.md)	 - Lists pipelines in a namespace
 * [tkn pipeline logs](tkn_pipeline_logs.md)	 - Show pipeline logs

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -1,6 +1,6 @@
 ## tkn pipeline delete
 
-Delete a pipeline in a namespace
+Delete pipelines in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn pipeline delete
 
 ### Synopsis
 
-Delete a pipeline in a namespace
+Delete pipelines in a namespace
 
 ### Examples
 
-Delete a Pipeline of name 'foo' in namespace 'bar'
+Delete Pipelines with names 'foo' and 'bar' in namespace 'quux'
 
-    tkn pipeline delete foo -n bar
+    tkn pipeline delete foo bar -n quux
 
 or
 
-    tkn p rm foo -n bar
+    tkn p rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -22,7 +22,7 @@ Manage pipelineruns
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn pipelinerun cancel](tkn_pipelinerun_cancel.md)	 - Cancel a PipelineRun in a namespace
-* [tkn pipelinerun delete](tkn_pipelinerun_delete.md)	 - Delete a pipelinerun in a namespace
+* [tkn pipelinerun delete](tkn_pipelinerun_delete.md)	 - Delete pipelineruns in a namespace
 * [tkn pipelinerun describe](tkn_pipelinerun_describe.md)	 - Describe a pipelinerun in a namespace
 * [tkn pipelinerun list](tkn_pipelinerun_list.md)	 - Lists pipelineruns in a namespace
 * [tkn pipelinerun logs](tkn_pipelinerun_logs.md)	 - Show the logs of PipelineRun

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -1,6 +1,6 @@
 ## tkn pipelinerun delete
 
-Delete a pipelinerun in a namespace
+Delete pipelineruns in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn pipelinerun delete
 
 ### Synopsis
 
-Delete a pipelinerun in a namespace
+Delete pipelineruns in a namespace
 
 ### Examples
 
-Delete a PipelineRun of name 'foo' in namespace 'bar':
+Delete PipelineRuns with names 'foo' and 'bar' in namespace 'quux':
 
-    tkn pipelinerun delete foo -n bar
+    tkn pipelinerun delete foo bar -n quux
 
 or
 
-    tkn pr rm foo -n bar
+    tkn pr rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -22,7 +22,7 @@ Manage pipeline resources
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn resource create](tkn_resource_create.md)	 - Create a pipeline resource in a namespace
-* [tkn resource delete](tkn_resource_delete.md)	 - Delete a pipeline resource in a namespace
+* [tkn resource delete](tkn_resource_delete.md)	 - Delete pipeline resources in a namespace
 * [tkn resource describe](tkn_resource_describe.md)	 - Describes a pipeline resource in a namespace
 * [tkn resource list](tkn_resource_list.md)	 - Lists pipeline resources in a namespace
 

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -1,6 +1,6 @@
 ## tkn resource delete
 
-Delete a pipeline resource in a namespace
+Delete pipeline resources in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn resource delete
 
 ### Synopsis
 
-Delete a pipeline resource in a namespace
+Delete pipeline resources in a namespace
 
 ### Examples
 
-Delete a PipelineResource of name 'foo' in namespace 'bar':
+Delete PipelineResources with names 'foo' and 'bar' in namespace 'quux':
 
-    tkn resource delete foo -n bar
+    tkn resource delete foo bar -n quux
 
 or
 
-    tkn res rm foo -n bar
+    tkn res rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -22,7 +22,7 @@ Manage tasks
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn task create](tkn_task_create.md)	 - Create a task in a namespace
-* [tkn task delete](tkn_task_delete.md)	 - Delete a task resource in a namespace
+* [tkn task delete](tkn_task_delete.md)	 - Delete task resources in a namespace
 * [tkn task describe](tkn_task_describe.md)	 - Describes a task in a namespace
 * [tkn task list](tkn_task_list.md)	 - Lists tasks in a namespace
 * [tkn task logs](tkn_task_logs.md)	 - Show task logs

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -1,6 +1,6 @@
 ## tkn task delete
 
-Delete a task resource in a namespace
+Delete task resources in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn task delete
 
 ### Synopsis
 
-Delete a task resource in a namespace
+Delete task resources in a namespace
 
 ### Examples
 
-Delete a Task of name 'foo' in namespace 'bar':
+Delete Tasks with names 'foo' and 'bar' in namespace 'quux':
 
-    tkn task delete foo -n bar
+    tkn task delete foo bar -n quux
 
 or
 
-    tkn t rm foo -n bar
+    tkn t rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -22,7 +22,7 @@ Manage taskruns
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn taskrun cancel](tkn_taskrun_cancel.md)	 - Cancel a TaskRun in a namespace
-* [tkn taskrun delete](tkn_taskrun_delete.md)	 - Delete a taskrun in a namespace
+* [tkn taskrun delete](tkn_taskrun_delete.md)	 - Delete taskruns in a namespace
 * [tkn taskrun describe](tkn_taskrun_describe.md)	 - Describe a taskrun in a namespace
 * [tkn taskrun list](tkn_taskrun_list.md)	 - Lists TaskRuns in a namespace
 * [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show taskruns logs

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -1,6 +1,6 @@
 ## tkn taskrun delete
 
-Delete a taskrun in a namespace
+Delete taskruns in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn taskrun delete
 
 ### Synopsis
 
-Delete a taskrun in a namespace
+Delete taskruns in a namespace
 
 ### Examples
 
-Delete a TaskRun of name 'foo' in namespace 'bar':
+Delete TaskRuns with names 'foo' and 'bar' in namespace 'quux':
 
-    tkn taskrun delete foo -n bar
+    tkn taskrun delete foo bar -n quux
 
 or
 
-    tkn tr rm foo -n bar
+    tkn tr rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_triggerbinding.md
+++ b/docs/cmd/tkn_triggerbinding.md
@@ -21,6 +21,6 @@ Manage triggerbindings
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn triggerbinding delete](tkn_triggerbinding_delete.md)	 - Delete a triggerbinding in a namespace
+* [tkn triggerbinding delete](tkn_triggerbinding_delete.md)	 - Delete triggerbindings in a namespace
 * [tkn triggerbinding list](tkn_triggerbinding_list.md)	 - Lists triggerbindings in a namespace
 

--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -1,6 +1,6 @@
 ## tkn triggerbinding delete
 
-Delete a triggerbinding in a namespace
+Delete triggerbindings in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn triggerbinding delete
 
 ### Synopsis
 
-Delete a triggerbinding in a namespace
+Delete triggerbindings in a namespace
 
 ### Examples
 
-Delete a TriggerBinding of name 'foo' in namespace 'bar'
+Delete TriggerBindings with names 'foo' and 'bar' in namespace 'quux'
 
-    tkn triggerbinding delete foo -n bar
+    tkn triggerbinding delete foo bar -n quux
 
 or
 
-    tkn tb rm foo -n bar
+    tkn tb rm foo bar -n quux
 
 
 ### Options

--- a/docs/cmd/tkn_triggertemplate.md
+++ b/docs/cmd/tkn_triggertemplate.md
@@ -21,6 +21,6 @@ Manage triggertemplates
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn triggertemplate delete](tkn_triggertemplate_delete.md)	 - Delete a triggertemplate in a namespace
+* [tkn triggertemplate delete](tkn_triggertemplate_delete.md)	 - Delete triggertemplates in a namespace
 * [tkn triggertemplate list](tkn_triggertemplate_list.md)	 - Lists triggertemplates in a namespace
 

--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -1,6 +1,6 @@
 ## tkn triggertemplate delete
 
-Delete a triggertemplate in a namespace
+Delete triggertemplates in a namespace
 
 ***Aliases**: rm*
 
@@ -12,17 +12,17 @@ tkn triggertemplate delete
 
 ### Synopsis
 
-Delete a triggertemplate in a namespace
+Delete triggertemplates in a namespace
 
 ### Examples
 
-Delete a TriggerTemplate of name 'foo' in namespace 'bar'
+Delete TriggerTemplates with names 'foo' and 'bar' in namespace 'quux'
 
-    tkn triggertemplate delete foo -n bar
+    tkn triggertemplate delete foo bar -n quux
 
 or
 
-    tkn tt rm foo -n bar
+    tkn tt rm foo bar -n quux
 
 
 ### Options

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertask\-delete \- Delete a clustertask resource in a cluster
+tkn\-clustertask\-delete \- Delete clustertask resources in a cluster
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertask\-delete \- Delete a clustertask resource in a cluster
 
 .SH DESCRIPTION
 .PP
-Delete a clustertask resource in a cluster
+Delete clustertask resources in a cluster
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete a clustertask resource in a cluster
 
 .SH EXAMPLE
 .PP
-Delete a ClusterTask of name 'foo':
+Delete ClusterTasks with names 'foo' and 'bar':
 
 .PP
 .RS
 
 .nf
-tkn clustertask delete foo
+tkn clustertask delete foo bar
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn ct rm foo
+tkn ct rm foo bar
 
 .fi
 .RE

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -61,13 +61,13 @@ Delete a condition in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a Condition of name 'foo' in namespace 'bar':
+Delete Conditions with names 'foo' and 'bar' in namespace 'quux':
 
 .PP
 .RS
 
 .nf
-tkn condition delete foo \-n bar
+tkn condition delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn cond rm foo \-n bar
+tkn cond rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-eventlistener-delete.1
+++ b/docs/man/man1/tkn-eventlistener-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-eventlistener\-delete \- Delete an EventListener in a namespace
+tkn\-eventlistener\-delete \- Delete EventListeners in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-eventlistener\-delete \- Delete an EventListener in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete an EventListener in a namespace
+Delete EventListeners in a namespace
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete an EventListener in a namespace
 
 .SH EXAMPLE
 .PP
-Delete an EventListener of name 'foo' in namespace 'bar'
+Delete EventListeners with names 'foo' and 'bar' in namespace 'bar'
 
 .PP
 .RS
 
 .nf
-tkn eventlistener delete foo \-n bar
+tkn eventlistener delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn el rm foo \-n bar
+tkn el rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipeline\-delete \- Delete a pipeline in a namespace
+tkn\-pipeline\-delete \- Delete pipelines in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipeline\-delete \- Delete a pipeline in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a pipeline in a namespace
+Delete pipelines in a namespace
 
 
 .SH OPTIONS
@@ -65,13 +65,13 @@ Delete a pipeline in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a Pipeline of name 'foo' in namespace 'bar'
+Delete Pipelines with names 'foo' and 'bar' in namespace 'quux'
 
 .PP
 .RS
 
 .nf
-tkn pipeline delete foo \-n bar
+tkn pipeline delete foo bar \-n quux
 
 .fi
 .RE
@@ -83,7 +83,7 @@ or
 .RS
 
 .nf
-tkn p rm foo \-n bar
+tkn p rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun\-delete \- Delete a pipelinerun in a namespace
+tkn\-pipelinerun\-delete \- Delete pipelineruns in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipelinerun\-delete \- Delete a pipelinerun in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a pipelinerun in a namespace
+Delete pipelineruns in a namespace
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete a pipelinerun in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a PipelineRun of name 'foo' in namespace 'bar':
+Delete PipelineRuns with names 'foo' and 'bar' in namespace 'quux':
 
 .PP
 .RS
 
 .nf
-tkn pipelinerun delete foo \-n bar
+tkn pipelinerun delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn pr rm foo \-n bar
+tkn pr rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-resource\-delete \- Delete a pipeline resource in a namespace
+tkn\-resource\-delete \- Delete pipeline resources in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-resource\-delete \- Delete a pipeline resource in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a pipeline resource in a namespace
+Delete pipeline resources in a namespace
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete a pipeline resource in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a PipelineResource of name 'foo' in namespace 'bar':
+Delete PipelineResources with names 'foo' and 'bar' in namespace 'quux':
 
 .PP
 .RS
 
 .nf
-tkn resource delete foo \-n bar
+tkn resource delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn res rm foo \-n bar
+tkn res rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-task\-delete \- Delete a task resource in a namespace
+tkn\-task\-delete \- Delete task resources in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-task\-delete \- Delete a task resource in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a task resource in a namespace
+Delete task resources in a namespace
 
 
 .SH OPTIONS
@@ -65,13 +65,13 @@ Delete a task resource in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a Task of name 'foo' in namespace 'bar':
+Delete Tasks with names 'foo' and 'bar' in namespace 'quux':
 
 .PP
 .RS
 
 .nf
-tkn task delete foo \-n bar
+tkn task delete foo bar \-n quux
 
 .fi
 .RE
@@ -83,7 +83,7 @@ or
 .RS
 
 .nf
-tkn t rm foo \-n bar
+tkn t rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun\-delete \- Delete a taskrun in a namespace
+tkn\-taskrun\-delete \- Delete taskruns in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-taskrun\-delete \- Delete a taskrun in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a taskrun in a namespace
+Delete taskruns in a namespace
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete a taskrun in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a TaskRun of name 'foo' in namespace 'bar':
+Delete TaskRuns with names 'foo' and 'bar' in namespace 'quux':
 
 .PP
 .RS
 
 .nf
-tkn taskrun delete foo \-n bar
+tkn taskrun delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn tr rm foo \-n bar
+tkn tr rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-triggerbinding-delete.1
+++ b/docs/man/man1/tkn-triggerbinding-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggerbinding\-delete \- Delete a triggerbinding in a namespace
+tkn\-triggerbinding\-delete \- Delete triggerbindings in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggerbinding\-delete \- Delete a triggerbinding in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a triggerbinding in a namespace
+Delete triggerbindings in a namespace
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete a triggerbinding in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a TriggerBinding of name 'foo' in namespace 'bar'
+Delete TriggerBindings with names 'foo' and 'bar' in namespace 'quux'
 
 .PP
 .RS
 
 .nf
-tkn triggerbinding delete foo \-n bar
+tkn triggerbinding delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn tb rm foo \-n bar
+tkn tb rm foo bar \-n quux
 
 .fi
 .RE

--- a/docs/man/man1/tkn-triggertemplate-delete.1
+++ b/docs/man/man1/tkn-triggertemplate-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggertemplate\-delete \- Delete a triggertemplate in a namespace
+tkn\-triggertemplate\-delete \- Delete triggertemplates in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggertemplate\-delete \- Delete a triggertemplate in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a triggertemplate in a namespace
+Delete triggertemplates in a namespace
 
 
 .SH OPTIONS
@@ -61,13 +61,13 @@ Delete a triggertemplate in a namespace
 
 .SH EXAMPLE
 .PP
-Delete a TriggerTemplate of name 'foo' in namespace 'bar'
+Delete TriggerTemplates with names 'foo' and 'bar' in namespace 'quux'
 
 .PP
 .RS
 
 .nf
-tkn triggertemplate delete foo \-n bar
+tkn triggertemplate delete foo bar \-n quux
 
 .fi
 .RE
@@ -79,7 +79,7 @@ or
 .RS
 
 .nf
-tkn tt rm foo \-n bar
+tkn tt rm foo bar \-n quux
 
 .fi
 .RE

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/tektoncd/plumbing v0.0.0-20191218171343-56a836c50336
 	github.com/tektoncd/triggers v0.1.1-0.20191218175743-c5b8b4d9ee00
 	go.opencensus.io v0.22.1 // indirect
+	go.uber.org/multierr v1.1.0
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -54,7 +54,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "ClusterTask deleted: tomatoes\n",
+			want:        "ClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -62,7 +62,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "ClusterTask deleted: tomatoes\n",
+			want:        "ClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -78,7 +78,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask \"tomatoes\" (y/n): ClusterTask deleted: tomatoes\n",
+			want:        "Are you sure you want to delete clustertask \"tomatoes\" (y/n): ClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/condition/delete_test.go
+++ b/pkg/cmd/condition/delete_test.go
@@ -73,7 +73,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Condition deleted: condition1\n",
+			want:        "Conditions deleted: \"condition1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -81,7 +81,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Condition deleted: condition1\n",
+			want:        "Conditions deleted: \"condition1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -97,7 +97,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete condition \"condition1\" (y/n): Condition deleted: condition1\n",
+			want:        "Are you sure you want to delete condition \"condition1\" (y/n): Conditions deleted: \"condition1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/eventlistener/delete_test.go
+++ b/pkg/cmd/eventlistener/delete_test.go
@@ -28,7 +28,7 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func TestEvetListenerDelete(t *testing.T) {
+func TestEventListenerDelete(t *testing.T) {
 	ns := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -67,7 +67,7 @@ func TestEvetListenerDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "EventListener deleted: el-1\n",
+			want:        "EventListeners deleted: \"el-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -75,7 +75,7 @@ func TestEvetListenerDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "EventListener deleted: el-1\n",
+			want:        "EventListeners deleted: \"el-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -91,7 +91,7 @@ func TestEvetListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete eventlistener \"el-1\" (y/n): EventListener deleted: el-1\n",
+			want:        "Are you sure you want to delete eventlistener \"el-1\" (y/n): EventListeners deleted: \"el-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/names"
 	"github.com/tektoncd/cli/pkg/helper/options"
 	validate "github.com/tektoncd/cli/pkg/helper/validate"
+	multierr "go.uber.org/multierr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -28,19 +30,19 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteAll: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `Delete a Pipeline of name 'foo' in namespace 'bar'
+	eg := `Delete Pipelines with names 'foo' and 'bar' in namespace 'quux'
 
-    tkn pipeline delete foo -n bar
+    tkn pipeline delete foo bar -n quux
 
 or
 
-    tkn p rm foo -n bar
+    tkn p rm foo bar -n quux
 `
 
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete a pipeline in a namespace",
+		Short:        "Delete pipelines in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
@@ -58,11 +60,11 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args[0]); err != nil {
+			if err := opts.CheckOptions(s, args); err != nil {
 				return err
 			}
 
-			return deletePipeline(opts, s, p, args[0])
+			return deletePipelines(opts, s, p, args)
 		},
 	}
 	f.AddFlags(c)
@@ -73,37 +75,58 @@ or
 	return c
 }
 
-func deletePipeline(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, pName string) error {
+func deletePipelines(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, pNames []string) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return fmt.Errorf("failed to create tekton client")
 	}
 
-	if err := cs.Tekton.TektonV1alpha1().Pipelines(p.Namespace()).Delete(pName, &metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("failed to delete pipeline %q: %s", pName, err)
-	}
-	fmt.Fprintf(s.Out, "Pipeline deleted: %s\n", pName)
-
-	if !opts.DeleteAll {
-		return nil
+	var errs []error
+	addPrintErr := func(err error) {
+		errs = append(errs, err)
+		fmt.Fprintf(s.Err, "%s\n", err)
 	}
 
-	lOpts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pName),
-	}
+	var successfulPipelines []string
+	var successfulPipelineRuns []string
 
-	pipelineRuns, err := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).List(lOpts)
-	if err != nil {
-		return err
-	}
+	for _, pName := range pNames {
+		if err := cs.Tekton.TektonV1alpha1().Pipelines(p.Namespace()).Delete(pName, &metav1.DeleteOptions{}); err != nil {
+			addPrintErr(fmt.Errorf("failed to delete pipeline %q: %s", pName, err))
+			continue
+		}
+		successfulPipelines = append(successfulPipelines, pName)
 
-	for _, pr := range pipelineRuns.Items {
-		if err := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Delete(pr.Name, &metav1.DeleteOptions{}); err != nil {
-			return fmt.Errorf("failed to delete pipelinerun %q: %s", pr.Name, err)
+		if !opts.DeleteAll {
+			continue
 		}
 
-		fmt.Fprintf(s.Out, "PipelineRun deleted: %s\n", pr.Name)
+		lOpts := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pName),
+		}
+
+		pipelineRuns, err := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).List(lOpts)
+		if err != nil {
+			addPrintErr(err)
+			continue
+		}
+
+		for _, pr := range pipelineRuns.Items {
+			if err := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Delete(pr.Name, &metav1.DeleteOptions{}); err != nil {
+				addPrintErr(fmt.Errorf("failed to delete pipelinerun %q: %s", pr.Name, err))
+				continue
+			}
+
+			successfulPipelineRuns = append(successfulPipelineRuns, pr.Name)
+		}
 	}
 
-	return nil
+	if len(successfulPipelineRuns) > 0 {
+		fmt.Fprintf(s.Out, "PipelineRuns deleted: %s\n", names.QuotedList(successfulPipelineRuns))
+	}
+	if len(successfulPipelines) > 0 {
+		fmt.Fprintf(s.Out, "Pipelines deleted: %s\n", names.QuotedList(successfulPipelines))
+	}
+
+	return multierr.Combine(errs...)
 }

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -109,7 +109,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Pipeline deleted: pipeline\n",
+			want:        "Pipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -117,7 +117,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Pipeline deleted: pipeline\n",
+			want:        "Pipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -133,7 +133,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipeline \"pipeline\" (y/n): Pipeline deleted: pipeline\n",
+			want:        "Are you sure you want to delete pipeline \"pipeline\" (y/n): Pipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -149,7 +149,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[3],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipeline and related resources \"pipeline\" (y/n): Pipeline deleted: pipeline\nPipelineRun deleted: pipeline-run-1\nPipelineRun deleted: pipeline-run-2\n",
+			want:        "Are you sure you want to delete pipeline and related resources \"pipeline\" (y/n): PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "With delete all and force delete flag",
@@ -157,7 +157,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[4],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Pipeline deleted: pipeline\nPipelineRun deleted: pipeline-run-1\nPipelineRun deleted: pipeline-run-2\n",
+			want:        "PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
 		},
 	}
 

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -71,7 +71,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineResource deleted: pre-1\n",
+			want:        "PipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -79,7 +79,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineResource deleted: pre-1\n",
+			want:        "PipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -95,7 +95,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelineresource \"pre-1\" (y/n): PipelineResource deleted: pre-1\n",
+			want:        "Are you sure you want to delete pipelineresource \"pre-1\" (y/n): PipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -96,7 +96,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineRun deleted: pipeline-run-1\n",
+			want:        "PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -104,7 +104,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineRun deleted: pipeline-run-1\n",
+			want:        "PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -120,7 +120,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelinerun \"pipeline-run-1\" (y/n): PipelineRun deleted: pipeline-run-1\n",
+			want:        "Are you sure you want to delete pipelinerun \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -88,7 +88,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Task deleted: task\n",
+			want:        "Tasks deleted: \"task\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -96,7 +96,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Task deleted: task\n",
+			want:        "Tasks deleted: \"task\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -112,7 +112,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete task \"task\" (y/n): Task deleted: task\n",
+			want:        "Are you sure you want to delete task \"task\" (y/n): Tasks deleted: \"task\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -128,7 +128,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[3],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete task and related resources \"task\" (y/n): Task deleted: task\nTaskRun deleted: task-run-1\nTaskRun deleted: task-run-2\n",
+			want:        "Are you sure you want to delete task and related resources \"task\" (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
 		},
 		{
 			name:        "With delete all and force delete flag",
@@ -136,7 +136,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[4],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Task deleted: task\nTaskRun deleted: task-run-1\nTaskRun deleted: task-run-2\n",
+			want:        "TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
 		},
 		{
 			name:        "Try to delete task from invalid namespace",

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -78,7 +78,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "TaskRun deleted: tr0-1\n",
+			want:        "TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -86,7 +86,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "TaskRun deleted: tr0-1\n",
+			want:        "TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -102,7 +102,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete taskrun \"tr0-1\" (y/n): TaskRun deleted: tr0-1\n",
+			want:        "Are you sure you want to delete taskrun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/triggerbinding/delete_test.go
+++ b/pkg/cmd/triggerbinding/delete_test.go
@@ -67,7 +67,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "TriggerBinding deleted: tb-1\n",
+			want:        "TriggerBindings deleted: \"tb-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -75,7 +75,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "TriggerBinding deleted: tb-1\n",
+			want:        "TriggerBindings deleted: \"tb-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -91,7 +91,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete triggerbinding \"tb-1\" (y/n): TriggerBinding deleted: tb-1\n",
+			want:        "Are you sure you want to delete triggerbinding \"tb-1\" (y/n): TriggerBindings deleted: \"tb-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/triggertemplate/delete.go
+++ b/pkg/cmd/triggertemplate/delete.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/names"
 	"github.com/tektoncd/cli/pkg/helper/options"
 	"github.com/tektoncd/cli/pkg/helper/validate"
+	"go.uber.org/multierr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -28,19 +30,19 @@ import (
 func deleteCommand(p cli.Params) *cobra.Command {
 	opts := &options.DeleteOptions{Resource: "triggertemplate", ForceDelete: false}
 	f := cliopts.NewPrintFlags("delete")
-	eg := `Delete a TriggerTemplate of name 'foo' in namespace 'bar'
+	eg := `Delete TriggerTemplates with names 'foo' and 'bar' in namespace 'quux'
 
-    tkn triggertemplate delete foo -n bar
+    tkn triggertemplate delete foo bar -n quux
 
 or
 
-    tkn tt rm foo -n bar
+    tkn tt rm foo bar -n quux
 `
 
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete a triggertemplate in a namespace",
+		Short:        "Delete triggertemplates in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
@@ -58,11 +60,11 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args[0]); err != nil {
+			if err := opts.CheckOptions(s, args); err != nil {
 				return err
 			}
 
-			return deleteTriggerTemplate(s, p, args[0])
+			return deleteTriggerTemplates(s, p, args)
 		},
 	}
 	f.AddFlags(c)
@@ -72,16 +74,27 @@ or
 	return c
 }
 
-func deleteTriggerTemplate(s *cli.Stream, p cli.Params, ttName string) error {
+func deleteTriggerTemplates(s *cli.Stream, p cli.Params, ttNames []string) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return fmt.Errorf("failed to create tekton client")
 	}
 
-	if err := cs.Triggers.TektonV1alpha1().TriggerTemplates(p.Namespace()).Delete(ttName, &metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("failed to delete triggertemplate %q: %s", ttName, err)
+	var errs []error
+	var success []string
+
+	for _, ttName := range ttNames {
+		if err := cs.Triggers.TektonV1alpha1().TriggerTemplates(p.Namespace()).Delete(ttName, &metav1.DeleteOptions{}); err != nil {
+			err = fmt.Errorf("failed to delete triggertemplate %q: %s", ttName, err)
+			errs = append(errs, err)
+			fmt.Fprintf(s.Err, "%s\n", err)
+			continue
+		}
+		success = append(success, ttName)
+	}
+	if len(success) > 0 {
+		fmt.Fprintf(s.Out, "TriggerTemplates deleted: %s\n", names.QuotedList(success))
 	}
 
-	fmt.Fprintf(s.Out, "TriggerTemplate deleted: %s\n", ttName)
-	return nil
+	return multierr.Combine(errs...)
 }

--- a/pkg/cmd/triggertemplate/delete_test.go
+++ b/pkg/cmd/triggertemplate/delete_test.go
@@ -67,7 +67,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "TriggerTemplate deleted: tt-1\n",
+			want:        "TriggerTemplates deleted: \"tt-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -75,7 +75,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "TriggerTemplate deleted: tt-1\n",
+			want:        "TriggerTemplates deleted: \"tt-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -91,7 +91,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete triggertemplate \"tt-1\" (y/n): TriggerTemplate deleted: tt-1\n",
+			want:        "Are you sure you want to delete triggertemplate \"tt-1\" (y/n): TriggerTemplates deleted: \"tt-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/helper/names/formats.go
+++ b/pkg/helper/names/formats.go
@@ -1,0 +1,14 @@
+package names
+
+import (
+	"fmt"
+	"strings"
+)
+
+func QuotedList(names []string) string {
+	quoted := make([]string, len(names))
+	for i := range names {
+		quoted[i] = fmt.Sprintf("%q", names[i])
+	}
+	return strings.Join(quoted, ", ")
+}

--- a/pkg/helper/options/delete.go
+++ b/pkg/helper/options/delete.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/names"
 )
 
 type DeleteOptions struct {
@@ -28,15 +29,16 @@ type DeleteOptions struct {
 	DeleteAll   bool
 }
 
-func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceName string) error {
+func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string) error {
 	if o.ForceDelete {
 		return nil
 	}
 
+	formattedNames := names.QuotedList(resourceNames)
 	if o.DeleteAll {
-		fmt.Fprintf(s.Out, "Are you sure you want to delete %s and related resources %q (y/n): ", o.Resource, resourceName)
+		fmt.Fprintf(s.Out, "Are you sure you want to delete %s and related resources %s (y/n): ", o.Resource, formattedNames)
 	} else {
-		fmt.Fprintf(s.Out, "Are you sure you want to delete %s %q (y/n): ", o.Resource, resourceName)
+		fmt.Fprintf(s.Out, "Are you sure you want to delete %s %s (y/n): ", o.Resource, formattedNames)
 	}
 
 	scanner := bufio.NewScanner(s.In)
@@ -45,7 +47,7 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceName string) error {
 		if t == "y" {
 			break
 		} else if t == "n" {
-			return fmt.Errorf("canceled deleting %s %q", o.Resource, resourceName)
+			return fmt.Errorf("canceled deleting %s %s", o.Resource, formattedNames)
 		}
 		fmt.Fprint(s.Out, "Please enter (y/n): ")
 	}

--- a/pkg/helper/options/delete_test.go
+++ b/pkg/helper/options/delete_test.go
@@ -26,58 +26,74 @@ import (
 func TestDeleteOptions(t *testing.T) {
 
 	testParams := []struct {
-		name         string
-		opt          *DeleteOptions
-		stream       *cli.Stream
-		resourceName string
-		wantError    bool
-		want         string
+		name           string
+		opt            *DeleteOptions
+		stream         *cli.Stream
+		resourcesNames []string
+		wantError      bool
+		want           string
 	}{
 		{
-			name:         "Default Option",
-			opt:          &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
-			stream:       &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
-			resourceName: "test",
-			wantError:    false,
-			want:         "",
+			name:           "Default Option",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{"test"},
+			wantError:      false,
+			want:           "",
 		},
 		{
-			name:         "Specify ForceDelete flag, answer yes",
-			opt:          &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteAll: false},
-			stream:       &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
-			resourceName: "test",
-			wantError:    false,
-			want:         "",
+			name:           "Specify ForceDelete flag, answer yes",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteAll: false},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{"test"},
+			wantError:      false,
+			want:           "",
 		},
 		{
-			name:         "Specify ForceDelete flag, answer no",
-			opt:          &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteAll: false},
-			stream:       &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
-			resourceName: "test",
-			wantError:    false,
-			want:         "",
+			name:           "Specify ForceDelete flag, answer no",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteAll: false},
+			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
+			resourcesNames: []string{"test"},
+			wantError:      false,
+			want:           "",
 		},
 		{
-			name:         "Specify DeleteAll flag, answer yes",
-			opt:          &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: true},
-			stream:       &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
-			resourceName: "test",
-			wantError:    false,
-			want:         "",
+			name:           "Specify DeleteAll flag, answer yes",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: true},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{"test"},
+			wantError:      false,
+			want:           "",
 		},
 		{
-			name:         "Specify DeleteAll flag, answer no",
-			opt:          &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: true},
-			stream:       &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
-			resourceName: "test",
-			wantError:    true,
-			want:         "canceled deleting testRes \"test\"",
+			name:           "Specify DeleteAll flag, answer no",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: true},
+			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
+			resourcesNames: []string{"test"},
+			wantError:      true,
+			want:           "canceled deleting testRes \"test\"",
+		},
+		{
+			name:           "Specify multiple resources, answer yes",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{"test1", "test2"},
+			wantError:      false,
+			want:           "",
+		},
+		{
+			name:           "Specify multiple resources, answer no",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
+			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
+			resourcesNames: []string{"test1", "test2"},
+			wantError:      true,
+			want:           "canceled deleting testRes \"test1\", \"test2\"",
 		},
 	}
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			err := tp.opt.CheckOptions(tp.stream, tp.resourceName)
+			err := tp.opt.CheckOptions(tp.stream, tp.resourcesNames)
 			if tp.wantError {
 				if err == nil {
 					t.Fatal("error expected here")


### PR DESCRIPTION
# Changes

Fixes https://github.com/tektoncd/cli/issues/572

This commit allows the user to delete multiple resources of the same kind at once. For example, to delete multiple tasks the user can issue the command `tkn task delete foo bar baz -n mynamespace` and all three tasks, foo, bar, and baz, will be deleted.

The user is only asked to confirm the multiple deletions a single time. Each deletion is handled individually, meaning that it's possible for some deletions to fail while the rest go on to succeed. However, if any deletions do fail then the command will end as an error.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Users can now delete multiple resources at once by providing more than one name to delete commands
```
