### PR TITLE
Add coloured status condition

### DIFF
--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -15,13 +15,24 @@
 package formatted
 
 import (
+	"github.com/fatih/color"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
+var ConditionColor = map[string]color.Attribute{
+	"Failed":    color.FgHiRed,
+	"Succeeded": color.FgHiGreen,
+	"Running":   color.FgHiBlue,
+	"Cancelled": color.FgHiMagenta,
+}
+
+func colorStatus(status string) string {
+	return color.New(ConditionColor[status]).Sprint(status)
+}
+
 // Condition returns a human readable text based on the status of the Condition
 func Condition(c v1beta1.Conditions) string {
-
 	var status string
 	if len(c) == 0 {
 		return "---"
@@ -35,14 +46,17 @@ func Condition(c v1beta1.Conditions) string {
 	case corev1.ConditionUnknown:
 		status = "Running"
 	}
+	cstatus := colorStatus(status)
 
 	if c[0].Reason != "" && c[0].Reason != status {
 
 		if c[0].Reason == "PipelineRunCancelled" || c[0].Reason == "TaskRunCancelled" {
-			status = "Cancelled" + "(" + c[0].Reason + ")"
-		} else {
-			status = status + "(" + c[0].Reason + ")"
+			status = colorStatus("Cancelled") + "(" + c[0].Reason + ")"
+		} else if c[0].Reason != status {
+			status = cstatus + "(" + c[0].Reason + ")"
 		}
+	} else {
+		status = cstatus
 	}
 
 	return status

--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -1,0 +1,15 @@
+package formatted
+
+import (
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestColor(t *testing.T) {
+	greenSuccess := color.New(color.FgHiGreen).Sprint("Succeeded")
+	cs := colorStatus("Succeeded")
+	if cs != greenSuccess {
+		t.Errorf("%s != %s", cs, greenSuccess)
+	}
+}


### PR DESCRIPTION
Simple colours of status.Condition, if there is a unknown status it would fall
back to normal color.

It would respect `-C/--no-colour` if we don't want color

Fixed at the same time a small bug when status == Reason it would show
status(status) so twice, now it would only show it when status != Reason

How it would look like : 

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/98980/72171140-9ab62b00-33d2-11ea-8847-0a27950bc3c3.png">

(may add more colours or emojis in the future. 😛 )

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [👍] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)

# Release Notes

```
conditions (ie: running/stopped or other) are now coloured..
```