### PR TITLE
Add Error Message for Deletion When No Args or --all Flag Specified

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -772,6 +772,7 @@ k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/cli-runtime v0.0.0-20191004110054-fe9b9282443f h1:vJOrMsZe+RD884n+WQ5So2oOp7SajI0Op3oOBg64ZsY=
 k8s.io/cli-runtime v0.0.0-20191004110054-fe9b9282443f/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
+k8s.io/cli-runtime v0.17.3 h1:0ZlDdJgJBKsu77trRUynNiWsRuAvAVPBNaQfnt/1qtc=
 k8s.io/client-go v0.0.0-20191004102537-eb5b9a8cfde7 h1:WyPHgjjXvF4zVVwKGZKKiJGBUW45AuN44uSOuH8euuE=
 k8s.io/client-go v0.0.0-20191004102537-eb5b9a8cfde7/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/cloud-provider v0.17.0/go.mod h1:Ze4c3w2C0bRsjkBUoHpFi+qWe3ob1wI2/7cUn+YQIDE=

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -130,6 +130,14 @@ func TestClusterTaskDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Error from using clustertask delete with no names or --all",
+			command:     []string{"delete"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide clustertask name(s) or use --all flag with delete",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/cmd/condition/delete_test.go
+++ b/pkg/cmd/condition/delete_test.go
@@ -149,6 +149,14 @@ func TestConditionDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Error from using condition delete with no names or --all",
+			command:     []string{"delete"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide condition name(s) or use --all flag with delete",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/cmd/eventlistener/delete_test.go
+++ b/pkg/cmd/eventlistener/delete_test.go
@@ -145,6 +145,14 @@ func TestEventListenerDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Error from using eventlistener delete with no names or --all",
+			command:     []string{"delete"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide eventlistener name(s) or use --all flag with delete",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -129,6 +129,14 @@ func TestPipelineResourceDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Error from using resource delete with no names or --all",
+			command:     []string{"delete"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide pipelineresource name(s) or use --all flag with delete",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -167,7 +167,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide pipelineruns to delete or --pipeline flag",
+			want:        "must provide pipelinerun name(s) or use --pipeline flag or --all flag to use delete",
 		},
 		{
 			name:        "Remove pipelineruns of a pipeline",

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -138,7 +138,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide taskruns to delete or --task flag",
+			want:        "must provide taskrun name(s) or use --task flag or --all flag to use delete",
 		},
 		{
 			name:        "Remove taskruns of a task",

--- a/pkg/cmd/triggerbinding/delete_test.go
+++ b/pkg/cmd/triggerbinding/delete_test.go
@@ -145,6 +145,14 @@ func TestTriggerBindingDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Error from using triggerbinding delete with no names or --all",
+			command:     []string{"delete"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide triggerbinding name(s) or use --all flag with delete",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/cmd/triggertemplate/delete_test.go
+++ b/pkg/cmd/triggertemplate/delete_test.go
@@ -145,6 +145,14 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Error from using triggertemplate delete with no names or --all",
+			command:     []string{"delete"},
+			input:       seeds[4],
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide triggertemplate name(s) or use --all flag with delete",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/helper/options/delete_test.go
+++ b/pkg/helper/options/delete_test.go
@@ -106,15 +106,13 @@ func TestDeleteOptions(t *testing.T) {
 		{
 			name:           "Error when all defaults specified with ParentResource",
 			opt:            &DeleteOptions{Resource: "TaskRun", ParentResource: "task", ForceDelete: false, DeleteRelated: false, DeleteAllNs: false},
-			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{},
 			wantError:      true,
-			want:           "must provide TaskRuns to delete or --task flag",
+			want:           "must provide TaskRun name(s) or use --task flag or --all flag to use delete",
 		},
 		{
 			name:           "Error when resource name provided with DeleteAllNs",
 			opt:            &DeleteOptions{DeleteAllNs: true},
-			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{"test1"},
 			wantError:      true,
 			want:           "--all flag should not have any arguments or flags specified with it",
@@ -129,10 +127,16 @@ func TestDeleteOptions(t *testing.T) {
 		{
 			name:           "Error when resource name provided with DeleteAll",
 			opt:            &DeleteOptions{DeleteAll: true},
-			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			resourcesNames: []string{"test1"},
 			wantError:      true,
 			want:           "--all flag should not have any arguments or flags specified with it",
+		},
+		{
+			name:           "Error when not specifying resource name or --all flag in non PipelineRun/TaskRun deletion",
+			opt:            &DeleteOptions{Resource: "Condition", ParentResource: "", ParentResourceName: "", DeleteRelated: false, DeleteAllNs: false},
+			resourcesNames: []string{},
+			wantError:      true,
+			want:           "must provide Condition name(s) or use --all flag with delete",
 		},
 	}
 


### PR DESCRIPTION
Since deletion commands, with the exception of Pipeline and Task, don't require an arg anymore as part of adding `--all`, there should be an error message if no args are passed for deletion or the `--all` flag isn't used. 

Currently, if a user runs something like `tkn condition delete`, the result would be getting a prompt like below:

```
Are you sure you want to delete condition  (y/n):
```

While this is harmless as far as deleting resources, it's not great presentation. This error message would result in the following change:

```
Error: must provide condition name(s) or use --all flag with delete
```

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Improve deletion error message if no args or no --all flag 
```
