### PR TITLE
Add tkn task start -f With Remote Files

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -30,7 +30,7 @@ like cat,foo,bar
 ### Options
 
 ```
-  -f, --filename string          filename containing a task definition
+  -f, --filename string          local or remote file name containing a task definition
   -h, --help                     help for start
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -21,7 +21,7 @@ Start tasks
 .SH OPTIONS
 .PP
 \fB\-f\fP, \fB\-\-filename\fP=""
-    filename containing a task definition
+    local or remote file name containing a task definition
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,7 @@ k8s.io/api v0.0.0-20191004102255-dacd7df5a50b h1:38Nx0U83WjBqn1hUWxlgKc7mvH7WhyH
 k8s.io/api v0.0.0-20191004102255-dacd7df5a50b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a h1:lDydUqHrbL/1l5ZQrqD1RIlabhmX8aiZEtxVUb+30iU=
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.17.0 h1:xRBnuie9rXcPxUkDizUsGvPf1cnlZCFu210op7J7LJo=
 k8s.io/cli-runtime v0.0.0-20191004110054-fe9b9282443f h1:vJOrMsZe+RD884n+WQ5So2oOp7SajI0Op3oOBg64ZsY=
 k8s.io/cli-runtime v0.0.0-20191004110054-fe9b9282443f/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/client-go v0.0.0-20191004102537-eb5b9a8cfde7 h1:WyPHgjjXvF4zVVwKGZKKiJGBUW45AuN44uSOuH8euuE=


### PR DESCRIPTION
Closes #557 

This pull request adds the ability to start a taskrun based on a task definition that does not exist in a namespace from a remote file definition. As of now, it only supports local files.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Allow tkn task start -f to work with remote files
```
