### PR TITLE
Add --keep to delete --all, to keep the last N pipelineruns

### DIFF
--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -32,6 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
+      --keep int                      Keep n least recent number of pipelineruns when deleting alls
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -p, --pipeline string               The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -32,6 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
+      --keep int                      Keep n least recent number of pipelineruns when deleting alls
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -t, --task string                   The name of a task whose taskruns should be deleted (does not delete the task)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -36,6 +36,10 @@ Delete pipelineruns in a namespace
     help for delete
 
 .PP
+\fB\-\-keep\fP=0
+    Keep n least recent number of pipelineruns when deleting alls
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -36,6 +36,10 @@ Delete taskruns in a namespace
     help for delete
 
 .PP
+\fB\-\-keep\fP=0
+    Keep n least recent number of pipelineruns when deleting alls
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -194,6 +194,22 @@ func TestPipelineRunDelete(t *testing.T) {
 			want:        "All PipelineRuns deleted in namespace \"ns\"\n",
 		},
 		{
+			name:        "Delete all keeping 2",
+			command:     []string{"delete", "--all", "-f", "--keep", "2", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 2 PipelineRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Keep -1 is a no go",
+			command:     []string{"delete", "--all", "-f", "--keep", "-1", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "keep option should not be lower than 0",
+		},
+		{
 			name:        "Error from using pipelinerun name with --all",
 			command:     []string{"delete", "pipelinerun", "--all", "-n", "ns"},
 			input:       seeds[4],

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -165,6 +165,22 @@ func TestTaskRunDelete(t *testing.T) {
 			want:        "All TaskRuns deleted in namespace \"ns\"\n",
 		},
 		{
+			name:        "Delete all keeping 2",
+			command:     []string{"delete", "--all", "-f", "--keep", "2", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 2 TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Keep -1 is a no go",
+			command:     []string{"delete", "--all", "-f", "--keep", "-1", "-n", "ns"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "keep option should not be lower than 0",
+		},
+		{
 			name:        "Error from using taskrun name with --all",
 			command:     []string{"delete", "taskrun", "--all", "-n", "ns"},
 			input:       seeds[4],

--- a/pkg/helper/options/delete.go
+++ b/pkg/helper/options/delete.go
@@ -36,7 +36,7 @@ type DeleteOptions struct {
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns string) error {
 	if o.Keep > 0 && !(o.DeleteAllNs || o.DeleteAll) {
-		return fmt.Errorf("must provide pipelineruns to delete or --pipeline flag")
+		return fmt.Errorf("must use --all flag with --keep")
 	}
 	// make sure no resource names are provided when using --all flag
 	if len(resourceNames) > 0 && (o.DeleteAllNs || o.DeleteAll) {


### PR DESCRIPTION
# Changes

Add a --keep to delete --all so we can keep N numbers. Users can set this up in
a cronjobs to clean old pipelineruns but keeping only the last ones.

Closes #718

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._