### PR TITLE
Adds timeout to pipeline start

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -47,6 +47,7 @@ two parameters (foo and bar)
   -s, --serviceaccount string         pass the serviceaccount name
       --showlog                       show logs right after starting the pipeline
       --task-serviceaccount strings   pass the service account corresponding to the task
+      --timeout string                timeout for pipelinerun (default "1h")
       --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
 ```
 

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -72,6 +72,10 @@ Parameters, at least those that have no default value
     pass the service account corresponding to the task
 
 .PP
+\fB\-\-timeout\fP="1h"
+    timeout for pipelinerun
+
+.PP
 \fB\-\-use\-pipelinerun\fP=""
     use this pipelinerun values to re\-run the pipeline.
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -17,4 +17,5 @@ spec:
     resourceRef:
       name: scaffold-git
   serviceAccountName: svc1
+  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -27,7 +27,8 @@
 				"value": "value1"
 			}
 		],
-		"serviceAccountName": "svc1"
+		"serviceAccountName": "svc1",
+		"timeout": "1h0m0s"
 	},
 	"status": {}
 }


### PR DESCRIPTION
Close #706

This adds a timeout option to `tkn pipeline start` command
timeout is string variable and value can be in format `1h10m2s`
default timeout value is `1h`

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
