### PR TITLE
Add --step flag for taskrun logs

### DIFF
--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -30,11 +30,11 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 ### Options
 
 ```
-  -a, --all                  show all logs including init steps injected by tekton
-  -f, --follow               stream live logs
-  -h, --help                 help for logs
-      --limit int            lists number of pipelineruns (default 5)
-  -t, --only-tasks strings   show logs for mentioned tasks only
+  -a, --all            show all logs including init steps injected by tekton
+  -f, --follow         stream live logs
+  -h, --help           help for logs
+      --limit int      lists number of pipelineruns (default 5)
+  -t, --task strings   show logs for mentioned tasks only
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -22,14 +22,19 @@ Show the live logs of TaskRun named 'foo' from namespace 'bar':
 
     tkn taskrun logs -f foo -n bar
 
+Show the logs of TaskRun named 'microservice-1' for step 'build' only from namespace 'bar':
+
+    tkn tr logs microservice-1 -s build -n bar
+
 
 ### Options
 
 ```
-  -a, --all         show all logs including init steps injected by tekton
-  -f, --follow      stream live logs
-  -h, --help        help for logs
-      --limit int   lists number of taskruns (default 5)
+  -a, --all            show all logs including init steps injected by tekton
+  -f, --follow         stream live logs
+  -h, --help           help for logs
+      --limit int      lists number of taskruns (default 5)
+  -s, --step strings   show logs for mentioned steps only
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -36,7 +36,7 @@ Show the logs of PipelineRun
     lists number of pipelineruns
 
 .PP
-\fB\-t\fP, \fB\-\-only\-tasks\fP=[]
+\fB\-t\fP, \fB\-\-task\fP=[]
     show logs for mentioned tasks only
 
 

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -35,6 +35,10 @@ Show taskruns logs
 \fB\-\-limit\fP=5
     lists number of taskruns
 
+.PP
+\fB\-s\fP, \fB\-\-step\fP=[]
+    show logs for mentioned steps only
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
@@ -75,6 +79,18 @@ Show the live logs of TaskRun named 'foo' from namespace 'bar':
 
 .nf
 tkn taskrun logs \-f foo \-n bar
+
+.fi
+.RE
+
+.PP
+Show the logs of TaskRun named 'microservice\-1' for step 'build' only from namespace 'bar':
+
+.PP
+.RS
+
+.nf
+tkn tr logs microservice\-1 \-s build \-n bar
 
 .fi
 .RE

--- a/pkg/cmd/pipelinerun/log_test.go
+++ b/pkg/cmd/pipelinerun/log_test.go
@@ -880,7 +880,7 @@ func updatePR(finalRuns []*v1alpha1.PipelineRun, watcher *watch.FakeWatcher) {
 	}()
 }
 
-func logOpts(name string, ns string, cs pipelinetest.Clients, streamer stream.NewStreamerFunc, allSteps bool, follow bool, onlyTasks ...string) *options.LogOptions {
+func logOpts(name string, ns string, cs pipelinetest.Clients, streamer stream.NewStreamerFunc, allSteps bool, follow bool, tasks ...string) *options.LogOptions {
 	p := test.Params{
 		Kube:   cs.Kube,
 		Tekton: cs.Pipeline,
@@ -889,7 +889,7 @@ func logOpts(name string, ns string, cs pipelinetest.Clients, streamer stream.Ne
 
 	logOptions := options.LogOptions{
 		PipelineRunName: name,
-		Tasks:           onlyTasks,
+		Tasks:           tasks,
 		AllSteps:        allSteps,
 		Follow:          follow,
 		Params:          &p,

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -70,7 +70,7 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
-	c.Flags().StringSliceVarP(&opts.Tasks, "only-tasks", "t", []string{}, "show logs for mentioned tasks only")
+	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned tasks only")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of pipelineruns")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")

--- a/pkg/helper/options/logs.go
+++ b/pkg/helper/options/logs.go
@@ -43,6 +43,7 @@ type LogOptions struct {
 	Stream          *cli.Stream
 	Streamer        stream.NewStreamerFunc
 	Tasks           []string
+	Steps           []string
 	Last            bool
 	Limit           int
 	AskOpts         survey.AskOpt


### PR DESCRIPTION
This will add --step flag for taskrun logs to
show logs of respective tasks only

Rename --only-tasks to --task in pipelinerun
logs

Add tests and docs

Fix #578

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Add --step flag for taskrun logs and change --only-tasks flag to --task for pipelinerun logs
```
