### PR TITLE
--all option for tkn triggerbinding delete

### DIFF
--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all TriggerBindings in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-triggerbinding-delete.1
+++ b/docs/man/man1/tkn-triggerbinding-delete.1
@@ -20,6 +20,10 @@ Delete triggerbindings in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all TriggerBindings in a namespace (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -27,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "triggerbinding", ForceDelete: false}
+	opts := &options.DeleteOptions{Resource: "triggerbinding", ForceDelete: false, DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete TriggerBindings with names 'foo' and 'bar' in namespace 'quux'
 
@@ -43,7 +43,7 @@ or
 		Aliases:      []string{"rm"},
 		Short:        "Delete triggerbindings in a namespace",
 		Example:      eg,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -63,17 +63,18 @@ or
 				return err
 			}
 
-			return deleteTriggerBindings(s, p, args)
+			return deleteTriggerBindings(s, p, args, opts.DeleteAllNs)
 		},
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all TriggerBindings in a namespace (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_triggerbinding")
 	return c
 }
 
-func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string) error {
+func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string, deleteAll bool) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return fmt.Errorf("failed to create tekton client")
@@ -81,7 +82,33 @@ func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string) error 
 	d := deleter.New("TriggerBinding", func(bindingName string) error {
 		return cs.Triggers.TektonV1alpha1().TriggerBindings(p.Namespace()).Delete(bindingName, &metav1.DeleteOptions{})
 	})
+
+	if deleteAll {
+		tbNames, err = allTriggerBindingNames(p, cs)
+		if err != nil {
+			return err
+		}
+	}
 	d.Delete(s, tbNames)
-	d.PrintSuccesses(s)
+
+	if !deleteAll {
+		d.PrintSuccesses(s)
+	} else if deleteAll {
+		if d.Errors() == nil {
+			fmt.Fprintf(s.Out, "All TriggerBindings deleted in namespace %q\n", p.Namespace())
+		}
+	}
 	return d.Errors()
+}
+
+func allTriggerBindingNames(p cli.Params, cs *cli.Clients) ([]string, error) {
+	tbs, err := cs.Triggers.TektonV1alpha1().TriggerBindings(p.Namespace()).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, tb := range tbs.Items {
+		names = append(names, tb.Name)
+	}
+	return names, nil
 }

--- a/pkg/cmd/triggerbinding/delete_test.go
+++ b/pkg/cmd/triggerbinding/delete_test.go
@@ -38,8 +38,12 @@ func TestTriggerBindingDelete(t *testing.T) {
 	}
 
 	seeds := make([]triggertest.Clients, 0)
-	for i := 0; i < 3; i++ {
-		tbs := []*v1alpha1.TriggerBinding{tb.TriggerBinding("tb-1", "ns")}
+	for i := 0; i < 5; i++ {
+		tbs := []*v1alpha1.TriggerBinding{
+			tb.TriggerBinding("tb-1", "ns"),
+			tb.TriggerBinding("tb-2", "ns"),
+			tb.TriggerBinding("tb-3", "ns"),
+		}
 		ctx, _ := rtesting.SetupFakeContext(t)
 		cs := triggertest.SeedResources(t, ctx, triggertest.Resources{TriggerBindings: tbs, Namespaces: ns})
 		seeds = append(seeds, cs)
@@ -70,6 +74,14 @@ func TestTriggerBindingDelete(t *testing.T) {
 			want:        "TriggerBindings deleted: \"tb-1\"\n",
 		},
 		{
+			name:        "With force delete flag (shorthand), multiple TriggerBindings",
+			command:     []string{"rm", "tb-2", "tb-3", "-n", "ns", "-f"},
+			input:       seeds[0],
+			inputStream: nil,
+			wantError:   false,
+			want:        "TriggerBindings deleted: \"tb-2\", \"tb-3\"\n",
+		},
+		{
 			name:        "With force delete flag",
 			command:     []string{"rm", "tb-1", "-n", "ns", "--force"},
 			input:       seeds[1],
@@ -94,12 +106,44 @@ func TestTriggerBindingDelete(t *testing.T) {
 			want:        "Are you sure you want to delete triggerbinding \"tb-1\" (y/n): TriggerBindings deleted: \"tb-1\"\n",
 		},
 		{
+			name:        "Without force delete flag, reply yes, multiple TriggerBindings",
+			command:     []string{"rm", "tb-2", "tb-3", "-n", "ns"},
+			input:       seeds[2],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete triggerbinding \"tb-2\", \"tb-3\" (y/n): TriggerBindings deleted: \"tb-2\", \"tb-3\"\n",
+		},
+		{
 			name:        "Remove non existent resource",
 			command:     []string{"rm", "nonexistent", "-n", "ns"},
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
 			want:        "failed to delete triggerbinding \"nonexistent\": triggerbindings.tekton.dev \"nonexistent\" not found",
+		},
+		{
+			name:        "Delete all with prompt",
+			command:     []string{"delete", "--all", "-n", "ns"},
+			input:       seeds[3],
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete all triggerbindings in namespace \"ns\" (y/n): All TriggerBindings deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all with -f",
+			command:     []string{"delete", "--all", "-f", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   false,
+			want:        "All TriggerBindings deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using triggerbinding name with --all",
+			command:     []string{"delete", "tb", "--all", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 	}
 


### PR DESCRIPTION
Part of #634 

`--all` option for `tkn triggerbinding delete` to delete all TriggerBindings in a namespace.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--all option for tkn triggerbinding delete that deletes all triggerbindings in a namespace
```
