### PR TITLE
--all option for tkn triggertemplate delete

### DIFF
--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+      --all                           Delete all TriggerTemplates in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-triggertemplate-delete.1
+++ b/docs/man/man1/tkn-triggertemplate-delete.1
@@ -20,6 +20,10 @@ Delete triggertemplates in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-all\fP[=false]
+    Delete all TriggerTemplates in a namespace (default: false)
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 


### PR DESCRIPTION
Part of #634 

`--all` option for `tkn triggertemplate delete` to delete all TriggerTemplates in a namespace.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--all option for tkn triggertemplate delete that deletes all triggertemplates in a namespace
```
