### PR TITLE
Makefile and presubmit minor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,11 @@ test-e2e: bin/tkn ## run e2e tests
 docs: bin/docs ## update docs
 	@echo "Update generated docs"
 	@./bin/docs --target=./docs/cmd
-
-.PHONY: man
-man: bin/docs ## update manpages
-	@echo "Update generated manpages"
 	@./bin/docs --target=./docs/man/man1 --kind=man
+	@rm -f ./bin/docs
 
 .PHONY: generated
-generated: test-unit-update-golden man docs fmt ## generate all files that needs to be generated
+generated: test-unit-update-golden docs fmt ## generate all files that needs to be generated
 
 .PHONY: clean
 clean: ## clean build artifacts

--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -733,7 +733,7 @@ func TestLog_run_failed_with_and_without_follow(t *testing.T) {
 	test.AssertOutput(t, failMessage+"\n", output)
 }
 
-func TestLog_pipeline_still_running(t *testing.T) {
+func TestLog_pipelinerun_still_running(t *testing.T) {
 	var (
 		pipelineName = "inprogress-pipeline"
 		prName       = "inprogress-run"
@@ -807,7 +807,7 @@ func TestLog_pipeline_still_running(t *testing.T) {
 	test.AssertOutput(t, "Pipeline still running ..."+"\n", output)
 }
 
-func TestLog_pipeline_status_done(t *testing.T) {
+func TestLog_pipelinerun_status_done(t *testing.T) {
 	var (
 		pipelineName = "done-pipeline"
 		prName       = "done-run"
@@ -908,7 +908,7 @@ func fetchLogs(lo *options.LogOptions) (string, error) {
 	return out.String(), err
 }
 
-func TestLog_pipeline_last(t *testing.T) {
+func TestLog_pipelinerun_last(t *testing.T) {
 	var (
 		pipelineName = "pipeline1"
 		prName       = "pr1"
@@ -976,7 +976,7 @@ func TestLog_pipeline_last(t *testing.T) {
 	test.AssertOutput(t, prName2, lopt.PipelineRunName)
 }
 
-func TestLog_pipeline_only_one(t *testing.T) {
+func TestLog_pipelinerun_only_one(t *testing.T) {
 	var (
 		pipelineName = "pipeline1"
 		prName       = "pr1"

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -31,7 +31,6 @@ function test_documentation_has_been_generated() {
     header "Testing if documentation has been generated"
 
     make docs
-    make man
 
     if [[ -n $(git status --porcelain docs/) ]];then
         echo "-- FATAL: The documentation or manpages didn't seem to be generated :"

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -43,6 +43,24 @@ function test_documentation_has_been_generated() {
     results_banner "Documentation" 0
 }
 
+
+function test_golden_has_been_generated() {
+    header "Testing if golden files has been generated"
+
+    make test-unit-update-golden
+
+    if [[ -n $(git status --porcelain pkg/) ]];then
+        echo "-- FATAL: The golden files didn't seem to be generated, rerun 'make generated' :"
+        git status docs
+        git diff docs
+        results_banner "Golden" 1
+        exit 1
+    fi
+
+    results_banner "Golden" 0
+}
+
+
 function check_lint() {
     header "Testing if golint/yamllint has been done"
 
@@ -61,6 +79,7 @@ function pre_build_tests() {
 }
 
 function post_build_tests() {
+    test_golden_has_been_generated
     test_documentation_has_been_generated
     check_lint
 }


### PR DESCRIPTION
# Changes

1. Generate manpages at the same time as make docs
   You always want to do the two at the same time and I always forget to run
   one or another.

   Since there is no reason to be separated, let's merge those two.

2. Modify test names as they are pipelinerun not pipeline tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```