### PR TITLE
Fix workspace not getting copied with --last

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -165,6 +165,7 @@ func startClusterTask(opt startOptions, args []string) error {
 		tr.Spec.Inputs = trLast.Spec.Inputs
 		tr.Spec.Outputs = trLast.Spec.Outputs
 		tr.Spec.ServiceAccountName = trLast.Spec.ServiceAccountName
+		tr.Spec.Workspaces = trLast.Spec.Workspaces
 	}
 
 	inputRes, err := mergeRes(tr.Spec.Inputs.Resources, opt.InputResources)

--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -100,6 +100,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 				tb.Step("busybox",
 					tb.StepName("exit"),
 				),
+				tb.TaskWorkspace("test", "test workspace", "/workspace/test/file", true),
 			),
 		),
 	}
@@ -114,6 +115,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 				tb.TaskRunInputs(tb.TaskRunInputsParam("print", "booms", "booms", "booms")),
 				tb.TaskRunInputs(tb.TaskRunInputsResource("my-repo", tb.TaskResourceBindingRef("git"))),
 				tb.TaskRunOutputs(tb.TaskRunOutputsResource("my-image", tb.TaskResourceBindingRef("image"))),
+				tb.TaskRunWorkspaceEmptyDir("test", ""),
 			),
 			tb.TaskRunStatus(
 				tb.TaskRunStartTime(time.Now()),

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -411,6 +411,7 @@ func (opt *startOptions) startPipeline(pName string) error {
 		// If the prLast is a "new" PR, let's populate those fields too
 		pr.Spec.ServiceAccountName = prLast.Spec.ServiceAccountName
 		pr.Spec.ServiceAccountNames = prLast.Spec.ServiceAccountNames
+		pr.Spec.Workspaces = prLast.Spec.Workspaces
 	}
 
 	if err := mergeRes(pr, opt.Resources); err != nil {

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -1743,12 +1743,14 @@ func Test_start_pipeline_last(t *testing.T) {
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineDeclaredResource("build-image", "image"),
+				tb.PipelineWorkspaceDeclaration("test=workspace"),
 				tb.PipelineParamSpec("pipeline-param-1", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
 				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
 				tb.PipelineTask("unit-test-1", "unit-test-task",
 					tb.PipelineTaskInputResource("workspace", "git-repo"),
 					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
 					tb.PipelineTaskOutputResource("workspace", "git-repo"),
+					tb.PipelineTaskWorkspaceBinding("task-test-workspace", "test-workspace"),
 				),
 			), // spec
 		), // pipeline
@@ -1763,6 +1765,7 @@ func Test_start_pipeline_last(t *testing.T) {
 				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
 				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
 				tb.PipelineRunParam("rev-param", "revision1"),
+				tb.PipelineRunWorkspaceBindingEmptyDir("test-new"),
 			),
 		),
 	}
@@ -1819,7 +1822,9 @@ func Test_start_pipeline_last(t *testing.T) {
 			test.AssertOutput(t, v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: "revision2"}, v.Value)
 		}
 	}
+
 	test.AssertOutput(t, "svc1", pr.Spec.ServiceAccountName)
+	test.AssertOutput(t, "test-new", pr.Spec.Workspaces[0].Name)
 }
 
 func Test_start_pipeline_last_without_res_param(t *testing.T) {

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -201,6 +201,7 @@ func startTask(opt startOptions, args []string) error {
 		tr.Spec.Inputs = trLast.Spec.Inputs
 		tr.Spec.Outputs = trLast.Spec.Outputs
 		tr.Spec.ServiceAccountName = trLast.Spec.ServiceAccountName
+		tr.Spec.Workspaces = trLast.Spec.Workspaces
 	}
 
 	inputRes, err := mergeRes(tr.Spec.Inputs.Resources, opt.InputResources)

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -280,6 +280,7 @@ func Test_start_task_last(t *testing.T) {
 				tb.Step("busybox",
 					tb.StepName("exit"),
 				),
+				tb.TaskWorkspace("test", "test workspace", "/workspace/test/file", true),
 			),
 		),
 	}
@@ -294,6 +295,7 @@ func Test_start_task_last(t *testing.T) {
 				tb.TaskRunInputs(tb.TaskRunInputsParam("print", "booms", "booms", "booms")),
 				tb.TaskRunInputs(tb.TaskRunInputsResource("my-repo", tb.TaskResourceBindingRef("git"))),
 				tb.TaskRunOutputs(tb.TaskRunOutputsResource("code-image", tb.TaskResourceBindingRef("image"))),
+				tb.TaskRunWorkspaceEmptyDir("test", ""),
 			),
 		),
 	}
@@ -356,6 +358,8 @@ func Test_start_task_last(t *testing.T) {
 	}
 
 	test.AssertOutput(t, "svc", tr.Spec.ServiceAccountName)
+	test.AssertOutput(t, "test", tr.Spec.Workspaces[0].Name)
+	test.AssertOutput(t, "", tr.Spec.Workspaces[0].SubPath)
 }
 
 func Test_start_task_last_with_inputs(t *testing.T) {


### PR DESCRIPTION
This will fix the issue of workspace not getting copied on
using pipeline. task and clustertask start with --last

Fix #638

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix workspace not getting copied with --last on start
```
