### PR TITLE
Skipping flaky interactive tests 🧨

### DIFF
--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -218,7 +218,8 @@ func TestPipelineLog(t *testing.T) {
 }
 
 func TestPipelineLog_Interactive(t *testing.T) {
-	t.Skip("Skipping this test due of some flakeyness")
+	t.Skip("Skipping due of flakiness")
+
 	clock := clockwork.NewFakeClock()
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -387,6 +387,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 }
 
 func TestPipelineStart_Interactive(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Pipelines: []*v1alpha1.Pipeline{

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -38,6 +38,8 @@ func init() {
 }
 
 func TestPipelineResource_resource_noName(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		PipelineResources: []*v1alpha1.PipelineResource{
 			tb.PipelineResource("res", "namespace",
@@ -105,6 +107,7 @@ func TestPipelineResource_resource_noName(t *testing.T) {
 }
 
 func TestPipelineResource_resource_already_exist(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		PipelineResources: []*v1alpha1.PipelineResource{
 			tb.PipelineResource("res", "namespace",
@@ -161,6 +164,7 @@ func TestPipelineResource_resource_already_exist(t *testing.T) {
 }
 
 func TestPipelineResource_allResourceType(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
@@ -270,6 +274,8 @@ func TestPipelineResource_allResourceType(t *testing.T) {
 }
 
 func TestPipelineResource_create_cloudEventResource(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -340,6 +346,8 @@ func TestPipelineResource_create_cloudEventResource(t *testing.T) {
 }
 
 func TestPipelineResource_create_clusterResource_secure_password_text(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -486,6 +494,8 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 }
 
 func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -636,6 +646,8 @@ func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T)
 }
 
 func TestPipelineResource_create_gitResource(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -733,6 +745,8 @@ func TestPipelineResource_create_gitResource(t *testing.T) {
 }
 
 func TestPipelineResource_create_imageResource(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -835,6 +849,8 @@ func TestPipelineResource_create_imageResource(t *testing.T) {
 }
 
 func TestPipelineResource_create_clusterResource_secure_password_secret(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -997,6 +1013,8 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 }
 
 func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -1171,6 +1189,8 @@ func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.
 }
 
 func TestPipelineResource_create_pullRequestResource(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -1300,6 +1320,8 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 }
 
 func TestPipelineResource_create_gcsStorageResource(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -1442,6 +1464,8 @@ func TestPipelineResource_create_gcsStorageResource(t *testing.T) {
 }
 
 func TestPipelineResource_create_buildGCSstorageResource(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: []*corev1.Namespace{
 			{

--- a/pkg/cmd/task/logs_test.go
+++ b/pkg/cmd/task/logs_test.go
@@ -143,6 +143,8 @@ func TestTaskLog(t *testing.T) {
 }
 
 func TestTaskLog2(t *testing.T) {
+	t.Skip("Skipping due of flakiness")
+
 	clock := clockwork.NewFakeClock()
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{


### PR DESCRIPTION
Skipping all flaky tests that does "interactive" testing, which hasn't been proven stable and arguably not supposed to be mixed with the unit tests.....

We should next move them to the e2e tests and have them working in a periodic job.
(When we have tekton on tekton CI)

Coverage is going to take a hit but sanity will be back.

Closes #499