### PR TITLE
Fix bug always overriding GenerateName when specifying last flag

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -406,6 +406,11 @@ func (opt *startOptions) startPipeline(pName string) error {
 		if err != nil {
 			return err
 		}
+		if len(prLast.ObjectMeta.GenerateName) > 0 {
+			pr.ObjectMeta.GenerateName = prLast.ObjectMeta.GenerateName
+		} else {
+			pr.ObjectMeta.GenerateName = prLast.ObjectMeta.Name + "-"
+		}
 		pr.Spec.Resources = prLast.Spec.Resources
 		pr.Spec.Params = prLast.Spec.Params
 		// If the prLast is a "new" PR, let's populate those fields too


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related issue is https://github.com/tektoncd/cli/issues/639

Although when user specified last flag script always override GenerateName.
So using GenerateName if last PipelineRun has a GenerateName,
If not, setting a GenerateName based on last PipelineRun Name.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
