### PR TITLE
Fix release tarball version to remove the v at first

### DIFF
--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -101,7 +101,7 @@ for c in ${COMMITS};do
 done
 
 # Add our VERSION so Makefile will pick it up when compiling
-echo ${RELEASE_VERSION} > VERSION
+echo ${RELEASE_VERSION#v} > VERSION
 git add VERSION
 git commit -sm "New version ${RELEASE_VERSION}" -m "${changelog}" VERSION
 git tag --sign -m \


### PR DESCRIPTION
Fix so we don't have a v at the begining of the version number, so we have the
same version as the other released version.

Should make it for the next release.

Closes #604