### PR TITLE
--prefix-name option for tkn pipeline start

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -42,6 +42,7 @@ two parameters (foo and bar)
   -L, --last                          re-run the pipeline using last pipelinerun values
       --output string                 format of pipelinerun dry-run (yaml or json)
   -p, --param stringArray             pass the param as key=value or key=value1,value2
+      --prefix-name string            specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name
       --showlog                       show logs right after starting the pipeline

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -52,6 +52,10 @@ Parameters, at least those that have no default value
     pass the param as key=value or key=value1,value2
 
 .PP
+\fB\-\-prefix\-name\fP=""
+    specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)
+
+.PP
 \fB\-r\fP, \fB\-\-resource\fP=[]
     pass the resource name and ref as name=ref
 

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -2554,3 +2554,152 @@ func Test_start_pipeline_last_generate_name(t *testing.T) {
 
 	test.AssertOutput(t, "test-generatename-pipeline-run-", pr.ObjectMeta.GenerateName)
 }
+
+func Test_start_pipeline_last_with_prefix_name(t *testing.T) {
+	pipelineName := "test-pipeline"
+
+	ps := []*v1alpha1.Pipeline{
+		tb.Pipeline(pipelineName, "ns",
+			tb.PipelineSpec(
+				tb.PipelineDeclaredResource("git-repo", "git"),
+				tb.PipelineDeclaredResource("build-image", "image"),
+				tb.PipelineParamSpec("pipeline-param-1", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
+				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
+				tb.PipelineTask("unit-test-1", "unit-test-task",
+					tb.PipelineTaskInputResource("workspace", "git-repo"),
+					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
+					tb.PipelineTaskOutputResource("workspace", "git-repo"),
+				),
+			),
+		),
+	}
+
+	prs := []*v1alpha1.PipelineRun{
+		tb.PipelineRun("test-pipeline-run-123", "ns",
+			tb.PipelineRunLabel("tekton.dev/pipeline", pipelineName),
+			tb.PipelineRunSpec(pipelineName,
+				tb.PipelineRunServiceAccountName("test-sa"),
+				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
+				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
+				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
+				tb.PipelineRunParam("rev-param", "revision1"),
+			),
+		),
+	}
+
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	seedData, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+
+	objs := []runtime.Object{ps[0], prs[0]}
+	pClient := newPipelineClient(objs...)
+
+	cs := pipelinetest.Clients{
+		Pipeline: pClient,
+		Kube:     seedData.Kube,
+	}
+
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	pipeline := Command(p)
+	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
+		"--last",
+		"-r=git-repo=scaffold-git",
+		"-p=rev-param=revision2",
+		"-s=svc1",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
+		"-n", "ns",
+		"--prefix-name", "myprname",
+	)
+
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	test.AssertOutput(t, expected, got)
+
+	pr, err := hpipelinerun.GetPipelineRun(p, v1.GetOptions{}, "random")
+	if err != nil {
+		t.Errorf("Error getting pipelineruns %s", err.Error())
+	}
+
+	test.AssertOutput(t, "myprname-", pr.ObjectMeta.GenerateName)
+}
+
+func Test_start_pipeline_with_prefix_name(t *testing.T) {
+	pipelineName := "test-pipeline"
+
+	ps := []*v1alpha1.Pipeline{
+		tb.Pipeline(pipelineName, "ns",
+			tb.PipelineSpec(
+				tb.PipelineDeclaredResource("git-repo", "git"),
+				tb.PipelineDeclaredResource("build-image", "image"),
+				tb.PipelineParamSpec("pipeline-param-1", v1alpha1.ParamTypeString, tb.ParamSpecDefault("somethingdifferent-1")),
+				tb.PipelineParamSpec("rev-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("revision")),
+				tb.PipelineTask("unit-test-1", "unit-test-task",
+					tb.PipelineTaskInputResource("workspace", "git-repo"),
+					tb.PipelineTaskOutputResource("image-to-use", "best-image"),
+					tb.PipelineTaskOutputResource("workspace", "git-repo"),
+				),
+			),
+		),
+	}
+
+	prs := []*v1alpha1.PipelineRun{
+		tb.PipelineRun("test-pipeline-run-123", "ns",
+			tb.PipelineRunLabel("tekton.dev/pipeline", pipelineName),
+			tb.PipelineRunSpec(pipelineName,
+				tb.PipelineRunServiceAccountName("test-sa"),
+				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
+				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
+				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
+				tb.PipelineRunParam("rev-param", "revision1"),
+			),
+		),
+	}
+
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	seedData, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+
+	objs := []runtime.Object{ps[0], prs[0]}
+	pClient := newPipelineClient(objs...)
+
+	cs := pipelinetest.Clients{
+		Pipeline: pClient,
+		Kube:     seedData.Kube,
+	}
+
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	pipeline := Command(p)
+	got, _ := test.ExecuteCommand(pipeline, "start", pipelineName,
+		"-r=git-repo=scaffold-git",
+		"-p=rev-param=revision2",
+		"-s=svc1",
+		"--task-serviceaccount=task3=task3svc3",
+		"--task-serviceaccount=task5=task3svc5",
+		"-n", "ns",
+		"--prefix-name", "myprname",
+	)
+
+	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	test.AssertOutput(t, expected, got)
+
+	pr, err := hpipelinerun.GetPipelineRun(p, v1.GetOptions{}, "random")
+	if err != nil {
+		t.Errorf("Error getting pipelineruns %s", err.Error())
+	}
+
+	test.AssertOutput(t, "myprname-", pr.ObjectMeta.GenerateName)
+}


### PR DESCRIPTION
Part of #671 

Adding `--name` option for `tkn pipeline start` to allow a user to specify what the name of the PipelineRun they will create is. Default name will follow the format `pipelinename-run-`.

This option will override `--last`, which will use the name of the last PipelineRun for a pipeline if nothing is specified. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--prefix-name option that allows user to specify name of pipelinerun
```
