### PR TITLE
Add --last  to `tkn pr logs`

### DIFF
--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -33,6 +33,7 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
   -a, --all            show all logs including init steps injected by tekton
   -f, --follow         stream live logs
   -h, --help           help for logs
+  -L, --last           show logs for last pipelinerun
       --limit int      lists number of pipelineruns (default 5)
   -t, --task strings   show logs for mentioned tasks only
 ```

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -32,6 +32,10 @@ Show the logs of PipelineRun
     help for logs
 
 .PP
+\fB\-L\fP, \fB\-\-last\fP[=false]
+    show logs for last pipelinerun
+
+.PP
 \fB\-\-limit\fP=5
     lists number of pipelineruns
 

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -69,6 +69,7 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 	}
 
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last pipelinerun")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
 	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned tasks only")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of pipelineruns")
@@ -125,7 +126,7 @@ func askRunName(opts *options.LogOptions) error {
 		return fmt.Errorf("No pipelineruns found")
 	}
 
-	if len(prs) == 1 {
+	if len(prs) == 1 || opts.Last {
 		opts.PipelineRunName = strings.Fields(prs[0])[0]
 		return nil
 	}


### PR DESCRIPTION
Add an extra test for when there is only one pr and make tkn auto choose it with
logs and no args

Closes #664



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```