### PR TITLE
Shows --- for empty values on "DEFAULT VALUES" column

### DIFF
--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -77,7 +77,7 @@ No params
  NAME	TYPE	DEFAULT VALUE
 {{- range $p := .ClusterTask.Spec.Inputs.Params }}
 {{- if not $p.Default }}
- {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ "" }}
+ {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ "---" }}
 {{- else }}
 {{- if eq $p.Type "string" }}
  {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ $p.Default.StringVal }}

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
@@ -13,7 +13,7 @@ Output Resources
 Params
 
  NAME    TYPE     DEFAULT VALUE
- myarg   string   
+ myarg   string   ---
 
 Steps
 

--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -54,7 +54,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
  NAME	TYPE	DEFAULT VALUE
 {{- range $i, $p := .Pipeline.Spec.Params }}
 {{- if not $p.Default }}
- {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ "" }}
+ {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ "---" }}
 {{- else }}
 {{- if eq $p.Type "string" }}
  {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ $p.Default.StringVal }}

--- a/pkg/cmd/pipeline/testdata/TestPipelinesDescribe_with_multiple_resource_param_task_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelinesDescribe_with_multiple_resource_param_task_run.golden
@@ -15,8 +15,8 @@ Params
  NAME              TYPE     DEFAULT VALUE
  pipeline-param    string   somethingdifferent
  rev-param         array    [booms booms booms]
- pipeline-param2   string   
- rev-param2        array    
+ pipeline-param2   string   ---
+ rev-param2        array    ---
 
 Tasks
 

--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -79,7 +79,7 @@ No params
  NAME	TYPE	DEFAULT VALUE
 {{- range $p := .Task.Spec.Inputs.Params }}
 {{- if not $p.Default }}
- {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ "" }}
+ {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ "---" }}
 {{- else }}
 {{- if eq $p.Type "string" }}
  {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ $p.Default.StringVal }}

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
@@ -17,8 +17,8 @@ Output Resources
 Params
 
  NAME      TYPE     DEFAULT VALUE
- myarg     string   
- myarray   array    
+ myarg     string   ---
+ myarray   array    ---
  print     string   somethingdifferent
  output    array    [booms booms booms]
 

--- a/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameParams.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameParams.golden
@@ -12,9 +12,9 @@ Output Resources
 Params
 
  NAME      TYPE     DEFAULT VALUE
- myarg     string   
- myprint   string   
- myarray   array    
+ myarg     string   ---
+ myprint   string   ---
+ myarray   array    ---
 
 Steps
 


### PR DESCRIPTION
On every other commands display in tkn if we don't have a value we show a `---`
but on the describe command for "DEFAULT VALUES" it just show it empty, let's do
it like every other commands.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [ ] Run the code checkers with `make check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```