### PR TITLE
nil Check for lr.Stream for TaskRun Logs

### DIFF
--- a/pkg/cmd/taskrun/log_reader.go
+++ b/pkg/cmd/taskrun/log_reader.go
@@ -126,7 +126,10 @@ func (lr *LogReader) readAvailableLogs(tr *v1alpha1.TaskRun) (<-chan Log, <-chan
 
 	//Check if taskrun failed on start up
 	if err := hasTaskRunFailed(tr.Status.Conditions, lr.Task); err != nil {
-		fmt.Fprintf(lr.Stream.Err, "%s\n", err.Error())
+		if lr.Stream != nil {
+			fmt.Fprintf(lr.Stream.Err, "%s\n", err.Error())
+		}
+		return nil, nil, err
 	}
 
 	if tr.Status.PodName == "" {


### PR DESCRIPTION
#691 introduced a way to get the logs of a failed TaskRun without using the `-f` flag, but it will panic if the pod fails while initializing. This pull request adds a nil check for `lr.Stream` to prevent panics in this case. 

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add nil check to prevent panics with pipelinerun logs
```
