### PR TITLE
Fix output=name for pipelinerun list

### DIFF
--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -89,7 +89,16 @@ List all PipelineRuns in a namespace 'foo':
 				return err
 			}
 
-			if output != "" && prs != nil {
+			if output == "name" && prs != nil {
+				w := cmd.OutOrStdout()
+				for _, pr := range prs.Items {
+					_, err := fmt.Fprintf(w, "pipelinerun.tekton.dev/%s\n", pr.Name)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			} else if output != "" && prs != nil {
 				return printer.PrintObject(cmd.OutOrStdout(), prs, f)
 			}
 			stream := &cli.Stream{

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -112,6 +112,12 @@ func TestListPipelineRuns(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name:      "by output as name",
+			command:   command(t, prs, clock.Now(), ns),
+			args:      []string{"list", "-n", "namespace", "-o", "name"},
+			wantError: false,
+		},
+		{
 			name:      "all in namespace",
 			command:   command(t, prs, clock.Now(), ns),
 			args:      []string{"list", "-n", "namespace"},

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-by_output_as_name.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-by_output_as_name.golden
@@ -1,0 +1,5 @@
+pipelinerun.tekton.dev/pr0-1
+pipelinerun.tekton.dev/pr3-1
+pipelinerun.tekton.dev/pr1-1
+pipelinerun.tekton.dev/pr2-2
+pipelinerun.tekton.dev/pr2-1


### PR DESCRIPTION
Let's fix -o name for pipelinerun listing the same way we can do 👍 

```
k get pr -o name
```

Let's do it for `tkn`

Will add the other command in following PR.

Closes #660



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```