### PR TITLE
Correct tkn task start Typo

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -20,7 +20,7 @@ Start Task foo by creating a TaskRun named "foo-run-xyz123" from namespace 'bar'
 
     tkn task start foo -s ServiceAccountName -n bar
 
-The rask can either be specified by reference in a cluster using the positional argument
+The task can either be specified by reference in a cluster using the positional argument
 or in a file using the --filename argument.
 
 For params value, if you want to provide multiple values, provide them comma separated

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -92,7 +92,7 @@ tkn task start foo \-s ServiceAccountName \-n bar
 .RE
 
 .PP
-The rask can either be specified by reference in a cluster using the positional argument
+The task can either be specified by reference in a cluster using the positional argument
 or in a file using the \-\-filename argument.
 
 .PP

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -100,7 +100,7 @@ func startCommand(p cli.Params) *cobra.Command {
 
     tkn task start foo -s ServiceAccountName -n bar
 
-The rask can either be specified by reference in a cluster using the positional argument
+The task can either be specified by reference in a cluster using the positional argument
 or in a file using the --filename argument.
 
 For params value, if you want to provide multiple values, provide them comma separated


### PR DESCRIPTION
Changing `rask` -> `task`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Correcting typo in tkn task start description
```
