### PR TITLE
Use -mod=vendor for golangci-lint too 👼

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ test: test-unit ## run all tests
 .PHONY: lint
 lint: lint-yaml ## run linter(s)
 	@echo "Linting..."
-	@golangci-lint run ./... --max-issues-per-linter=0 --max-same-issues=0 --deadline 5m
+	@golangci-lint run ./... --modules-download-mode=vendor \
+							--max-issues-per-linter=0 \
+							--max-same-issues=0 \
+							--deadline 5m
 
 .PHONY: lint-yaml
 lint-yaml: ${YAML_FILES} ## runs yamllint on all yaml files

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -122,7 +122,7 @@ func Run(opts *options.LogOptions) error {
 		return err
 	}
 
-	log.NewLogWriter(log.LogTypePipeline).Write(opts.Stream, logC, errC)
+	log.NewWriter(log.LogTypePipeline).Write(opts.Stream, logC, errC)
 
 	return nil
 }

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -128,7 +128,7 @@ func Run(opts *options.LogOptions) error {
 		return err
 	}
 
-	log.NewLogWriter(log.LogTypeTask).Write(opts.Stream, logC, errC)
+	log.NewWriter(log.LogTypeTask).Write(opts.Stream, logC, errC)
 	return nil
 }
 

--- a/pkg/helper/log/writer.go
+++ b/pkg/helper/log/writer.go
@@ -21,22 +21,22 @@ import (
 	"github.com/tektoncd/cli/pkg/formatted"
 )
 
-// LogWriter helps logging pod"s log
-type LogWriter struct {
+// Writer helps logging pod"s log
+type Writer struct {
 	fmt     *formatted.Color
 	logType string
 }
 
-// NewLogWriter returns the new instance of LogWriter
-func NewLogWriter(logType string) *LogWriter {
-	return &LogWriter{
+// NewWriter returns the new instance of LogWriter
+func NewWriter(logType string) *Writer {
+	return &Writer{
 		fmt:     formatted.NewColor(),
 		logType: logType,
 	}
 }
 
 // Write formatted pod's logs
-func (lw *LogWriter) Write(s *cli.Stream, logC <-chan Log, errC <-chan error) {
+func (lw *Writer) Write(s *cli.Stream, logC <-chan Log, errC <-chan error) {
 	for logC != nil || errC != nil {
 		select {
 		case l, ok := <-logC:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

> --modules-download-mode string Modules download mode. If not empty,
> passed as -mod=<mode> to go tools

---

Also: Fix linting on pkg/log

LogWriter is on the package log, which makes is `log.LogWriter`… the
`Log` prefix is not required.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
