### PR TITLE
Add flag to task and pipeline to only delete related resources

### DIFF
--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-  -a, --all                           Whether to delete related resources (pipelineruns) (default: false)
+  -a, --all                           Whether to also delete related resources (pipelineruns) (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -32,6 +32,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+  -p, --pipeline string               The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-  -a, --all                           Whether to delete related resources (taskruns) (default: false)
+  -a, --all                           Whether to also delete related resources (taskruns) (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -32,6 +32,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+  -t, --task string                   The name of a task whose taskruns should be deleted (does not delete the task)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -21,7 +21,7 @@ Delete pipelines in a namespace
 .SH OPTIONS
 .PP
 \fB\-a\fP, \fB\-\-all\fP[=false]
-    Whether to delete related resources (pipelineruns) (default: false)
+    Whether to also delete related resources (pipelineruns) (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -36,6 +36,10 @@ Delete pipelineruns in a namespace
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 
 .PP
+\fB\-p\fP, \fB\-\-pipeline\fP=""
+    The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
+
+.PP
 \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -21,7 +21,7 @@ Delete task resources in a namespace
 .SH OPTIONS
 .PP
 \fB\-a\fP, \fB\-\-all\fP[=false]
-    Whether to delete related resources (taskruns) (default: false)
+    Whether to also delete related resources (taskruns) (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -36,6 +36,10 @@ Delete taskruns in a namespace
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 
 .PP
+\fB\-t\fP, \fB\-\-task\fP=""
+    The name of a task whose taskruns should be deleted (does not delete the task)
+
+.PP
 \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -75,5 +75,7 @@ func deleteClusterTasks(s *cli.Stream, p cli.Params, tNames []string) error {
 	d := deleter.New("ClusterTask", func(taskName string) error {
 		return cs.Tekton.TektonV1alpha1().ClusterTasks().Delete(taskName, &metav1.DeleteOptions{})
 	})
-	return d.Execute(s, tNames)
+	d.Delete(s, tNames)
+	d.PrintSuccesses(s)
+	return d.Errors()
 }

--- a/pkg/cmd/condition/delete.go
+++ b/pkg/cmd/condition/delete.go
@@ -80,5 +80,7 @@ func deleteConditions(s *cli.Stream, p cli.Params, condNames []string) error {
 	d := deleter.New("Condition", func(conditionName string) error {
 		return cs.Tekton.TektonV1alpha1().Conditions(p.Namespace()).Delete(conditionName, &metav1.DeleteOptions{})
 	})
-	return d.Execute(s, condNames)
+	d.Delete(s, condNames)
+	d.PrintSuccesses(s)
+	return d.Errors()
 }

--- a/pkg/cmd/eventlistener/delete.go
+++ b/pkg/cmd/eventlistener/delete.go
@@ -81,5 +81,7 @@ func deleteEventListeners(s *cli.Stream, p cli.Params, elNames []string) error {
 	d := deleter.New("EventListener", func(listenerName string) error {
 		return cs.Triggers.TektonV1alpha1().EventListeners(p.Namespace()).Delete(listenerName, &metav1.DeleteOptions{})
 	})
-	return d.Execute(s, elNames)
+	d.Delete(s, elNames)
+	d.PrintSuccesses(s)
+	return d.Errors()
 }

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -36,7 +36,7 @@ func TestPipelineDelete(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	seeds := make([]pipelinetest.Clients, 0)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 7; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Pipelines: []*v1alpha1.Pipeline{
 				tb.Pipeline("pipeline", "ns",

--- a/pkg/cmd/pipelineresource/delete.go
+++ b/pkg/cmd/pipelineresource/delete.go
@@ -82,5 +82,7 @@ func deleteResources(s *cli.Stream, p cli.Params, preNames []string) error {
 	d := deleter.New("PipelineResource", func(resourceName string) error {
 		return cs.Tekton.TektonV1alpha1().PipelineResources(p.Namespace()).Delete(resourceName, &metav1.DeleteOptions{})
 	})
-	return d.Execute(s, preNames)
+	d.Delete(s, preNames)
+	d.PrintSuccesses(s)
+	return d.Errors()
 }

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -130,6 +130,22 @@ func TestPipelineRunDelete(t *testing.T) {
 			wantError:   true,
 			want:        "failed to delete pipelinerun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
+		{
+			name:        "Attempt remove forgetting to include pipelinerun names",
+			command:     []string{"rm", "-n", "ns"},
+			input:       seeds[2],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide pipelineruns to delete or --pipeline flag",
+		},
+		{
+			name:        "Remove pipelineruns of a pipeline",
+			command:     []string{"rm", "--pipeline", "pipeline", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        `Are you sure you want to delete all pipelineruns related to pipeline "pipeline" (y/n): `,
+		},
 	}
 
 	for _, tp := range testParams {
@@ -144,12 +160,13 @@ func TestPipelineRunDelete(t *testing.T) {
 			out, err := test.ExecuteCommand(pipelinerun, tp.command...)
 			if tp.wantError {
 				if err == nil {
-					t.Errorf("Error expected here")
+					t.Errorf("error expected here")
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
 				}
-				test.AssertOutput(t, tp.want, err.Error())
 			} else {
 				if err != nil {
-					t.Errorf("Unexpected Error")
+					t.Errorf("unexpected Error")
 				}
 				test.AssertOutput(t, tp.want, out)
 			}

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -112,6 +112,22 @@ func TestTaskRunDelete(t *testing.T) {
 			wantError:   true,
 			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
 		},
+		{
+			name:        "Attempt remove forgetting to include taskrun names",
+			command:     []string{"rm", "-n", "ns"},
+			input:       seeds[2],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide taskruns to delete or --task flag",
+		},
+		{
+			name:        "Remove taskruns of a task",
+			command:     []string{"rm", "--task", "task", "-n", "ns"},
+			input:       seeds[0],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        `Are you sure you want to delete all taskruns related to task "task" (y/n): `,
+		},
 	}
 
 	for _, tp := range testParams {
@@ -127,8 +143,9 @@ func TestTaskRunDelete(t *testing.T) {
 			if tp.wantError {
 				if err == nil {
 					t.Errorf("error expected here")
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
 				}
-				test.AssertOutput(t, tp.want, err.Error())
 			} else {
 				if err != nil {
 					t.Errorf("unexpected Error")

--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -81,5 +81,7 @@ func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string) error 
 	d := deleter.New("TriggerBinding", func(bindingName string) error {
 		return cs.Triggers.TektonV1alpha1().TriggerBindings(p.Namespace()).Delete(bindingName, &metav1.DeleteOptions{})
 	})
-	return d.Execute(s, tbNames)
+	d.Delete(s, tbNames)
+	d.PrintSuccesses(s)
+	return d.Errors()
 }

--- a/pkg/cmd/triggertemplate/delete.go
+++ b/pkg/cmd/triggertemplate/delete.go
@@ -81,5 +81,7 @@ func deleteTriggerTemplates(s *cli.Stream, p cli.Params, ttNames []string) error
 	d := deleter.New("TriggerTemplate", func(templateName string) error {
 		return cs.Triggers.TektonV1alpha1().TriggerTemplates(p.Namespace()).Delete(templateName, &metav1.DeleteOptions{})
 	})
-	return d.Execute(s, ttNames)
+	d.Delete(s, ttNames)
+	d.PrintSuccesses(s)
+	return d.Errors()
 }

--- a/pkg/helper/deleter/deleter_test.go
+++ b/pkg/helper/deleter/deleter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 )
 
-func TestExecute(t *testing.T) {
+func TestDelete(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		names       []string
@@ -32,20 +32,22 @@ func TestExecute(t *testing.T) {
 		names:       []string{"baz"},
 		expectedOut: "",
 		expectedErr: "failed to delete foobar \"baz\": there was an unfortunate incident\n",
-		deleteFunc:  func(string) error { return errors.New("there was an unfortunate incident") },
+		deleteFunc:  unsuccessfulDeleteFunc("there was an unfortunate incident"),
 	}, {
 		description: "prints multiple errors if multiple deletions fail",
 		names:       []string{"baz", "quux"},
 		expectedOut: "",
 		expectedErr: "failed to delete foobar \"baz\": there was an unfortunate incident\nfailed to delete foobar \"quux\": there was an unfortunate incident\n",
-		deleteFunc:  func(string) error { return errors.New("there was an unfortunate incident") },
+		deleteFunc:  unsuccessfulDeleteFunc("there was an unfortunate incident"),
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			stdout := &strings.Builder{}
 			stderr := &strings.Builder{}
 			streams := &cli.Stream{Out: stdout, Err: stderr}
 			d := New("FooBar", tc.deleteFunc)
-			if err := d.Execute(streams, tc.names); err != nil {
+			d.Delete(streams, tc.names)
+			d.PrintSuccesses(streams)
+			if err := d.Errors(); err != nil {
 				if tc.expectedErr == "" {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -57,5 +59,139 @@ func TestExecute(t *testing.T) {
 				t.Errorf("expected stderr %q received %q", tc.expectedErr, stderr.String())
 			}
 		})
+	}
+}
+
+func TestDeleteRelated(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		relatedKind string
+		listFunc    func(string) ([]string, error)
+		deleteFunc  func(string) error
+		expectedOut string
+		expectedErr string
+	}{{
+		description: "doesnt print anything if no related are configured",
+	}, {
+		description: "prints success message with deleted relations",
+		relatedKind: "FooBarRun",
+		listFunc:    successfulListFunc("fbr1", "fbr2"),
+		deleteFunc:  successfulDeleteFunc(),
+		expectedOut: "FooBarRuns deleted: \"fbr1\", \"fbr2\"\n",
+	}, {
+		description: "prints error message with problems encountered during deletes",
+		relatedKind: "FooBarRun",
+		listFunc:    successfulListFunc("fbr1"),
+		deleteFunc:  unsuccessfulDeleteFunc("bad times"),
+		expectedErr: "failed to delete foobarrun \"fbr1\": bad times\n",
+	}, {
+		description: "prints error message with problems encountered during list",
+		relatedKind: "FooBarRun",
+		listFunc:    unsuccessfulListFunc("bad times"),
+		deleteFunc:  successfulDeleteFunc(),
+		expectedErr: "failed to list foobarruns: bad times\n",
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			stdout := &strings.Builder{}
+			stderr := &strings.Builder{}
+			streams := &cli.Stream{Out: stdout, Err: stderr}
+			d := New("FooBar", successfulDeleteFunc())
+			if tc.relatedKind != "" {
+				d.WithRelated(tc.relatedKind, tc.listFunc, tc.deleteFunc)
+				d.DeleteRelated(streams, []string{"foo"})
+			}
+			d.PrintSuccesses(streams)
+			if err := d.Errors(); err != nil {
+				if tc.expectedErr == "" {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if stdout.String() != tc.expectedOut {
+				t.Errorf("expected stdout %q received %q", tc.expectedOut, stdout.String())
+			}
+			if stderr.String() != tc.expectedErr {
+				t.Errorf("expected stderr %q received %q", tc.expectedErr, stderr.String())
+			}
+		})
+	}
+}
+
+func TestDeleteAndDeleteRelated(t *testing.T) {
+	for _, tc := range []struct {
+		description       string
+		kind              string
+		names             []string
+		relatedKind       string
+		deleteFunc        func(string) error
+		listRelatedFunc   func(string) ([]string, error)
+		deleteRelatedFunc func(string) error
+		expectedOut       string
+		expectedErr       string
+	}{{
+		description: "doesnt print anything if no related are configured",
+	}, {
+		description:       "prints success message with deleted and deleted relations",
+		kind:              "FooBar",
+		names:             []string{"fb1"},
+		relatedKind:       "FooBarRun",
+		deleteFunc:        successfulDeleteFunc(),
+		listRelatedFunc:   successfulListFunc("fbr1", "fbr2"),
+		deleteRelatedFunc: successfulDeleteFunc(),
+		expectedOut:       "FooBarRuns deleted: \"fbr1\", \"fbr2\"\nFooBars deleted: \"fb1\"\n",
+	}, {
+		description:       "prints error message with errors encountered during deletes and does not attempt to delete related",
+		kind:              "FooBar",
+		names:             []string{"fb1"},
+		relatedKind:       "FooBarRun",
+		deleteFunc:        unsuccessfulDeleteFunc("bad times"),
+		listRelatedFunc:   successfulListFunc("fbr1"),
+		deleteRelatedFunc: successfulDeleteFunc(),
+		expectedErr:       "failed to delete foobar \"fb1\": bad times\n",
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			stdout := &strings.Builder{}
+			stderr := &strings.Builder{}
+			streams := &cli.Stream{Out: stdout, Err: stderr}
+			d := New(tc.kind, tc.deleteFunc)
+			d.WithRelated(tc.relatedKind, tc.listRelatedFunc, tc.deleteRelatedFunc)
+			deletedNames := d.Delete(streams, tc.names)
+			d.DeleteRelated(streams, deletedNames)
+			d.PrintSuccesses(streams)
+			if err := d.Errors(); err != nil {
+				if tc.expectedErr == "" {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if stdout.String() != tc.expectedOut {
+				t.Errorf("expected stdout %q received %q", tc.expectedOut, stdout.String())
+			}
+			if stderr.String() != tc.expectedErr {
+				t.Errorf("expected stderr %q received %q", tc.expectedErr, stderr.String())
+			}
+		})
+	}
+}
+
+func successfulDeleteFunc() func(string) error {
+	return func(string) error {
+		return nil
+	}
+}
+
+func unsuccessfulDeleteFunc(message string) func(string) error {
+	return func(string) error {
+		return errors.New(message)
+	}
+}
+
+func successfulListFunc(returnedNames ...string) func(string) ([]string, error) {
+	return func(string) ([]string, error) {
+		return returnedNames, nil
+	}
+}
+
+func unsuccessfulListFunc(message string) func(string) ([]string, error) {
+	return func(string) ([]string, error) {
+		return nil, errors.New(message)
 	}
 }

--- a/pkg/helper/options/delete.go
+++ b/pkg/helper/options/delete.go
@@ -24,9 +24,11 @@ import (
 )
 
 type DeleteOptions struct {
-	Resource    string
-	ForceDelete bool
-	DeleteAll   bool
+	Resource           string
+	ParentResource     string
+	ParentResourceName string
+	ForceDelete        bool
+	DeleteAll          bool
 }
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string) error {
@@ -35,9 +37,17 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string) erro
 	}
 
 	formattedNames := names.QuotedList(resourceNames)
-	if o.DeleteAll {
+
+	if len(resourceNames) == 0 && o.ParentResource != "" && o.ParentResourceName == "" {
+		return fmt.Errorf("must provide %ss to delete or --%s flag", o.Resource, o.ParentResource)
+	}
+
+	switch {
+	case o.ParentResource != "" && o.ParentResourceName != "":
+		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss related to %s %q (y/n): ", o.Resource, o.ParentResource, o.ParentResourceName)
+	case o.DeleteAll:
 		fmt.Fprintf(s.Out, "Are you sure you want to delete %s and related resources %s (y/n): ", o.Resource, formattedNames)
-	} else {
+	default:
 		fmt.Fprintf(s.Out, "Are you sure you want to delete %s %s (y/n): ", o.Resource, formattedNames)
 	}
 

--- a/pkg/helper/options/delete_test.go
+++ b/pkg/helper/options/delete_test.go
@@ -89,6 +89,13 @@ func TestDeleteOptions(t *testing.T) {
 			wantError:      true,
 			want:           "canceled deleting testRes \"test1\", \"test2\"",
 		},
+		{
+			name:           "Specify parent resource, answer y",
+			opt:            &DeleteOptions{Resource: "testRes", ParentResource: "testParentRes", ParentResourceName: "my-test-resource-parent"},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{""},
+			wantError:      false,
+		},
 	}
 
 	for _, tp := range testParams {
@@ -100,7 +107,7 @@ func TestDeleteOptions(t *testing.T) {
 				}
 				test.AssertOutput(t, tp.want, err.Error())
 			} else if err != nil {
-				t.Fatal("unexpected Error")
+				t.Fatalf("unexpected Error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

Fixes #589 

This commit adds a flag to delete resources related to a parent - a
taskrun's parent is a task, a pipelinerun's parent is a pipeline -
without deleting the task or pipeline.
    
The flags are:
`tkn taskrun delete --task task-name`
`tkn pipelinerun delete --pipeline pipeline-name`

TODO:

- [ ] Add unit tests for the rewritten flags --task and --pipeline

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
tkn delete pipeline --delete-pipelineruns flag has been added to allow deletion of only the pipelineruns related to a pipeline (not the pipeline itself)
tkn delete task --delete-taskruns flag has been added to allow deletion of only the taskruns related to a task (not the task itself)
```
