### PR TITLE
Add colouring for steps status 🎨 

### DIFF
--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -24,10 +24,13 @@ var ConditionColor = map[string]color.Attribute{
 	"Failed":    color.FgHiRed,
 	"Succeeded": color.FgHiGreen,
 	"Running":   color.FgHiBlue,
-	"Cancelled": color.FgHiMagenta,
+	"Cancelled": color.FgHiYellow,
+	"Completed": color.FgHiMagenta,
+	"Pending":   color.FgHiWhite,
 }
 
-func colorStatus(status string) string {
+// ColorStatus Get a status coloured
+func ColorStatus(status string) string {
 	return color.New(ConditionColor[status]).Sprint(status)
 }
 
@@ -46,12 +49,12 @@ func Condition(c v1beta1.Conditions) string {
 	case corev1.ConditionUnknown:
 		status = "Running"
 	}
-	cstatus := colorStatus(status)
+	cstatus := ColorStatus(status)
 
 	if c[0].Reason != "" && c[0].Reason != status {
 
 		if c[0].Reason == "PipelineRunCancelled" || c[0].Reason == "TaskRunCancelled" {
-			status = colorStatus("Cancelled") + "(" + c[0].Reason + ")"
+			status = ColorStatus("Cancelled") + "(" + c[0].Reason + ")"
 		} else if c[0].Reason != status {
 			status = cstatus + "(" + c[0].Reason + ")"
 		}

--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestColor(t *testing.T) {
 	greenSuccess := color.New(color.FgHiGreen).Sprint("Succeeded")
-	cs := colorStatus("Succeeded")
+	cs := ColorStatus("Succeeded")
 	if cs != greenSuccess {
 		t.Errorf("%s != %s", cs, greenSuccess)
 	}

--- a/pkg/helper/validate/validate.go
+++ b/pkg/helper/validate/validate.go
@@ -17,6 +17,7 @@ package validate
 import (
 	"fmt"
 
+	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
@@ -94,15 +95,15 @@ func StepReasonExists(state v1alpha1.StepState) string {
 	if state.Waiting == nil {
 
 		if state.Running != nil {
-			return "Running"
+			return formatted.ColorStatus("Running")
 		}
 
 		if state.Terminated != nil {
-			return state.Terminated.Reason
+			return formatted.ColorStatus(state.Terminated.Reason)
 		}
 
-		return pendingState
+		return formatted.ColorStatus(pendingState)
 	}
 
-	return state.Waiting.Reason
+	return formatted.ColorStatus(state.Waiting.Reason)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Steps status is coloured now 🌈 🎨 

![image](https://user-images.githubusercontent.com/98980/72264166-88c6c900-361a-11ea-8fb2-17d5fcac36fa.png)


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```