### PR TITLE
Sort Steps for tkn taskrun desc by StartedAt

### DIFF
--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -509,3 +509,194 @@ func TestTaskRunDescribe_cancel_taskrun(t *testing.T) {
 	}
 	golden.Assert(t, actual, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func Test_SortStepStatesByStartTime_Waiting_Not_Nil(t *testing.T) {
+	stepStates := []v1alpha1.StepState{
+		{
+			Name: "step1",
+			ContainerState: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				},
+			},
+		},
+		{
+			Name: "step2",
+			ContainerState: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				},
+			},
+		},
+	}
+
+	sortedSteps := sortStepStatesByStartTime(stepStates)
+
+	element0 := sortedSteps[0].Name
+	if element0 != "step1" {
+		t.Errorf("sortStepStatesByStartTime should be step1 but returned: %s", element0)
+	}
+
+	element1 := sortedSteps[1].Name
+	if element1 != "step2" {
+		t.Errorf("sortStepStatesByStartTime should be step2 but returned: %s", element1)
+	}
+}
+
+func Test_SortStepStatesByStartTime_Step1_Running(t *testing.T) {
+	stepStates := []v1alpha1.StepState{
+		{
+			Name: "step1",
+			ContainerState: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+		{
+			Name: "step2",
+			ContainerState: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				},
+			},
+		},
+	}
+
+	sortedSteps := sortStepStatesByStartTime(stepStates)
+
+	element0 := sortedSteps[0].Name
+	if element0 != "step1" {
+		t.Errorf("sortStepStatesByStartTime should be step1 but returned: %s", element0)
+	}
+
+	element1 := sortedSteps[1].Name
+	if element1 != "step2" {
+		t.Errorf("sortStepStatesByStartTime should be step2 but returned: %s", element1)
+	}
+}
+
+func Test_SortStepStatesByStartTime_Step2_Running(t *testing.T) {
+	stepStates := []v1alpha1.StepState{
+		{
+			Name: "step1",
+			ContainerState: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				},
+			},
+		},
+		{
+			Name: "step2",
+			ContainerState: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+	}
+
+	sortedSteps := sortStepStatesByStartTime(stepStates)
+
+	element0 := sortedSteps[0].Name
+	if element0 != "step2" {
+		t.Errorf("sortStepStatesByStartTime should be step2 but returned: %s", element0)
+	}
+
+	element1 := sortedSteps[1].Name
+	if element1 != "step1" {
+		t.Errorf("sortStepStatesByStartTime should be step1 but returned: %s", element1)
+	}
+}
+
+func Test_SortStepStatesByStartTime_Both_Steps_Running(t *testing.T) {
+	stepStates := []v1alpha1.StepState{
+		{
+			Name: "step1",
+			ContainerState: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+				},
+			},
+		},
+		{
+			Name: "step2",
+			ContainerState: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Now().Add(-2 * time.Minute)},
+				},
+			},
+		},
+	}
+
+	sortedSteps := sortStepStatesByStartTime(stepStates)
+
+	element0 := sortedSteps[0].Name
+	if element0 != "step2" {
+		t.Errorf("sortStepStatesByStartTime should be step2 but returned: %s", element0)
+	}
+
+	element1 := sortedSteps[1].Name
+	if element1 != "step1" {
+		t.Errorf("sortStepStatesByStartTime should be step1 but returned: %s", element1)
+	}
+}
+
+func Test_SortStepStatesByStartTime_Steps_Terminated_And_Running(t *testing.T) {
+	stepStates := []v1alpha1.StepState{
+		{
+			Name: "step1",
+			ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					StartedAt: metav1.Time{Time: time.Now().Add(-4 * time.Minute)},
+				},
+			},
+		},
+		{
+			Name: "step2",
+			ContainerState: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Now().Add(-2 * time.Minute)},
+				},
+			},
+		},
+		{
+			Name: "step3",
+			ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					StartedAt: metav1.Time{Time: time.Now().Add(-3 * time.Minute)},
+				},
+			},
+		},
+		{
+			Name: "step4",
+			ContainerState: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+				},
+			},
+		},
+	}
+
+	sortedSteps := sortStepStatesByStartTime(stepStates)
+
+	element0 := sortedSteps[0].Name
+	if element0 != "step1" {
+		t.Errorf("sortStepStatesByStartTime should be step1 but returned: %s", element0)
+	}
+
+	element1 := sortedSteps[1].Name
+	if element1 != "step3" {
+		t.Errorf("sortStepStatesByStartTime should be step3 but returned: %s", element1)
+	}
+
+	element2 := sortedSteps[2].Name
+	if element2 != "step2" {
+		t.Errorf("sortStepStatesByStartTime should be step2 but returned: %s", element2)
+	}
+
+	element3 := sortedSteps[3].Name
+	if element3 != "step4" {
+		t.Errorf("sortStepStatesByStartTime should be step3 but returned: %s", element3)
+	}
+}


### PR DESCRIPTION
Closes #460 

This pull request sorts steps that are part of a TaskRun by start time. The start time is from a list of StepStates part of the TaskRun. Each StepState has a Terminated/Running container state from which the `StartedAt` field can be pulled. If the container state is in a waiting state (i.e. PodInitializing), the order will be determined by how steps are ordered for the Task.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Sort steps by start time for tkn tr desc
```
