### PR TITLE
Refactor delete command code to be a bit more DRY

### DIFF
--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -86,7 +86,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
-			want:        "Failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/helper/deleter/deleter.go
+++ b/pkg/helper/deleter/deleter.go
@@ -1,0 +1,101 @@
+package deleter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/names"
+	"go.uber.org/multierr"
+)
+
+// Deleter encapsulates behaviour around deleting resources and their relations.
+// While actually performing a deletion is left to calling code, this helper
+// type standardizes the sequencing, messaging and error handling related to
+// deletions.
+type Deleter struct {
+	errors                   []error
+	successfulDeletes        []string
+	successfulRelatedDeletes []string
+
+	kind        string
+	relatedKind string
+
+	delete func(string) error
+
+	listRelated   func(string) ([]string, error)
+	deleteRelated func(string) error
+}
+
+// New returns a Deleter that will delete resources of kind with the given
+// delete func when Execute is called.
+func New(kind string, deleteFunc func(string) error) *Deleter {
+	return &Deleter{
+		kind:   kind,
+		delete: deleteFunc,
+	}
+}
+
+// WithRelated tells this Deleter that it should also delete related resources
+// when Execute is called. Related resources will be of given kind, the names of
+// those resources must be provided by listFunc and each related resource will be
+// passed to deleteFunc for deletion.
+func (d *Deleter) WithRelated(kind string, listFunc func(string) ([]string, error), deleteFunc func(string) error) {
+	d.relatedKind = kind
+	d.listRelated = listFunc
+	d.deleteRelated = deleteFunc
+}
+
+// Execute performs the deletion of resources and relations. Errors are aggregated
+// and returned at the end of the func.
+func (d *Deleter) Execute(streams *cli.Stream, resourceNames []string) error {
+	for _, name := range resourceNames {
+		if err := d.delete(name); err != nil {
+			d.printAndAddError(streams, fmt.Errorf("failed to delete %s %q: %s", strings.ToLower(d.kind), name, err))
+		} else {
+			d.successfulDeletes = append(d.successfulDeletes, name)
+		}
+	}
+	if d.relatedKind != "" && d.listRelated != nil && d.deleteRelated != nil {
+		for _, name := range d.successfulDeletes {
+			d.deleteRelatedList(streams, name)
+		}
+	}
+	d.printSuccesses(streams)
+	return multierr.Combine(d.errors...)
+}
+
+// deleteRelatedList gets the list of resources related to resourceName using the
+// provided listFunc and then calls the deleteRelated func for each relation.
+func (d *Deleter) deleteRelatedList(streams *cli.Stream, resourceName string) {
+	if related, err := d.listRelated(resourceName); err != nil {
+		d.printAndAddError(streams, err)
+	} else {
+		for _, subresource := range related {
+			if err := d.deleteRelated(subresource); err != nil {
+				err = fmt.Errorf("failed to delete %s %q: %s", strings.ToLower(d.relatedKind), subresource, err)
+				d.printAndAddError(streams, err)
+			} else {
+				d.successfulRelatedDeletes = append(d.successfulRelatedDeletes, subresource)
+			}
+		}
+	}
+}
+
+// printSuccesses writes success messages to the provided stdout stream.
+func (d *Deleter) printSuccesses(streams *cli.Stream) {
+	if len(d.successfulRelatedDeletes) > 0 {
+		fmt.Fprintf(streams.Out, "%ss deleted: %s\n", d.relatedKind, names.QuotedList(d.successfulRelatedDeletes))
+	}
+	if len(d.successfulDeletes) > 0 {
+		fmt.Fprintf(streams.Out, "%ss deleted: %s\n", d.kind, names.QuotedList(d.successfulDeletes))
+	}
+}
+
+// printAndAddError prints the given error to the given stderr stream and
+// adds that error to the list of accumulated errors that have occurred
+// during execution.
+func (d *Deleter) printAndAddError(streams *cli.Stream, err error) {
+	d.errors = append(d.errors, err)
+	fmt.Fprintf(streams.Err, "%s\n", err)
+}

--- a/pkg/helper/deleter/deleter_test.go
+++ b/pkg/helper/deleter/deleter_test.go
@@ -1,0 +1,61 @@
+package deleter
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/cli"
+)
+
+func TestExecute(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		names       []string
+		expectedOut string
+		expectedErr string
+		deleteFunc  func(string) error
+	}{{
+		description: "doesnt print anything if no names provided",
+		names:       []string{},
+		expectedOut: "",
+		expectedErr: "",
+		deleteFunc:  func(string) error { return nil },
+	}, {
+		description: "prints success message if names provided",
+		names:       []string{"foo", "bar"},
+		expectedOut: "FooBars deleted: \"foo\", \"bar\"\n",
+		expectedErr: "",
+		deleteFunc:  func(string) error { return nil },
+	}, {
+		description: "prints errors if returned during delete",
+		names:       []string{"baz"},
+		expectedOut: "",
+		expectedErr: "failed to delete foobar \"baz\": there was an unfortunate incident\n",
+		deleteFunc:  func(string) error { return errors.New("there was an unfortunate incident") },
+	}, {
+		description: "prints multiple errors if multiple deletions fail",
+		names:       []string{"baz", "quux"},
+		expectedOut: "",
+		expectedErr: "failed to delete foobar \"baz\": there was an unfortunate incident\nfailed to delete foobar \"quux\": there was an unfortunate incident\n",
+		deleteFunc:  func(string) error { return errors.New("there was an unfortunate incident") },
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			stdout := &strings.Builder{}
+			stderr := &strings.Builder{}
+			streams := &cli.Stream{Out: stdout, Err: stderr}
+			d := New("FooBar", tc.deleteFunc)
+			if err := d.Execute(streams, tc.names); err != nil {
+				if tc.expectedErr == "" {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if stdout.String() != tc.expectedOut {
+				t.Errorf("expected stdout %q received %q", tc.expectedOut, stdout.String())
+			}
+			if stderr.String() != tc.expectedErr {
+				t.Errorf("expected stderr %q received %q", tc.expectedErr, stderr.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

While implementing [multiple delete](https://github.com/tektoncd/cli/pull/577) I noticed that each delete command was implementing its own error handling and messaging even though each was doing exactly the same thing. This made working on the code more error-prone - I had to double check that I'd added each of my changes correctly across every repetition of the delete behaviour.

So this commit introduces a helper type, `Deleter`, that does most of the repetitive work and is now reused across all the delete commands.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)