### PR TITLE
--all option for tkn el delete

### DIFF
--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all EventListeners in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-eventlistener-delete.1
+++ b/docs/man/man1/tkn-eventlistener-delete.1
@@ -20,6 +20,10 @@ Delete EventListeners in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all EventListeners in a namespace (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/eventlistener/delete.go
+++ b/pkg/cmd/eventlistener/delete.go
@@ -27,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "eventlistener", ForceDelete: false}
+	opts := &options.DeleteOptions{Resource: "eventlistener", ForceDelete: false, DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete EventListeners with names 'foo' and 'bar' in namespace 'bar'
 
@@ -43,7 +43,7 @@ or
 		Aliases:      []string{"rm"},
 		Short:        "Delete EventListeners in a namespace",
 		Example:      eg,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -63,17 +63,18 @@ or
 				return err
 			}
 
-			return deleteEventListeners(s, p, args)
+			return deleteEventListeners(s, p, args, opts.DeleteAllNs)
 		},
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all EventListeners in a namespace (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_eventlistener")
 	return c
 }
 
-func deleteEventListeners(s *cli.Stream, p cli.Params, elNames []string) error {
+func deleteEventListeners(s *cli.Stream, p cli.Params, elNames []string, deleteAll bool) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return fmt.Errorf("failed to create tekton client")
@@ -81,7 +82,32 @@ func deleteEventListeners(s *cli.Stream, p cli.Params, elNames []string) error {
 	d := deleter.New("EventListener", func(listenerName string) error {
 		return cs.Triggers.TektonV1alpha1().EventListeners(p.Namespace()).Delete(listenerName, &metav1.DeleteOptions{})
 	})
+	if deleteAll {
+		elNames, err = allEventListenerNames(p, cs)
+		if err != nil {
+			return err
+		}
+	}
 	d.Delete(s, elNames)
-	d.PrintSuccesses(s)
+
+	if !deleteAll {
+		d.PrintSuccesses(s)
+	} else if deleteAll {
+		if d.Errors() == nil {
+			fmt.Fprintf(s.Out, "All EventListeners deleted in namespace %q\n", p.Namespace())
+		}
+	}
 	return d.Errors()
+}
+
+func allEventListenerNames(p cli.Params, cs *cli.Clients) ([]string, error) {
+	els, err := cs.Triggers.TektonV1alpha1().EventListeners(p.Namespace()).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, el := range els.Items {
+		names = append(names, el.Name)
+	}
+	return names, nil
 }


### PR DESCRIPTION
Part of #634 

`--all` option for `tkn eventlistener delete` to delete all EventListeners in a namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--all option for tkn eventlistener delete that deletes all eventlisteners in a namespace
```
