### PR TITLE
Set no colours automatically when not running with a tty or a pipe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/tektoncd/triggers v0.1.1-0.20191218175743-c5b8b4d9ee00
 	go.opencensus.io v0.22.1 // indirect
 	go.uber.org/multierr v1.1.0
-	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect
+	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -15,10 +15,13 @@
 package flags
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/completion"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -90,6 +93,11 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 		return err
 	}
 	p.SetNoColour(nocolourFlag)
+
+	// Make sure we set as Nocolour if we don't have a terminal (ie redirection)
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		p.SetNoColour(true)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Before:

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/98980/72510252-61a20e80-3849-11ea-9248-9bd97df4d97a.png">

Now:

<img width="1384" alt="image" src="https://user-images.githubusercontent.com/98980/72510231-57801000-3849-11ea-960d-01f5e5cff582.png">

Closes #570