### PR TITLE
Add --dry-run Option for tkn ct start

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -29,10 +29,12 @@ like cat,foo,bar
 ### Options
 
 ```
+      --dry-run                  preview taskrun without running it
   -h, --help                     help for start
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.
   -L, --last                     re-run the clustertask using last taskrun values
+      --output string            format of taskrun dry-run (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value or key=value1,value2
   -s, --serviceaccount string    pass the serviceaccount name

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -20,6 +20,10 @@ Start clustertasks
 
 .SH OPTIONS
 .PP
+\fB\-\-dry\-run\fP[=false]
+    preview taskrun without running it
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for start
 
@@ -34,6 +38,10 @@ Start clustertasks
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
     re\-run the clustertask using last taskrun values
+
+.PP
+\fB\-\-output\fP=""
+    format of taskrun dry\-run (yaml or json)
 
 .PP
 \fB\-o\fP, \fB\-\-outputresource\fP=[]

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_no_output.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_no_output.golden
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  creationTimestamp: null
+  generateName: clustertask-2-run-
+  labels:
+    key: value
+spec:
+  inputs:
+    resources:
+    - name: my-repo
+      resourceRef:
+        name: git
+  outputs:
+    resources:
+    - name: code-image
+      resourceRef:
+        name: output-image
+  serviceAccountName: svc1
+  taskRef:
+    kind: ClusterTask
+    name: clustertask-2
+  timeout: 1h0m0s
+status:
+  podName: ""

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_output=json.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_output=json.golden
@@ -1,0 +1,42 @@
+{
+	"kind": "TaskRun",
+	"apiVersion": "tekton.dev/v1alpha1",
+	"metadata": {
+		"generateName": "clustertask-2-run-",
+		"creationTimestamp": null,
+		"labels": {
+			"key": "value"
+		}
+	},
+	"spec": {
+		"inputs": {
+			"resources": [
+				{
+					"name": "my-repo",
+					"resourceRef": {
+						"name": "git"
+					}
+				}
+			]
+		},
+		"outputs": {
+			"resources": [
+				{
+					"name": "code-image",
+					"resourceRef": {
+						"name": "output-image"
+					}
+				}
+			]
+		},
+		"serviceAccountName": "svc1",
+		"taskRef": {
+			"name": "clustertask-2",
+			"kind": "ClusterTask"
+		},
+		"timeout": "1h0m0s"
+	},
+	"status": {
+		"podName": ""
+	}
+}


### PR DESCRIPTION
Closes #659 

Similar to #662 and #643, this pull request adds the ability to do a dry run of a taskrun with `tkn clustertask start`. A notable issue with this, is that steps won't be included with this approach since it mainly relies on a `TaskRef` to start clustertasks, but it does show information on inputs, outputs, and params as well as the task reference being used.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add --dry-run option to tkn clustertask start
```
