### PR TITLE
Fix overriding GenerateName on taskrun

### DIFF
--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -207,6 +207,11 @@ func startTask(opt startOptions, args []string) error {
 		if err != nil {
 			return err
 		}
+		if len(trLast.ObjectMeta.GenerateName) > 0 {
+			tr.ObjectMeta.GenerateName = trLast.ObjectMeta.GenerateName
+		} else {
+			tr.ObjectMeta.GenerateName = trLast.ObjectMeta.Name + "-"
+		}
 		tr.Spec.Inputs = trLast.Spec.Inputs
 		tr.Spec.Outputs = trLast.Spec.Outputs
 		tr.Spec.ServiceAccountName = trLast.Spec.ServiceAccountName

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -364,6 +364,82 @@ func Test_start_task_last(t *testing.T) {
 	test.AssertOutput(t, "", tr.Spec.Workspaces[0].SubPath)
 }
 
+func Test_start_task_last_generate_name(t *testing.T) {
+	tasks := []*v1alpha1.Task{
+		tb.Task("task", "ns",
+			tb.TaskSpec(
+				tb.TaskInputs(
+					tb.InputsResource("my-repo", v1alpha1.PipelineResourceTypeGit),
+					tb.InputsParamSpec("myarg", v1alpha1.ParamTypeString),
+					tb.InputsParamSpec("print", v1alpha1.ParamTypeArray),
+				),
+				tb.TaskOutputs(
+					tb.OutputsResource("code-image", v1alpha1.PipelineResourceTypeImage),
+				),
+				tb.Step("busybox",
+					tb.StepName("hello"),
+				),
+				tb.Step("busybox",
+					tb.StepName("exit"),
+				),
+				tb.TaskWorkspace("test", "test workspace", "/workspace/test/file", true),
+			),
+		),
+	}
+
+	taskruns := []*v1alpha1.TaskRun{
+		tb.TaskRun("taskrun-123", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "task"),
+			tb.TaskRunSpec(
+				tb.TaskRunTaskRef("task"),
+				tb.TaskRunServiceAccountName("svc"),
+				tb.TaskRunInputs(tb.TaskRunInputsParam("myarg", "value")),
+				tb.TaskRunInputs(tb.TaskRunInputsParam("print", "booms", "booms", "booms")),
+				tb.TaskRunInputs(tb.TaskRunInputsResource("my-repo", tb.TaskResourceBindingRef("git"))),
+				tb.TaskRunOutputs(tb.TaskRunOutputsResource("code-image", tb.TaskResourceBindingRef("image"))),
+				tb.TaskRunWorkspaceEmptyDir("test", ""),
+			),
+		),
+	}
+
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	// Setting GenerateName for test
+	taskruns[0].ObjectMeta.GenerateName = "test-generatename-task-run-"
+
+	seedData, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+
+	objs := []runtime.Object{tasks[0], taskruns[0]}
+	pClient := newPipelineClient(objs...)
+
+	cs := pipelinetest.Clients{
+		Pipeline: pClient,
+		Kube:     seedData.Kube,
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	task := Command(p)
+	got, _ := test.ExecuteCommand(task, "start", "task",
+		"--last",
+		"-n=ns")
+
+	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	test.AssertOutput(t, expected, got)
+
+	tr, err := cs.Pipeline.TektonV1alpha1().TaskRuns("ns").Get("random", v1.GetOptions{})
+	if err != nil {
+		t.Errorf("Error listing taskruns %s", err.Error())
+	}
+
+	test.AssertOutput(t, "test-generatename-task-run-", tr.ObjectMeta.GenerateName)
+}
+
 func Test_start_task_last_with_inputs(t *testing.T) {
 	tasks := []*v1alpha1.Task{
 		tb.Task("task", "ns",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This fixes https://github.com/tektoncd/cli/issues/666

when user specified last flag, script always override GenerateName.
So using GenerateName if last TaskRun has a GenerateName,
If not, setting a GenerateName based on last TaskRun Name.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
