### PR TITLE
Delete taskruns related to pipeline

### DIFF
--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-  -a, --all                           Whether to delete related resources (pipelineruns) (default: false)
+  -a, --all                           Whether to delete related resources (pipelineruns, taskruns) (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -21,7 +21,7 @@ Delete pipelines in a namespace
 .SH OPTIONS
 .PP
 \fB\-a\fP, \fB\-\-all\fP[=false]
-    Whether to delete related resources (pipelineruns) (default: false)
+    Whether to delete related resources (pipelineruns, taskruns) (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]

--- a/pkg/helper/deleter/deleter_test.go
+++ b/pkg/helper/deleter/deleter_test.go
@@ -20,25 +20,25 @@ func TestExecute(t *testing.T) {
 		names:       []string{},
 		expectedOut: "",
 		expectedErr: "",
-		deleteFunc:  func(string) error { return nil },
+		deleteFunc:  successfulDeleteFunc,
 	}, {
 		description: "prints success message if names provided",
 		names:       []string{"foo", "bar"},
 		expectedOut: "FooBars deleted: \"foo\", \"bar\"\n",
 		expectedErr: "",
-		deleteFunc:  func(string) error { return nil },
+		deleteFunc:  successfulDeleteFunc,
 	}, {
 		description: "prints errors if returned during delete",
 		names:       []string{"baz"},
 		expectedOut: "",
-		expectedErr: "failed to delete foobar \"baz\": there was an unfortunate incident\n",
-		deleteFunc:  func(string) error { return errors.New("there was an unfortunate incident") },
+		expectedErr: "failed to delete foobar \"baz\": unsuccessful delete func\n",
+		deleteFunc:  unsuccessfulDeleteFunc,
 	}, {
 		description: "prints multiple errors if multiple deletions fail",
 		names:       []string{"baz", "quux"},
 		expectedOut: "",
-		expectedErr: "failed to delete foobar \"baz\": there was an unfortunate incident\nfailed to delete foobar \"quux\": there was an unfortunate incident\n",
-		deleteFunc:  func(string) error { return errors.New("there was an unfortunate incident") },
+		expectedErr: "failed to delete foobar \"baz\": unsuccessful delete func\nfailed to delete foobar \"quux\": unsuccessful delete func\n",
+		deleteFunc:  unsuccessfulDeleteFunc,
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			stdout := &strings.Builder{}
@@ -58,4 +58,98 @@ func TestExecute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWithRelated(t *testing.T) {
+	type related struct {
+		kind   string
+		list   func(string) ([]string, error)
+		delete func(string) error
+	}
+
+	for _, tc := range []struct {
+		description string
+		related     []related
+		expectedErr string
+	}{{
+		description: "single related kind is deleted ok",
+		related: []related{{
+			kind:   "FooBar",
+			list:   successfulListFunc,
+			delete: successfulDeleteFunc,
+		}},
+	}, {
+		description: "multiple related kinds are deleted ok",
+		related: []related{{
+			kind:   "FooBar",
+			list:   successfulListFunc,
+			delete: successfulDeleteFunc,
+		}, {
+			kind:   "BazQuux",
+			list:   successfulListFunc,
+			delete: successfulDeleteFunc,
+		}},
+	}, {
+		description: "failure to delete one related kind does not cause others to fail",
+		related: []related{{
+			kind:   "FooBar",
+			list:   successfulListFunc,
+			delete: unsuccessfulDeleteFunc,
+		}, {
+			kind:   "BazQuux",
+			list:   successfulListFunc,
+			delete: successfulDeleteFunc,
+		}},
+		expectedErr: `deleting relation of "foo", failed to delete foobar "related1": unsuccessful delete func
+deleting relation of "foo", failed to delete foobar "related2": unsuccessful delete func
+`,
+	}, {
+		description: "failure to list one related kind does not cause others to fail deletion",
+		related: []related{{
+			kind:   "FooBar",
+			list:   unsuccessfulListFunc,
+			delete: successfulDeleteFunc,
+		}, {
+			kind:   "BazQuux",
+			list:   successfulListFunc,
+			delete: successfulDeleteFunc,
+		}},
+		expectedErr: "fetching list of foobars related to \"foo\" failed: unsuccessful list func\n",
+	}} {
+		names := []string{"foo"}
+
+		t.Run(tc.description, func(t *testing.T) {
+			stdout := &strings.Builder{}
+			stderr := &strings.Builder{}
+			streams := &cli.Stream{Out: stdout, Err: stderr}
+			d := New("FooBar", successfulDeleteFunc)
+			for _, related := range tc.related {
+				d.WithRelated(related.kind, related.list, related.delete)
+			}
+			if err := d.Execute(streams, names); err != nil {
+				if tc.expectedErr == "" {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if stderr.String() != tc.expectedErr {
+				t.Errorf("expected stderr %q received %q", tc.expectedErr, stderr.String())
+			}
+		})
+	}
+}
+
+func successfulListFunc(string) ([]string, error) {
+	return []string{"related1", "related2"}, nil
+}
+
+func unsuccessfulListFunc(string) ([]string, error) {
+	return nil, errors.New("unsuccessful list func")
+}
+
+func successfulDeleteFunc(string) error {
+	return nil
+}
+
+func unsuccessfulDeleteFunc(string) error {
+	return errors.New("unsuccessful delete func")
 }


### PR DESCRIPTION
# Changes

Fixes #588 

This PR updates the deleter helper to support removing multiple kinds of related resources and adds some testing around that behaviour.

This PR then updates the pipeline delete command so that specifying `--all` causes related taskruns as well as pipelineruns to be deleted.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Deleting a pipeline with the --all flag will now delete related taskruns as well as pipelineruns.
```
