### PR TITLE
--all option for tkn taskrun delete

### DIFF
--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all taskruns in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -20,6 +20,10 @@ Delete taskruns in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all taskruns in a namespace (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -54,7 +54,7 @@ or
 				Err: cmd.OutOrStderr(),
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, ""); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/condition/delete.go
+++ b/pkg/cmd/condition/delete.go
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/eventlistener/delete.go
+++ b/pkg/cmd/eventlistener/delete.go
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -27,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteAll: false}
+	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteRelated: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete Pipelines with names 'foo' and 'bar' in namespace 'quux'
 
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 
@@ -68,7 +68,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAll, "all", "a", false, "Whether to also delete related resources (pipelineruns) (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteRelated, "all", "a", false, "Whether to also delete related resources (pipelineruns) (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 	return c
@@ -86,7 +86,7 @@ func deletePipelines(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, p
 		return cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Delete(pipelineRunName, &metav1.DeleteOptions{})
 	})
 	deletedPipelineNames := d.Delete(s, pNames)
-	if opts.DeleteAll {
+	if opts.DeleteRelated {
 		d.DeleteRelated(s, deletedPipelineNames)
 	}
 	d.PrintSuccesses(s)

--- a/pkg/cmd/pipelineresource/delete.go
+++ b/pkg/cmd/pipelineresource/delete.go
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -60,7 +60,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -27,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "task", ForceDelete: false, DeleteAll: false}
+	opts := &options.DeleteOptions{Resource: "task", ForceDelete: false, DeleteRelated: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete Tasks with names 'foo' and 'bar' in namespace 'quux':
 
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 
@@ -68,7 +68,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAll, "all", "a", false, "Whether to also delete related resources (taskruns) (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteRelated, "all", "a", false, "Whether to also delete related resources (taskruns) (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_task")
 	return c
@@ -86,7 +86,7 @@ func deleteTask(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, taskNa
 		return cs.Tekton.TektonV1alpha1().TaskRuns(p.Namespace()).Delete(taskRunName, &metav1.DeleteOptions{})
 	})
 	deletedTaskNames := d.Delete(s, taskNames)
-	if opts.DeleteAll {
+	if opts.DeleteRelated {
 		d.DeleteRelated(s, deletedTaskNames)
 	}
 	d.PrintSuccesses(s)

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -39,9 +39,29 @@ func TestTaskRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]pipelinetest.Clients, 0)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		trs := []*v1alpha1.TaskRun{
 			tb.TaskRun("tr0-1", "ns",
+				tb.TaskRunLabel("tekton.dev/task", "random"),
+				tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+				tb.TaskRunStatus(
+					tb.StatusCondition(apis.Condition{
+						Status: corev1.ConditionTrue,
+						Reason: resources.ReasonSucceeded,
+					}),
+				),
+			),
+			tb.TaskRun("tr0-2", "ns",
+				tb.TaskRunLabel("tekton.dev/task", "random"),
+				tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+				tb.TaskRunStatus(
+					tb.StatusCondition(apis.Condition{
+						Status: corev1.ConditionTrue,
+						Reason: resources.ReasonSucceeded,
+					}),
+				),
+			),
+			tb.TaskRun("tr0-3", "ns",
 				tb.TaskRunLabel("tekton.dev/task", "random"),
 				tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
 				tb.TaskRunStatus(
@@ -127,6 +147,30 @@ func TestTaskRunDelete(t *testing.T) {
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
 			want:        `Are you sure you want to delete all taskruns related to task "task" (y/n): `,
+		},
+		{
+			name:        "Delete all with prompt",
+			command:     []string{"delete", "--all", "-n", "ns"},
+			input:       seeds[3],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete all taskruns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all with -f",
+			command:     []string{"delete", "--all", "-f", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "All TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using taskrun name with --all",
+			command:     []string{"delete", "taskrun", "--all", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: strings.NewReader("y"),
+			wantError:   true,
+			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 	}
 

--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/triggertemplate/delete.go
+++ b/pkg/cmd/triggertemplate/delete.go
@@ -43,7 +43,7 @@ or
 		Aliases:      []string{"rm"},
 		Short:        "Delete triggertemplates in a namespace",
 		Example:      eg,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -59,7 +59,7 @@ or
 				return err
 			}
 
-			if err := opts.CheckOptions(s, args); err != nil {
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
 

--- a/pkg/helper/options/delete_test.go
+++ b/pkg/helper/options/delete_test.go
@@ -35,7 +35,7 @@ func TestDeleteOptions(t *testing.T) {
 	}{
 		{
 			name:           "Default Option",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteRelated: false, DeleteAllNs: false},
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{"test"},
 			wantError:      false,
@@ -43,7 +43,7 @@ func TestDeleteOptions(t *testing.T) {
 		},
 		{
 			name:           "Specify ForceDelete flag, answer yes",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteAll: false},
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteRelated: false},
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{"test"},
 			wantError:      false,
@@ -51,23 +51,23 @@ func TestDeleteOptions(t *testing.T) {
 		},
 		{
 			name:           "Specify ForceDelete flag, answer no",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteAll: false},
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: true, DeleteRelated: false},
 			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
 			resourcesNames: []string{"test"},
 			wantError:      false,
 			want:           "",
 		},
 		{
-			name:           "Specify DeleteAll flag, answer yes",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: true},
+			name:           "Specify DeleteRelated flag, answer yes",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteRelated: true},
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{"test"},
 			wantError:      false,
 			want:           "",
 		},
 		{
-			name:           "Specify DeleteAll flag, answer no",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: true},
+			name:           "Specify DeleteRelated flag, answer no",
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteRelated: true},
 			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
 			resourcesNames: []string{"test"},
 			wantError:      true,
