### PR TITLE
Add Namespace to tkn pipeline desc

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -31,6 +31,7 @@ import (
 )
 
 const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
+{{decorate "bold" "Namespace"}}:	{{ .Pipeline.Namespace }}
 
 {{decorate "underline bold" "Resources\n"}}
 {{- $rl := len .Pipeline.Spec.Resources }}{{ if eq $rl 0 }}

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -94,7 +94,8 @@ func TestPipelinesDescribe_empty(t *testing.T) {
 	}
 
 	expected := []string{
-		"Name:   pipeline\n",
+		"Name:        pipeline",
+		"Namespace:   ns\n",
 		"Resources\n",
 		" No resources\n",
 		"Params\n",
@@ -163,7 +164,8 @@ func TestPipelinesDescribe_with_run(t *testing.T) {
 	}
 
 	expected := []string{
-		"Name:   pipeline\n",
+		"Name:        pipeline",
+		"Namespace:   ns\n",
 		"Resources\n",
 		" No resources\n",
 		"Params\n",
@@ -237,7 +239,8 @@ func TestPipelinesDescribe_with_task_run(t *testing.T) {
 	}
 
 	expected := []string{
-		"Name:   pipeline\n",
+		"Name:        pipeline",
+		"Namespace:   ns\n",
 		"Resources\n",
 		" No resources\n",
 		"Params\n",
@@ -315,7 +318,8 @@ func TestPipelinesDescribe_with_resource_param_task_run(t *testing.T) {
 	}
 
 	expected := []string{
-		"Name:   pipeline\n",
+		"Name:        pipeline",
+		"Namespace:   ns\n",
 		"Resources\n",
 		" NAME   TYPE",
 		" name   git\n",
@@ -402,7 +406,8 @@ func TestPipelinesDescribe_with_multiple_resource_param_task_run(t *testing.T) {
 	}
 
 	expected := []string{
-		"Name:   pipeline\n",
+		"Name:        pipeline",
+		"Namespace:   ns\n",
 		"Resources\n",
 		" NAME             TYPE",
 		" code             git",


### PR DESCRIPTION
This will add the Namespace information to `pipeline desc`

This will look like this : 

![image](https://user-images.githubusercontent.com/98980/72458632-38419e00-37c9-11ea-863b-372fe41d11e0.png)


Closes #606

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [👍] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)

- [🤷‍♂]Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [🤷‍♂] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [👍] Run the code checkers with `make check`
- [👍] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

