### PR TITLE
Refactor --dry-run Tests for tkn pipeline start To Use Golden File

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tektoncd/pipeline v0.9.2 h1:eJ9x1KY/XpUGmTjNdowRHF7G9FozKGptHnEGwKO4W/I=
 github.com/tektoncd/pipeline v0.9.2/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=
+github.com/tektoncd/pipeline v0.10.0 h1:znCqo/kMts+rvt8eB/8W2dBniN3e51tCzQ7aRo8PFKs=
 github.com/tektoncd/plumbing v0.0.0-20191218171343-56a836c50336 h1:gTedwNTH1vMF6wlA6wvQqinpH0ls8G6oQgsaHuuqCGc=
 github.com/tektoncd/plumbing v0.0.0-20191218171343-56a836c50336/go.mod h1:QZHgU07PRBTRF6N57w4+ApRu8OgfYLFNqCDlfEZaD9Y=
 github.com/tektoncd/plumbing/pipelinerun-logs v0.0.0-20191206114338-712d544c2c21/go.mod h1:S62EUWtqmejjJgUMOGB1CCCHRp6C706laH06BoALkzU=

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  labels:
+    jemange: desfrites
+  namespace: ns
+spec:
+  params:
+  - name: pipeline-param
+    value: value1
+  pipelineRef:
+    name: test-pipeline
+  podTemplate: {}
+  resources:
+  - name: source
+    resourceRef:
+      name: scaffold-git
+  serviceAccountName: svc1
+status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -1,0 +1,34 @@
+{
+	"kind": "PipelineRun",
+	"apiVersion": "tekton.dev/v1alpha1",
+	"metadata": {
+		"generateName": "test-pipeline-run-",
+		"namespace": "ns",
+		"creationTimestamp": null,
+		"labels": {
+			"jemange": "desfrites"
+		}
+	},
+	"spec": {
+		"pipelineRef": {
+			"name": "test-pipeline"
+		},
+		"resources": [
+			{
+				"name": "source",
+				"resourceRef": {
+					"name": "scaffold-git"
+				}
+			}
+		],
+		"params": [
+			{
+				"name": "pipeline-param",
+				"value": "value1"
+			}
+		],
+		"serviceAccountName": "svc1",
+		"podTemplate": {}
+	},
+	"status": {}
+}


### PR DESCRIPTION
Use golden file for `--dry-run` tests only. Add `goldenFile` boolean to test struct so golden file is only used for large output from tests.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

N/A
