### PR TITLE
Update gotest.tools to use our fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/cel-go v0.3.2 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-github v17.0.0+incompatible // indirect
-	github.com/google/go-licenses v0.0.0-20191220124820-2ee7a02f6ae4 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hako/durafmt v0.0.0-20180520121703-7b7ae1e72ead
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -41,6 +40,7 @@ replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/kr/pty => github.com/creack/pty v1.1.9
 	github.com/spf13/cobra => github.com/chmouel/cobra v0.0.0-20200107083527-379e7a80af0c
+	gotest.tools/v3 => github.com/vdemeester/gotest.tools/v3 v3.0.0-20200204071644-508f0e6cc012
 	knative.dev/pkg => knative.dev/pkg v0.0.0-20190909195211-528ad1c1dd62
 	knative.dev/pkg/vendor/github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,6 @@ github.com/google/go-containerregistry v0.0.0-20200115214256-379933c9c22b/go.mod
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-licenses v0.0.0-20191112164736-212ea350c932/go.mod h1:16wa6pRqNDUIhOtwF0GcROVqMeXHZJ7H6eGDFUh5Pfk=
-github.com/google/go-licenses v0.0.0-20191220124820-2ee7a02f6ae4 h1:kn7u+BkIkXuAGfzgheHfx01WfPP9H/H6Uo95g3bhmSQ=
-github.com/google/go-licenses v0.0.0-20191220124820-2ee7a02f6ae4/go.mod h1:JWeTIGPLQ9gF618ZOdlUitd1gRR/l99WOkHOlmR/UVA=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 h1:ScAXWS+TR6MZKex+7Z8rneuSJH+FSDqd6ocQyl+ZHo4=
@@ -502,6 +500,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/vdemeester/gotest.tools/v3 v3.0.0-20200204071644-508f0e6cc012 h1:lq15xCxq32PmjAnPyDoK7GGx4qRDEtO4E/lPHwgZ7ZM=
+github.com/vdemeester/gotest.tools/v3 v3.0.0-20200204071644-508f0e6cc012/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238/go.mod h1:JwQJCMWpUDqjZrB5jpw0f5VbN7U95zxFy1ZDpoEarGo=
 github.com/vdemeester/k8s-pkg-credentialprovider v1.13.12-1/go.mod h1:Fko0rTxEtDW2kju5Ky7yFJNS3IcNvW8IPsp4/e9oev0=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
@@ -541,7 +541,6 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -632,7 +631,6 @@ golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191119060738-e882bf8e40c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -672,7 +670,6 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191010171213-8abd42400456/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112005509-a3f652f18032/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115165105-de0b1760071a h1:bEJ3JL2YUH3tt9KX9dsy0WUF3WOrhjtNjK93o0svepY=
 golang.org/x/tools v0.0.0-20200115165105-de0b1760071a/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
@@ -761,8 +758,6 @@ gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gotest.tools/v3 v3.0.0 h1:d+tVGRu6X0ZBQ+kyAR8JKi6AXhTP2gmQaoIYaGFz634=
-gotest.tools/v3 v3.0.0/go.mod h1:TUP+/YtXl/dp++T+SZ5v2zUmLVBHmptSb/ajDLCJ+3c=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/vendor/gotest.tools/v3/assert/assert.go
+++ b/vendor/gotest.tools/v3/assert/assert.go
@@ -62,12 +62,13 @@ See http://gotest.tools/assert/cmd/gty-migrate-from-testify.
 
 
 */
-package assert // import "gotest.tools/assert"
+package assert // import "gotest.tools/v3/assert"
 
 import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"reflect"
 
 	gocmp "github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert/cmp"
