### PR TITLE
--dry-run Option for tkn pipeline start

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -36,9 +36,11 @@ two parameters (foo and bar)
 ### Options
 
 ```
+      --dry-run                       preview pipelinerun without running it
   -h, --help                          help for start
   -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the pipeline using last pipelinerun values
+  -o, --output string                 format of pipelinerun dry-run (yaml or json)
   -p, --param stringArray             pass the param as key=value or key=value1,value2
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -28,6 +28,10 @@ Parameters, at least those that have no default value
 
 .SH OPTIONS
 .PP
+\fB\-\-dry\-run\fP[=false]
+    preview pipelinerun without running it
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for start
 
@@ -38,6 +42,10 @@ Parameters, at least those that have no default value
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
     re\-run the pipeline using last pipelinerun values
+
+.PP
+\fB\-o\fP, \fB\-\-output\fP=""
+    format of pipelinerun dry\-run (yaml or json)
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tektoncd/pipeline v0.9.2 h1:eJ9x1KY/XpUGmTjNdowRHF7G9FozKGptHnEGwKO4W/I=
 github.com/tektoncd/pipeline v0.9.2/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=
+github.com/tektoncd/pipeline v0.10.0 h1:znCqo/kMts+rvt8eB/8W2dBniN3e51tCzQ7aRo8PFKs=
 github.com/tektoncd/plumbing v0.0.0-20191218171343-56a836c50336 h1:gTedwNTH1vMF6wlA6wvQqinpH0ls8G6oQgsaHuuqCGc=
 github.com/tektoncd/plumbing v0.0.0-20191218171343-56a836c50336/go.mod h1:QZHgU07PRBTRF6N57w4+ApRu8OgfYLFNqCDlfEZaD9Y=
 github.com/tektoncd/plumbing/pipelinerun-logs v0.0.0-20191206114338-712d544c2c21/go.mod h1:S62EUWtqmejjJgUMOGB1CCCHRp6C706laH06BoALkzU=
@@ -404,6 +405,7 @@ k8s.io/api v0.0.0-20191004102255-dacd7df5a50b h1:38Nx0U83WjBqn1hUWxlgKc7mvH7WhyH
 k8s.io/api v0.0.0-20191004102255-dacd7df5a50b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a h1:lDydUqHrbL/1l5ZQrqD1RIlabhmX8aiZEtxVUb+30iU=
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/cli-runtime v0.0.0-20191004110054-fe9b9282443f h1:vJOrMsZe+RD884n+WQ5So2oOp7SajI0Op3oOBg64ZsY=
 k8s.io/cli-runtime v0.0.0-20191004110054-fe9b9282443f/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/client-go v0.0.0-20191004102537-eb5b9a8cfde7 h1:WyPHgjjXvF4zVVwKGZKKiJGBUW45AuN44uSOuH8euuE=

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -360,6 +360,108 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			wantError: true,
 			want:      "no pipelineruns related to pipeline test-pipeline found in namespace ns",
 		},
+		{
+			name: "Dry Run with invalid output",
+			command: []string{"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"-o", "invalid",
+			},
+			namespace: "",
+			input:     cs2,
+			wantError: true,
+			want:      "output format specifed is invalid but must be yaml or json",
+		},
+		{
+			name: "Dry Run with only --dry-run specified",
+			command: []string{"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+			},
+			namespace: "",
+			input:     cs2,
+			wantError: false,
+			want: `apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  labels:
+    jemange: desfrites
+  namespace: ns
+spec:
+  params:
+  - name: pipeline-param
+    value: value1
+  pipelineRef:
+    name: test-pipeline
+  podTemplate: {}
+  resources:
+  - name: source
+    resourceRef:
+      name: scaffold-git
+  serviceAccountName: svc1
+status: {}
+`,
+		},
+		{
+			name: "Dry Run with output=json",
+			command: []string{"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"-o", "json",
+			},
+			namespace: "",
+			input:     cs2,
+			wantError: false,
+			want: `{
+	"kind": "PipelineRun",
+	"apiVersion": "tekton.dev/v1alpha1",
+	"metadata": {
+		"generateName": "test-pipeline-run-",
+		"namespace": "ns",
+		"creationTimestamp": null,
+		"labels": {
+			"jemange": "desfrites"
+		}
+	},
+	"spec": {
+		"pipelineRef": {
+			"name": "test-pipeline"
+		},
+		"resources": [
+			{
+				"name": "source",
+				"resourceRef": {
+					"name": "scaffold-git"
+				}
+			}
+		],
+		"params": [
+			{
+				"name": "pipeline-param",
+				"value": "value1"
+			}
+		],
+		"serviceAccountName": "svc1",
+		"podTemplate": {}
+	},
+	"status": {}
+}
+`,
+		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
Closes #372 

# Changes

This pull request adds a `--dry-run` option for `tkn pipeline start`. The idea would be to print the pipelinerun to stdout so a user can look over the pipelinerun without actually running the pipeline. 

An `--output` option will also be made available to output the dry run in yaml or json:

**Output the pipeline named pipelinename in namespace ns in yaml:**

`tkn pipeline start pipelinename -n ns --dry-run --output yaml`

**Output the pipeline named pipelinename in namespace ns in json:**
`tkn pipeline start pipelinename -n ns --dry-run -o json`

**Not using output flag with --dry-run uses yaml output default:**

`tkn pipeline start pipelinename -n ns --dry-run`

Example out:

**output = json**

```json
{
	"kind": "PipelineRun",
	"apiVersion": "tekton.dev/v1alpha1",
	"metadata": {
		"generateName": "deploy-pipeline-run-",
		"namespace": "default",
		"creationTimestamp": null
	},
	"spec": {
		"pipelineRef": {
			"name": "deploy-pipeline"
		},
		"resources": [
			{
				"name": "app-git",
				"resourceRef": {
					"name": "nodejs-ex-git"
				}
			},
			{
				"name": "app-image",
				"resourceRef": {
					"name": "nodejs-ex-image"
				}
			}
		],
		"serviceAccountName": "default",
		"podTemplate": {}
	},
	"status": {}
}
```

**output = yaml**

```yaml
kind: PipelineRun
metadata:
  creationTimestamp: null
  generateName: deploy-pipeline-run-
  namespace: default
spec:
  pipelineRef:
    name: deploy-pipeline
  podTemplate: {}
  resources:
  - name: app-git
    resourceRef:
      name: nodejs-ex-git
  - name: app-image
    resourceRef:
      name: nodejs-ex-image
  serviceAccountName: default
status: {}

```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add --dry-run option to tkn pipeline start to preview a pipelinerun
```
