### PR TITLE
Makefile fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,8 @@ These are the criteria that every PR should meet, please check them off as you
 review them:
 
 - [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
-- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
-- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
 - [ ] Run the code checkers with `make check`
+- [ ] Regenerate the manpages, docs and go formatting with `make generated`
 - [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
 
 _See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check: lint test
 test: test-unit ## run all tests
 
 .PHONY: lint
-lint: ## run linter(s)
+lint: lint-yaml ## run linter(s)
 	@echo "Linting..."
 	@golangci-lint run ./... --timeout 5m
 
@@ -80,13 +80,16 @@ man: bin/docs ## update manpages
 	@echo "Update generated manpages"
 	@./bin/docs --target=./docs/man/man1 --kind=man
 
+.PHONY: generated
+generated: test-unit-update-golden man docs fmt ## generate all files that needs to be generated
+
 .PHONY: clean
 clean: ## clean build artifacts
 	rm -fR bin VERSION
 
-.PHONY: fmt ## formats teh god code(excludes vendors dir)
+.PHONY: fmt ## formats the GO code(excludes vendors dir)
 fmt:
-	@go fmt $(go list ./... | grep -v /vendor/)
+	@go fmt `go list ./... | grep -v /vendor/`
 
 .PHONY: help
 help: ## print this help


### PR DESCRIPTION
Some makefile fixes:

* Include `lint-yaml` target when doing `make lint`
* Add `generate` target that would includes all the generation targets (ie man
  docs/golden)
* Fix `make fmt`, since $() is evaluated in makefile, need to use backquote for subshell
  exansion