### PR TITLE
Add flag --use-pipelinerun to start the rerun with a specific pr

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -46,6 +46,7 @@ two parameters (foo and bar)
   -s, --serviceaccount string         pass the serviceaccount name
       --showlog                       show logs right after starting the pipeline
       --task-serviceaccount strings   pass the service account corresponding to the task
+      --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -67,6 +67,10 @@ Parameters, at least those that have no default value
 \fB\-\-task\-serviceaccount\fP=[]
     pass the service account corresponding to the task
 
+.PP
+\fB\-\-use\-pipelinerun\fP=""
+    use this pipelinerun values to re\-run the pipeline.
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/helper/pipelinerun/pipelinerun.go
+++ b/pkg/helper/pipelinerun/pipelinerun.go
@@ -18,9 +18,25 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	prhsort "github.com/tektoncd/cli/pkg/helper/pipelinerun/sort"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetPipelineRun return a pipelinerun in a namespace from its name
+func GetPipelineRun(p cli.Params, opts metav1.GetOptions, prname string) (*v1alpha1.PipelineRun, error) {
+	cs, err := p.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	prun, err := cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Get(prname, opts)
+	if err != nil {
+		return nil, err
+	}
+	return prun, nil
+}
+
+// GetAllPipelineRuns returns all pipelinesruns running in a namespace
 func GetAllPipelineRuns(p cli.Params, opts metav1.ListOptions, limit int) ([]string, error) {
 	cs, err := p.Clients()
 	if err != nil {


### PR DESCRIPTION
Add the flag --use-pipelinerun which like --last would reuse a PR but instead of
the last one it would use the specified one.

What is the use case? When using trigger/webhook I get different PR created for some pull-request that goes to the trigger service. 
I'd like to rerun a specific failed run for a PR without having to copy past all the params manually. 

Since the failed PR is not necessary the last one, as multiple concurrent of them can be running.

Closes #679



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [X] Run the code checkers with `make check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```