@@ -118,6 +119,10 @@ func assert(
 		return true
 
 	case error:
+		// Handle nil structs which implement error as a nil error
+		if reflect.ValueOf(check).IsNil() {
+			return true
+		}
 		msg := "error is not nil: "
 		t.Log(format.WithCustomMessage(failureMessage+msg+check.Error(), msgAndArgs...))
 

--- a/vendor/gotest.tools/v3/assert/cmp/compare.go
+++ b/vendor/gotest.tools/v3/assert/cmp/compare.go
@@ -1,5 +1,5 @@
 /*Package cmp provides Comparisons for Assert and Check*/
-package cmp // import "gotest.tools/assert/cmp"
+package cmp // import "gotest.tools/v3/assert/cmp"
 
 import (
 	"fmt"
@@ -104,10 +104,10 @@ func Equal(x, y interface{}) Comparison {
 			return multiLineDiffResult(diff)
 		}
 		return ResultFailureTemplate(`
-			{{- .Data.x}} (
+			{{- printf "%v" .Data.x}} (
 				{{- with callArg 0 }}{{ formatNode . }} {{end -}}
 				{{- printf "%T" .Data.x -}}
-			) != {{ .Data.y}} (
+			) != {{ printf "%v" .Data.y}} (
 				{{- with callArg 1 }}{{ formatNode . }} {{end -}}
 				{{- printf "%T" .Data.y -}}
 			)`,

--- a/vendor/gotest.tools/v3/golden/golden.go
+++ b/vendor/gotest.tools/v3/golden/golden.go
@@ -1,8 +1,11 @@
 /*Package golden provides tools for comparing large mutli-line strings.
 
 Golden files are files in the ./testdata/ subdirectory of the package under test.
+Golden files can be automatically updated to match new values by running
+`go test pkgname -test.update-golden`. To ensure the update is correct
+compare the diff of the old expected value to the new expected value.
 */
-package golden // import "gotest.tools/golden"
+package golden // import "gotest.tools/v3/golden"
 
 import (
 	"bytes"
@@ -68,11 +71,12 @@ func exactBytes(in []byte) []byte {
 	return in
 }
 
-// Assert compares the actual content to the expected content in the golden file.
-// If the `-test.update-golden` flag is set then the actual content is written
+// Assert compares actual to the expected value in the golden file.
+//
+// Running `go test pkgname -test.update-golden` will write the value of actual
 // to the golden file.
-// Returns whether the assertion was successful (true) or not (false).
-// This is equivalent to assert.Check(t, String(actual, filename))
+//
+// This is equivalent to assert.Assert(t, String(actual, filename))
 func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -82,7 +86,8 @@ func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...int
 
 // String compares actual to the contents of filename and returns success
 // if the strings are equal.
-// If the `-test.update-golden` flag is set then the actual content is written
+//
+// Running `go test pkgname -test.update-golden` will write the value of actual
 // to the golden file.
 //
 // Any \r\n substrings in actual are converted to a single \n character
@@ -102,15 +107,23 @@ func String(actual string, filename string) cmp.Comparison {
 			From: "expected",
 			To:   "actual",
 		})
-		return cmp.ResultFailure("\n" + diff)
+		return cmp.ResultFailure("\n" + diff + failurePostamble(filename))
 	}
 }
 
-// AssertBytes compares the actual result to the expected result in the golden
-// file. If the `-test.update-golden` flag is set then the actual content is
-// written to the golden file.
-// Returns whether the assertion was successful (true) or not (false).
-// This is equivalent to assert.Check(t, Bytes(actual, filename))
+func failurePostamble(filename string) string {
+	return fmt.Sprintf(`
+
+You can run 'go test . -test.update-golden' to automatically update %s to the new expected value.'
+`, Path(filename))
+}
+
+// AssertBytes compares actual to the expected value in the golden.
+//
+// Running `go test pkgname -test.update-golden` will write the value of actual
+// to the golden file.
+//
+// This is equivalent to assert.Assert(t, Bytes(actual, filename))
 func AssertBytes(
 	t assert.TestingT,
 	actual []byte,
@@ -125,7 +138,8 @@ func AssertBytes(
 
 // Bytes compares actual to the contents of filename and returns success
 // if the bytes are equal.
-// If the `-test.update-golden` flag is set then the actual content is written
+//
+// Running `go test pkgname -test.update-golden` will write the value of actual
 // to the golden file.
 func Bytes(actual []byte, filename string) cmp.Comparison {
 	return func() cmp.Result {
@@ -134,7 +148,7 @@ func Bytes(actual []byte, filename string) cmp.Comparison {
 			return result
 		}
 		msg := fmt.Sprintf("%v (actual) != %v (expected)", actual, expected)
-		return cmp.ResultFailure(msg)
+		return cmp.ResultFailure(msg + failurePostamble(filename))
 	}
 }
 

--- a/vendor/gotest.tools/v3/internal/difflib/difflib.go
+++ b/vendor/gotest.tools/v3/internal/difflib/difflib.go
@@ -4,7 +4,7 @@ Original source: https://github.com/pmezard/go-difflib
 
 This file is trimmed to only the parts used by this repository.
 */
-package difflib // import "gotest.tools/internal/difflib"
+package difflib // import "gotest.tools/v3/internal/difflib"
 
 func min(a, b int) int {
 	if a < b {

--- a/vendor/gotest.tools/v3/internal/format/format.go
+++ b/vendor/gotest.tools/v3/internal/format/format.go
@@ -1,4 +1,4 @@
-package format // import "gotest.tools/internal/format"
+package format // import "gotest.tools/v3/internal/format"
 
 import "fmt"
 

--- a/vendor/gotest.tools/v3/internal/source/source.go
+++ b/vendor/gotest.tools/v3/internal/source/source.go
@@ -1,4 +1,4 @@
-package source // import "gotest.tools/internal/source"
+package source // import "gotest.tools/v3/internal/source"
 
 import (
 	"bytes"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -429,7 +429,7 @@ google.golang.org/grpc/tap
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.5
 gopkg.in/yaml.v2
-# gotest.tools/v3 v3.0.0
+# gotest.tools/v3 v3.0.0 => github.com/vdemeester/gotest.tools/v3 v3.0.0-20200204071644-508f0e6cc012
 gotest.tools/v3/assert
 gotest.tools/v3/assert/cmp
 gotest.tools/v3/golden


### PR DESCRIPTION
As we are facing some issues with gotest.tools while
building the rpms, we will use our fork till the
upstream PR https://github.com/gotestyourself/gotest.tools/pull/184
gets merged and released

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

