### PR TITLE
Generate steps name when none has been provided

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -93,7 +93,7 @@ No params
  No steps
 {{- else }}
 {{- range $step := .Task.Spec.Steps }}
- {{decorate "bullet" $step.Name }}
+ {{ autoStepName $step.Name | decorate "bullet" }} 
 {{- end }}
 {{- end }}
 
@@ -193,6 +193,7 @@ func printTaskDescription(s *cli.Stream, p cli.Params, tname string) error {
 		"formatDuration":  formatted.Duration,
 		"formatCondition": formatted.Condition,
 		"decorate":        formatted.DecorateAttr,
+		"autoStepName":    formatted.AutoStepName,
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -15,6 +15,9 @@
 package formatted
 
 import (
+	"fmt"
+	"sync/atomic"
+
 	"github.com/fatih/color"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
@@ -29,9 +32,22 @@ var ConditionColor = map[string]color.Attribute{
 	"Pending":   color.FgHiWhite,
 }
 
+var stepCounter uint64
+
 // ColorStatus Get a status coloured
 func ColorStatus(status string) string {
 	return color.New(ConditionColor[status]).Sprint(status)
+}
+
+// AutoStepName when our stepName is empty return a generated name as generated
+// on pipeLine
+func AutoStepName(stepName string) string {
+	unnamedStep := fmt.Sprintf("unnamed-%d", stepCounter)
+	atomic.AddUint64(&stepCounter, 1)
+	if stepName != "" {
+		return stepName
+	}
+	return unnamedStep
 }
 
 // Condition returns a human readable text based on the status of the Condition

--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -3,6 +3,8 @@ package formatted
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/fatih/color"
 )
 
@@ -12,4 +14,15 @@ func TestColor(t *testing.T) {
 	if cs != greenSuccess {
 		t.Errorf("%s != %s", cs, greenSuccess)
 	}
+}
+
+func TestAutoStepName(t *testing.T) {
+	firstRound := AutoStepName("")
+	assert.Equal(t, firstRound, "unnamed-0")
+
+	secondRound := AutoStepName("named")
+	assert.Equal(t, secondRound, "named")
+
+	thirdRound := AutoStepName("")
+	assert.Equal(t, thirdRound, "unnamed-2")
 }


### PR DESCRIPTION
Let's generate the step name if the user has not provided one, like what is done
pipeline (which would shows up in tr)

Before:

![image](https://user-images.githubusercontent.com/98980/72275775-dfd69900-362e-11ea-90c0-28b2f5ac1975.png)

After:

![image](https://user-images.githubusercontent.com/98980/72462328-25cb6280-37d1-11ea-95b3-26a68ab4342e.png)


Closes #[593]



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```