### PR TITLE
Add --output for TriggerBinding and TaskRuns

### DIFF
--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -88,8 +88,16 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
 				return err
 			}
-
-			if output != "" && trs != nil {
+			if output == "name" && trs != nil {
+				w := cmd.OutOrStdout()
+				for _, tr := range trs.Items {
+					_, err := fmt.Fprintf(w, "taskrun.tekton.dev/%s\n", tr.Name)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			} else if output != "" && trs != nil {
 				return printer.PrintObject(cmd.OutOrStdout(), trs, f)
 			}
 

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -122,6 +122,12 @@ func TestListTaskRuns(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name:      "by output as name",
+			command:   command(t, trs, now, ns),
+			args:      []string{"list", "-n", "foo", "-o", "name"},
+			wantError: false,
+		},
+		{
 			name:      "all in namespace",
 			command:   command(t, trs, now, ns),
 			args:      []string{"list", "-n", "foo"},

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-by_output_as_name.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-by_output_as_name.golden
@@ -1,0 +1,5 @@
+taskrun.tekton.dev/tr0-1
+taskrun.tekton.dev/tr3-1
+taskrun.tekton.dev/tr2-2
+taskrun.tekton.dev/tr1-1
+taskrun.tekton.dev/tr2-1

--- a/pkg/cmd/triggerbinding/list.go
+++ b/pkg/cmd/triggerbinding/list.go
@@ -80,7 +80,16 @@ or
 				Err: cmd.OutOrStderr(),
 			}
 
-			if output != "" {
+			if output == "name" && tbs != nil {
+				w := cmd.OutOrStdout()
+				for _, pr := range tbs.Items {
+					_, err := fmt.Fprintf(w, "triggerbinding.tekton.dev/%s\n", pr.Name)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			} else if output != "" {
 				return printer.PrintObject(stream.Out, tbs, f)
 			}
 

--- a/pkg/cmd/triggerbinding/list_test.go
+++ b/pkg/cmd/triggerbinding/list_test.go
@@ -80,6 +80,12 @@ func TestListTriggerBinding(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name:      "by output as name",
+			command:   command(t, tbs, now, ns),
+			args:      []string{"list", "-n", "foo", "-o", "name"},
+			wantError: false,
+		},
+		{
 			name:      "Multiple TriggerBinding with output format",
 			command:   command(t, tbs, now, ns),
 			args:      []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},

--- a/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-by_output_as_name.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-by_output_as_name.golden
@@ -1,0 +1,4 @@
+triggerbinding.tekton.dev/tb1
+triggerbinding.tekton.dev/tb2
+triggerbinding.tekton.dev/tb3
+triggerbinding.tekton.dev/tb4


### PR DESCRIPTION
ClusterTasks.list and Conditions.list are a bit different on how they do listing
compared to others so may need to this in a following patch (and I think there
is a bit refactoring that can be done too for commononlize things).

Closes #675