### PR TITLE
Fix help command

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -35,8 +35,7 @@ import (
 )
 
 const usageTemplate = `Usage:{{if .Runnable}}
-{{.UseLine}}{{end}}{{if .Ha
-sAvailableSubCommands}}
+{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:


### PR DESCRIPTION
Introduce with a typo in c36b6ce7742e8f1435718890e2d9442b44eb7d30

I guess that happened 🤦‍♂ 

Closes #710

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```