### PR TITLE
Add --last flag to tkn taskrun logs

### DIFF
--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -33,6 +33,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
   -a, --all            show all logs including init steps injected by tekton
   -f, --follow         stream live logs
   -h, --help           help for logs
+  -L, --last           show logs for last taskrun
       --limit int      lists number of taskruns (default 5)
   -s, --step strings   show logs for mentioned steps only
 ```

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -32,6 +32,10 @@ Show taskruns logs
     help for logs
 
 .PP
+\fB\-L\fP, \fB\-\-last\fP[=false]
+    show logs for last taskrun
+
+.PP
 \fB\-\-limit\fP=5
     lists number of taskruns
 

--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -733,7 +733,7 @@ func TestLog_run_failed_with_and_without_follow(t *testing.T) {
 	test.AssertOutput(t, failMessage+"\n", output)
 }
 
-func TestLog_pipeline_still_running(t *testing.T) {
+func TestLog_pipelinerun_still_running(t *testing.T) {
 	var (
 		pipelineName = "inprogress-pipeline"
 		prName       = "inprogress-run"
@@ -807,7 +807,7 @@ func TestLog_pipeline_still_running(t *testing.T) {
 	test.AssertOutput(t, "Pipeline still running ..."+"\n", output)
 }
 
-func TestLog_pipeline_status_done(t *testing.T) {
+func TestLog_pipelinerun_status_done(t *testing.T) {
 	var (
 		pipelineName = "done-pipeline"
 		prName       = "done-run"
@@ -908,7 +908,7 @@ func fetchLogs(lo *options.LogOptions) (string, error) {
 	return out.String(), err
 }
 
-func TestLog_pipeline_last(t *testing.T) {
+func TestLog_pipelinerun_last(t *testing.T) {
 	var (
 		pipelineName = "pipeline1"
 		prName       = "pr1"
@@ -976,7 +976,7 @@ func TestLog_pipeline_last(t *testing.T) {
 	test.AssertOutput(t, prName2, lopt.PipelineRunName)
 }
 
-func TestLog_pipeline_only_one(t *testing.T) {
+func TestLog_pipelinerun_only_one(t *testing.T) {
 	var (
 		pipelineName = "pipeline1"
 		prName       = "pr1"

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -75,6 +75,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 		},
 	}
 
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last taskrun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of taskruns")
@@ -133,7 +134,7 @@ func askRunName(opts *options.LogOptions) error {
 		return fmt.Errorf("No taskruns found")
 	}
 
-	if len(trs) == 1 {
+	if len(trs) == 1 || opts.Last {
 		opts.TaskrunName = strings.Fields(trs[0])[0]
 		return nil
 	}


### PR DESCRIPTION
It's useful to be abel to see the logs of the last started pipeline without
having to bother much on choosing it...

Closes #312

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```