### PR TITLE
--prefix-name option for tkn task start

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -39,6 +39,7 @@ like cat,foo,bar
       --output string            format of taskrun dry-run (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value or key=value1,value2
+      --prefix-name string       specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the task
   -t, --timeout int              timeout for taskrun in seconds (default 3600)

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -56,6 +56,10 @@ Start tasks
     pass the param as key=value or key=value1,value2
 
 .PP
+\fB\-\-prefix\-name\fP=""
+    specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
+
+.PP
 \fB\-s\fP, \fB\-\-serviceaccount\fP=""
     pass the serviceaccount name
 


### PR DESCRIPTION
Closes #671 

Adding `--prefix-name` option for `tkn task start` to allow a user to specify what the name of the TaskRun they will create is. Default name will follow the format `taskname-run-`.

This option will override `--last`, which will use the name of the last PipelineRun for a pipeline if nothing is specified. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
--prefix-name option that allows user to specify name of pipelinerun
```
