### PR TITLE
Fix bug about Complete logs not shown for failed TaskRun

### DIFF
--- a/pkg/cmd/taskrun/log_reader.go
+++ b/pkg/cmd/taskrun/log_reader.go
@@ -125,7 +125,7 @@ func (lr *LogReader) readAvailableLogs(tr *v1alpha1.TaskRun) (<-chan Log, <-chan
 
 	//Check if taskrun failed on start up
 	if err := hasTaskRunFailed(tr.Status.Conditions, lr.Task); err != nil {
-		return nil, nil, err
+		fmt.Fprintf(lr.Stream.Err, "%s\n", err.Error())
 	}
 
 	if tr.Status.PodName == "" {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related issue is https://github.com/tektoncd/cli/issues/587

This bug seems to be happen from When pod status is failed ```hasTaskRunFailed``` method returns error immediately,
so pod's logs can't be shown up.

This fix stop returning error immediately, if pod status is failed just logging error on standard error.

Test yaml files is
```
apiVersion: tekton.dev/v1alpha1
kind: Task
metadata:
  name: tt
spec:
  steps:
    - name: echo
      image: ubuntu
      command:
        - echol
      args:
        - "hello world"
---
apiVersion: tekton.dev/v1alpha1
kind: TaskRun
metadata:
  name: diff-tt
spec:
  taskRef:
    name: tt
---
```

from this fix, logs can be shown like below.
```
$ tkn tr ls
NAME       STARTED          DURATION     STATUS               
diff-tt2   45 minutes ago   10 seconds   Succeeded   
diff-tt    53 minutes ago   9 seconds    Failed 
```

```
$ tkn tr logs diff-tt
task tt has failed: "step-echo" exited with code 1 (image: "docker-pullable://ubuntu@sha256:8d31dad0c58f552e890d68bbfb735588b6b820a46e459672d96e585871acc110"); for logs run: kubectl -n default logs diff-tt-pod-h2gwv -c step-echo
[echo] {"level":"info","ts":1581057041.4130957,"logger":"fallback-logger","caller":"logging/config.go:69","msg":"Fetch GitHub commit ID from kodata failed: \"KO_DATA_PATH\" does not exist or is empty"}
[echo] 2020/02/07 06:30:42 Error executing command: exec: "echol": executable file not found in $PATH

container step-echo has failed  : [{"name":"","digest":"","key":"StartedAt","value":"2020-02-07T06:30:42Z","resourceRef":{}}]
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
