### PR TITLE
Remove Second TaskRun from tkn pr desc Test

### DIFF
--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -822,14 +822,6 @@ func TestPipelineRunDescribe_without_tr_start_time(t *testing.T) {
 				}),
 			),
 		),
-		tb.TaskRun("tr-2", "ns",
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Type:   apis.ConditionReady,
-					Status: corev1.ConditionUnknown,
-				}),
-			),
-		),
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
@@ -845,10 +837,6 @@ func TestPipelineRunDescribe_without_tr_start_time(t *testing.T) {
 					}),
 					tb.PipelineRunTaskRunsStatus("tr-1", &v1alpha1.PipelineRunTaskRunStatus{
 						PipelineTaskName: "t-1",
-						Status:           &trs[0].Status,
-					}),
-					tb.PipelineRunTaskRunsStatus("tr-2", &v1alpha1.PipelineRunTaskRunStatus{
-						PipelineTaskName: "t-2",
 						Status:           &trs[0].Status,
 					}),
 					tb.PipelineRunStartTime(clock.Now()),
@@ -890,7 +878,6 @@ No params
 Taskruns
 NAME   TASK NAME   STARTED   DURATION   STATUS
 tr-1   t-1         ---       ---        Running
-tr-2   t-2         ---       ---        Running
 `
 
 	test.AssertOutput(t, expected, actual)


### PR DESCRIPTION
Closes #599 

This pull request changes the flaky unit test in #599 to have only one taskrun. This will prevent the taskruns for the pipelinerun in the test from having inconsistent ordering while achieving the same level of code coverage.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

N/A