@@ -75,7 +75,7 @@ func TestDeleteOptions(t *testing.T) {
 		},
 		{
 			name:           "Specify multiple resources, answer yes",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteRelated: false},
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{"test1", "test2"},
 			wantError:      false,
@@ -83,7 +83,7 @@ func TestDeleteOptions(t *testing.T) {
 		},
 		{
 			name:           "Specify multiple resources, answer no",
-			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteAll: false},
+			opt:            &DeleteOptions{Resource: "testRes", ForceDelete: false, DeleteRelated: false},
 			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
 			resourcesNames: []string{"test1", "test2"},
 			wantError:      true,
@@ -96,11 +96,34 @@ func TestDeleteOptions(t *testing.T) {
 			resourcesNames: []string{""},
 			wantError:      false,
 		},
+		{
+			name:           "Specify DeleteAllNs option",
+			opt:            &DeleteOptions{DeleteAllNs: true},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{},
+			wantError:      false,
+		},
+		{
+			name:           "Error when all defaults specified with ParentResource",
+			opt:            &DeleteOptions{Resource: "TaskRun", ParentResource: "task", ForceDelete: false, DeleteRelated: false, DeleteAllNs: false},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{},
+			wantError:      true,
+			want:           "must provide TaskRuns to delete or --task flag",
+		},
+		{
+			name:           "Error when resource name provided with DeleteAllNs",
+			opt:            &DeleteOptions{DeleteAllNs: true},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{"test1"},
+			wantError:      true,
+			want:           "--all flag should not have any arguments or flags specified with it",
+		},
 	}
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			err := tp.opt.CheckOptions(tp.stream, tp.resourcesNames)
+			err := tp.opt.CheckOptions(tp.stream, tp.resourcesNames, "")
 			if tp.wantError {
 				if err == nil {
 					t.Fatal("error expected here")


### PR DESCRIPTION
Part of #634 

This pull request adds an `--all` option to `tkn taskrun delete` that will delete all taskruns that exist in a namespace. It follows the pattern we use for all delete commands by prompting the user if he or she would like to delete the resource. There is also the `-f` option to force a delete without a prompt. 

**Delete all taskruns in namespace ns:**

```
tkn taskrun delete --all -n ns

Are you sure you want to delete all TaskRuns in namespace "ns" (y/n): 
```

There will be a slight issue implementing this `--all` approach for Pipeline/Task: the `--all` flag is already in use, but I think we should change those to `--related` as it focuses on deleting related pipelineruns/taskruns. 

# Changes

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--all option for tkn taskrun delete that deletes all taskruns in a namespace
```
