### PR TITLE
--all option for tkn condition delete

### DIFF
--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all Conditions in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -20,6 +20,10 @@ Delete a condition in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all Conditions in a namespace (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/condition/delete.go
+++ b/pkg/cmd/condition/delete.go
@@ -27,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "condition", ForceDelete: false}
+	opts := &options.DeleteOptions{Resource: "condition", ForceDelete: false, DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete Conditions with names 'foo' and 'bar' in namespace 'quux':
 
@@ -43,7 +43,7 @@ or
 		Aliases:      []string{"rm"},
 		Short:        "Delete a condition in a namespace",
 		Example:      eg,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -63,16 +63,17 @@ or
 				return err
 			}
 
-			return deleteConditions(s, p, args)
+			return deleteConditions(s, p, args, opts.DeleteAllNs)
 		},
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all Conditions in a namespace (default: false)")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_condition")
 	return c
 }
 
-func deleteConditions(s *cli.Stream, p cli.Params, condNames []string) error {
+func deleteConditions(s *cli.Stream, p cli.Params, condNames []string, deleteAll bool) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return fmt.Errorf("failed to create tekton client")
@@ -80,7 +81,33 @@ func deleteConditions(s *cli.Stream, p cli.Params, condNames []string) error {
 	d := deleter.New("Condition", func(conditionName string) error {
 		return cs.Tekton.TektonV1alpha1().Conditions(p.Namespace()).Delete(conditionName, &metav1.DeleteOptions{})
 	})
+	if deleteAll {
+		condNames, err = allConditionNames(p, cs)
+		if err != nil {
+			return err
+		}
+	}
 	d.Delete(s, condNames)
-	d.PrintSuccesses(s)
+
+	if !deleteAll {
+		d.PrintSuccesses(s)
+	} else if deleteAll {
+		if d.Errors() == nil {
+			fmt.Fprintf(s.Out, "All Conditions deleted in namespace %q\n", p.Namespace())
+		}
+	}
+
 	return d.Errors()
+}
+
+func allConditionNames(p cli.Params, cs *cli.Clients) ([]string, error) {
+	conds, err := cs.Tekton.TektonV1alpha1().Conditions(p.Namespace()).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, cond := range conds.Items {
+		names = append(names, cond.Name)
+	}
+	return names, nil
 }


### PR DESCRIPTION
Part of #634 

`--all` option for `tkn condition delete` to delete all conditions in a namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--all option for tkn cond delete that deletes all conditions in a namespace
```
