### PR TITLE
--all option for tkn resource delete

### DIFF
--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all PipelineResources in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -20,6 +20,10 @@ Delete pipeline resources in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all PipelineResources in a namespace (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/pipelineresource/delete.go
+++ b/pkg/cmd/pipelineresource/delete.go
@@ -27,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "pipelineresource", ForceDelete: false}
+	opts := &options.DeleteOptions{Resource: "pipelineresource", ForceDelete: false, DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete PipelineResources with names 'foo' and 'bar' in namespace 'quux':
 
@@ -43,7 +43,7 @@ or
 		Aliases:      []string{"rm"},
 		Short:        "Delete pipeline resources in a namespace",
 		Example:      eg,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -63,17 +63,18 @@ or
 				return err
 			}
 
-			return deleteResources(s, p, args)
+			return deleteResources(s, p, args, opts.DeleteAllNs)
 		},
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all PipelineResources in a namespace (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelineresource")
 	return c
 }
 
-func deleteResources(s *cli.Stream, p cli.Params, preNames []string) error {
+func deleteResources(s *cli.Stream, p cli.Params, preNames []string, deleteAll bool) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return fmt.Errorf("failed to create tekton client")
@@ -82,7 +83,32 @@ func deleteResources(s *cli.Stream, p cli.Params, preNames []string) error {
 	d := deleter.New("PipelineResource", func(resourceName string) error {
 		return cs.Resource.TektonV1alpha1().PipelineResources(p.Namespace()).Delete(resourceName, &metav1.DeleteOptions{})
 	})
+	if deleteAll {
+		preNames, err = allPipelineResourceNames(p, cs)
+		if err != nil {
+			return err
+		}
+	}
 	d.Delete(s, preNames)
-	d.PrintSuccesses(s)
+
+	if !deleteAll {
+		d.PrintSuccesses(s)
+	} else if deleteAll {
+		if d.Errors() == nil {
+			fmt.Fprintf(s.Out, "All PipelineResources deleted in namespace %q\n", p.Namespace())
+		}
+	}
 	return d.Errors()
+}
+
+func allPipelineResourceNames(p cli.Params, cs *cli.Clients) ([]string, error) {
+	resources, err := cs.Resource.TektonV1alpha1().PipelineResources(p.Namespace()).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, resource := range resources.Items {
+		names = append(names, resource.Name)
+	}
+	return names, nil
 }

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -37,7 +37,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 	}
 
 	seeds := make([]pipelinetest.Clients, 0)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		pres := []*v1alpha1.PipelineResource{
 			tb.PipelineResource("pre-1", "ns",
 				tb.PipelineResourceSpec("image",
@@ -104,6 +104,30 @@ func TestPipelineResourceDelete(t *testing.T) {
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
 			want:        "failed to delete pipelineresource \"nonexistent\": pipelineresources.tekton.dev \"nonexistent\" not found",
+		},
+		{
+			name:        "Delete all with prompt",
+			command:     []string{"delete", "--all", "-n", "ns"},
+			input:       seeds[3],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete all pipelineresources in namespace \"ns\" (y/n): All PipelineResources deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all with -f",
+			command:     []string{"delete", "--all", "-f", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   false,
+			want:        "All PipelineResources deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using pipelineresource name with --all",
+			command:     []string{"delete", "pipelineresource", "--all", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 	}
 


### PR DESCRIPTION
Part of #634 

Adding `--all` option for `tkn resource delete` to delete all PipelineResources in a namespace.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
--all option for tkn resource delete that deletes all pipelineresources in a namespace
```
