### PR TITLE
Add nil Check for PipelineRun Desc TaskRun Sorting

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,7 @@ knative.dev/caching v0.0.0-20190719140829-2032732871ff h1:PrlDvOGvCASqW5Fs3ZGes0
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/pkg v0.0.0-20190909195211-528ad1c1dd62 h1:0neKnC9hstF5Lewj6OaAJdXqk22IZ7pnOPQ8Zl8cfq4=
 knative.dev/pkg v0.0.0-20190909195211-528ad1c1dd62/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
+knative.dev/pkg v0.0.0-20200108203553-8c6241207427 h1:swUPz/GhGE0bdXX8Ys6AXhjshbCcYXgW9weH7LvK28U=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -217,8 +217,16 @@ func newTaskrunListFromMap(statusMap map[string]*v1alpha1.PipelineRunTaskRunStat
 	return trl
 }
 
-func (s taskrunList) Len() int      { return len(s) }
-func (s taskrunList) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s taskrunList) Less(i, j int) bool {
-	return s[j].Status.StartTime.Before(s[i].Status.StartTime)
+func (trs taskrunList) Len() int      { return len(trs) }
+func (trs taskrunList) Swap(i, j int) { trs[i], trs[j] = trs[j], trs[i] }
+func (trs taskrunList) Less(i, j int) bool {
+	if trs[j].Status.StartTime == nil {
+		return false
+	}
+
+	if trs[i].Status.StartTime == nil {
+		return true
+	}
+
+	return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
 }


### PR DESCRIPTION
Closes #584 

There isn't a nil check in place for when a TaskRun doesn't have a starting time. This causes the issue reported in #584. 

This issue has been reported and resolved previously for sorting pipelineruns/taskruns and the changes in this pr have been shown to resolve the issue. We just simply missed updating `tkn pr desc` after the original bug was reported. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add nil check for tkn pr desc taskrun sorting
```
