### PR TITLE
Add pipeline version information

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -35,7 +35,8 @@ import (
 )
 
 const usageTemplate = `Usage:{{if .Runnable}}
-{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+{{.UseLine}}{{end}}{{if .Ha
+sAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
@@ -89,7 +90,7 @@ func Root(p cli.Params) *cobra.Command {
 		taskrun.Command(p),
 		triggerbinding.Command(p),
 		triggertemplate.Command(p),
-		version.Command(),
+		version.Command(p),
 	)
 
 	return cmd

--- a/pkg/cmd/version/testdata/TestVersionGood.golden
+++ b/pkg/cmd/version/testdata/TestVersionGood.golden
@@ -1,0 +1,2 @@
+Client version: v1.2.3
+Pipeline version: unknown

--- a/pkg/cmd/version/testdata/TestVersionGood/test-available-new-version.golden
+++ b/pkg/cmd/version/testdata/TestVersionGood/test-available-new-version.golden
@@ -1,0 +1,1 @@
+A newer version (v0.0.2) of Tekton CLI is available, please check https://github.com/tektoncd/cli/releases/tag/v0.0.2

--- a/pkg/cmd/version/testdata/TestVersionGood/test-same-version.golden
+++ b/pkg/cmd/version/testdata/TestVersionGood/test-same-version.golden
@@ -1,0 +1,1 @@
+You are running the latest version (v0.0.10) of Tekton CLI

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -26,6 +26,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/version"
 )
 
 // NOTE: use go build -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(git describe)"
@@ -35,7 +37,7 @@ const devVersion = "dev"
 const latestReleaseURL = "https://api.github.com/repos/tektoncd/cli/releases/latest"
 
 // Command returns version command
-func Command() *cobra.Command {
+func Command(p cli.Params) *cobra.Command {
 	var check bool
 
 	var cmd = &cobra.Command{
@@ -46,6 +48,15 @@ func Command() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
+
+			cs, err := p.Clients()
+			if err == nil {
+				version, _ := version.GetPipelineVersion(cs)
+				if version == "" {
+					version = "unknown"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Pipeline version: %s\n", version)
+			}
 
 			if !check || clientVersion == devVersion {
 				return nil

--- a/pkg/helper/version/version.go
+++ b/pkg/helper/version/version.go
@@ -1,0 +1,55 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const pipelineNamespace = "tekton-pipelines"
+
+// GetPipelineVersion Get pipeline version, functions imported from Dashboard
+func GetPipelineVersion(c *cli.Clients) (string, error) {
+	version := ""
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=controller,app.kubernetes.io/name=tekton-pipelines",
+	}
+
+	deployments, err := c.Kube.AppsV1().Deployments(pipelineNamespace).List(listOptions)
+	if err != nil {
+		return "", err
+	}
+
+	for _, deployment := range deployments.Items {
+		deploymentAnnotations := deployment.Spec.Template.GetAnnotations()
+
+		// For master of Tekton Pipelines
+		version = deploymentAnnotations["pipeline.tekton.dev/release"]
+
+		// For Tekton Pipelines 0.10.0 + 0.10.1
+		if version == "" {
+			version = deploymentAnnotations["tekton.dev/release"]
+		}
+
+		// For Tekton Pipelines 0.9.0 - 0.9.2
+		if version == "" {
+			deploymentImage := deployment.Spec.Template.Spec.Containers[0].Image
+			if strings.Contains(deploymentImage, "pipeline/cmd/controller") && strings.Contains(deploymentImage, ":") && strings.Contains(deploymentImage, "@") {
+				s := strings.SplitAfter(deploymentImage, ":")
+				if strings.Contains(s[1], "@") {
+					t := strings.Split(s[1], "@")
+					version = t[0]
+				}
+			}
+		}
+	}
+
+	if version == "" {
+		return "", fmt.Errorf("Error getting the tekton pipelines deployment version. Version is unknown")
+	}
+
+	return version, nil
+}


### PR DESCRIPTION
Add pipeline service version information to `tkn pipeline version`. The logic
has been imported from dashboard https://git.io/JvC4h

I don't have a full test for it, since the machinery to fake a Deployment is
quite tedious to import/implement and this is not used anywhere else.

Moved the version tests to use `golden`

Closes #463

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Regenerate the manpages and docs with `make docs` and `make man` if needed.
- [X] Run the code checkers with `make check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```