### PR TITLE
Add tkn cluster delete --all

### DIFF
--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all clustertasks (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -20,6 +20,10 @@ Delete clustertask resources in a cluster
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all clustertasks (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/helper/options/delete.go
+++ b/pkg/helper/options/delete.go
@@ -30,10 +30,11 @@ type DeleteOptions struct {
 	ForceDelete        bool
 	DeleteRelated      bool
 	DeleteAllNs        bool
+	DeleteAll          bool
 }
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns string) error {
-	if len(resourceNames) > 0 && o.DeleteAllNs {
+	if len(resourceNames) > 0 && (o.DeleteAllNs || o.DeleteAll) {
 		return fmt.Errorf("--all flag should not have any arguments or flags specified with it")
 	}
 
@@ -50,6 +51,8 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	switch {
 	case o.DeleteAllNs:
 		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss in namespace %q (y/n): ", o.Resource, ns)
+	case o.DeleteAll:
+		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss (y/n): ", o.Resource)
 	case o.ParentResource != "" && o.ParentResourceName != "":
 		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss related to %s %q (y/n): ", o.Resource, o.ParentResource, o.ParentResourceName)
 	case o.DeleteRelated:

--- a/pkg/helper/options/delete_test.go
+++ b/pkg/helper/options/delete_test.go
@@ -119,6 +119,21 @@ func TestDeleteOptions(t *testing.T) {
 			wantError:      true,
 			want:           "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:           "Specify DeleteAll option",
+			opt:            &DeleteOptions{DeleteAll: true},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{},
+			wantError:      false,
+		},
+		{
+			name:           "Error when resource name provided with DeleteAll",
+			opt:            &DeleteOptions{DeleteAll: true},
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			resourcesNames: []string{"test1"},
+			wantError:      true,
+			want:           "--all flag should not have any arguments or flags specified with it",
+		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
Part of #634 

Add `--all` option for `tkn ct delete`.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--all option for tkn clustertask delete that deletes all clustertasks
```
