### PR TITLE
Show Sidecar Names with tkn tr desc

### DIFF
--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
@@ -25,3 +25,7 @@ No params
 Steps
 
 No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
@@ -22,3 +22,7 @@ No params
 Steps
 
 No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
@@ -26,3 +26,7 @@ No params
 Steps
 
 No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
@@ -30,3 +30,7 @@ Steps
  NAME    STATUS
  step1   Completed
  step2   Completed
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_taskref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_taskref.golden
@@ -25,3 +25,7 @@ No params
 Steps
 
 No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
@@ -30,3 +30,7 @@ Steps
  NAME    STATUS
  step1   Completed
  step2   Completed
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_default.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_default.golden
@@ -30,3 +30,7 @@ Steps
  NAME    STATUS
  step1   Error
  step2   ---
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
@@ -28,5 +28,10 @@ Params
 Steps
 
  NAME    STATUS
- step1   Running
- step2   Running
+ step1   PodInitializing
+ step2   PodInitializing
+
+Sidecars
+
+ NAME
+ sidecar1

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
@@ -28,5 +28,11 @@ Params
 Steps
 
  NAME    STATUS
- step1   PodInitializing
- step2   PodInitializing
+ step1   Running
+ step2   Running
+
+Sidecars
+
+ NAME
+ sidecar1
+ sidecar2

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -64,6 +64,8 @@ func DecorateAttr(attrString, message string) string {
 		return fmt.Sprintf("💌 ")
 	case "taskruns":
 		return fmt.Sprintf("🗂  ")
+	case "sidecars":
+		return fmt.Sprintf("🚗 ")
 	}
 
 	attr := color.Reset

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -80,13 +80,13 @@ func TestDecoration(t *testing.T) {
 	funcMap := template.FuncMap{
 		"decorate": DecorateAttr,
 	}
-	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
+	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
 	processed := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(aTemplate))
 	buf := new(bytes.Buffer)
 
 	if err := processed.Execute(buf, nil); err != nil {
 		t.Error("Could not process the template.")
 	}
-	test.AssertOutput(t, "∙ Foo 📦 ⚓ 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
+	test.AssertOutput(t, "∙ Foo 📦 ⚓ 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
 
 }

--- a/pkg/helper/taskrun/description/taskrun_description.go
+++ b/pkg/helper/taskrun/description/taskrun_description.go
@@ -91,6 +91,17 @@ No steps
  {{decorate "bullet" $step.Name }}	{{ $reason }}
 {{- end }}
 {{- end }}
+
+{{decorate "sidecars" ""}}{{decorate "underline bold" "Sidecars"}}
+{{$sidecars := .TaskRun.Status.Sidecars }}
+{{- $l := len $sidecars }}{{ if eq $l 0 }}
+No sidecars
+{{- else }}
+ NAME
+{{- range $sidecar := $sidecars }}
+ {{decorate "bullet" $sidecar.Name }}
+{{- end }}
+{{- end }}
 `
 
 func sortStepStatesByStartTime(steps []v1alpha1.StepState) []v1alpha1.StepState {


### PR DESCRIPTION
Part of #655 

This pull request adds the names of Sidecar containers associated with a TaskRun to `tkn tr desc`. Unfortunately, the [ContainerState is not available](https://github.com/tektoncd/pipeline/issues/2074) for Sidecars at this time, but I have a [pull request](https://github.com/tektoncd/pipeline/pull/2075) for this open and may be available as soon as next release of pipeline. For now, we can at least show what sidecars are present as part of a TaskRun.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add Sidecar names to tkn taskrun describe
```
