### PR TITLE
Refactoring log reader.

### DIFF
--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/cli/pkg/helper/log"
 	"github.com/tektoncd/cli/pkg/helper/options"
 	prhelper "github.com/tektoncd/cli/pkg/helper/pipelinerun"
-	"github.com/tektoncd/cli/pkg/helper/pods"
 	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -97,24 +96,10 @@ func Run(opts *options.LogOptions) error {
 			return err
 		}
 	}
-	streamer := pods.NewStream
-	if opts.Streamer != nil {
-		streamer = opts.Streamer
-	}
-	cs, err := opts.Params.Clients()
+
+	lr, err := log.NewReader(log.LogTypePipeline, opts)
 	if err != nil {
 		return err
-	}
-
-	lr := &LogReader{
-		Run:      opts.PipelineRunName,
-		Ns:       opts.Params.Namespace(),
-		Clients:  cs,
-		Streamer: streamer,
-		Stream:   opts.Stream,
-		Follow:   opts.Follow,
-		AllSteps: opts.AllSteps,
-		Tasks:    opts.Tasks,
 	}
 
 	logC, errC, err := lr.Read()

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -23,15 +23,13 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/helper/log"
 	"github.com/tektoncd/cli/pkg/helper/options"
-	"github.com/tektoncd/cli/pkg/helper/pods"
 	trlist "github.com/tektoncd/cli/pkg/helper/taskrun/list"
 	validate "github.com/tektoncd/cli/pkg/helper/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	msgTRNotFoundErr = "Unable to get Taskrun"
-	defaultLimit     = 5
+	defaultLimit = 5
 )
 
 func logCommand(p cli.Params) *cobra.Command {
@@ -102,25 +100,9 @@ func Run(opts *options.LogOptions) error {
 		}
 	}
 
-	streamer := pods.NewStream
-	if opts.Streamer != nil {
-		streamer = opts.Streamer
-	}
-
-	cs, err := opts.Params.Clients()
+	lr, err := log.NewReader(log.LogTypeTask, opts)
 	if err != nil {
 		return err
-	}
-
-	lr := &LogReader{
-		Run:      opts.TaskrunName,
-		Ns:       opts.Params.Namespace(),
-		Clients:  cs,
-		Streamer: streamer,
-		Stream:   opts.Stream,
-		Follow:   opts.Follow,
-		AllSteps: opts.AllSteps,
-		Steps:    opts.Steps,
 	}
 
 	logC, errC, err := lr.Read()

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/log"
 	"github.com/tektoncd/cli/pkg/helper/options"
 	"github.com/tektoncd/cli/pkg/helper/pods/fake"
 	"github.com/tektoncd/cli/pkg/helper/pods/stream"
@@ -169,7 +170,7 @@ func TestLog_missing_taskrun(t *testing.T) {
 
 	c := Command(p)
 	got, _ := test.ExecuteCommand(c, "logs", "output-taskrun-2", "-n", "ns")
-	expected := "Error: " + msgTRNotFoundErr + ": taskruns.tekton.dev \"output-taskrun-2\" not found\n"
+	expected := "Error: " + log.MsgTRNotFoundErr + ": taskruns.tekton.dev \"output-taskrun-2\" not found\n"
 	test.AssertOutput(t, expected, got)
 }
 

--- a/pkg/helper/log/reader.go
+++ b/pkg/helper/log/reader.go
@@ -1,0 +1,99 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/helper/options"
+	"github.com/tektoncd/cli/pkg/helper/pods"
+	"github.com/tektoncd/cli/pkg/helper/pods/stream"
+)
+
+type Reader struct {
+	run      string
+	ns       string
+	clients  *cli.Clients
+	streamer stream.NewStreamerFunc
+	stream   *cli.Stream
+	allSteps bool
+	follow   bool
+	tasks    []string
+	steps    []string
+	logType  string
+	task     string
+	number   int
+}
+
+func NewReader(logType string, opts *options.LogOptions) (*Reader, error) {
+	streamer := pods.NewStream
+	if opts.Streamer != nil {
+		streamer = opts.Streamer
+	}
+
+	cs, err := opts.Params.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	var run string
+	switch logType {
+	case LogTypePipeline:
+		run = opts.PipelineRunName
+	case LogTypeTask:
+		run = opts.TaskrunName
+	}
+
+	return &Reader{
+		run:      run,
+		ns:       opts.Params.Namespace(),
+		clients:  cs,
+		streamer: streamer,
+		stream:   opts.Stream,
+		follow:   opts.Follow,
+		allSteps: opts.AllSteps,
+		tasks:    opts.Tasks,
+		steps:    opts.Steps,
+		logType:  logType,
+	}, nil
+}
+
+func (r *Reader) Read() (<-chan Log, <-chan error, error) {
+	switch r.logType {
+	case LogTypePipeline:
+		return r.readPipelineLog()
+	case LogTypeTask:
+		return r.readTaskLog()
+	}
+	return nil, nil, fmt.Errorf("unknown log type")
+}
+
+func (r *Reader) setNumber(number int) {
+	r.number = number
+}
+
+func (r *Reader) setRun(run string) {
+	r.run = run
+}
+
+func (r *Reader) setTask(task string) {
+	r.task = task
+}
+
+func (r *Reader) clone() *Reader {
+	c := *r
+	return &c
+}

--- a/pkg/helper/taskrun/taskrun.go
+++ b/pkg/helper/taskrun/taskrun.go
@@ -15,34 +15,12 @@
 package taskrun
 
 import (
-	"github.com/tektoncd/cli/pkg/cli"
-	"github.com/tektoncd/cli/pkg/cmd/taskrun"
-	"github.com/tektoncd/cli/pkg/helper/pods/stream"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
 type Run struct {
 	Name string
 	Task string
-}
-
-//NewLogReader returns the new instance of LogReader for
-//a Run instance
-func (t *Run) NewLogReader(ns string, clientSet *cli.Clients,
-	streamer stream.NewStreamerFunc,
-	num int, follow bool,
-	allSteps bool) *taskrun.LogReader {
-
-	return &taskrun.LogReader{
-		Run:      t.Name,
-		Task:     t.Task,
-		Number:   num,
-		Ns:       ns,
-		Clients:  clientSet,
-		Streamer: streamer,
-		Follow:   follow,
-		AllSteps: allSteps,
-	}
 }
 
 func IsFiltered(tr Run, allowed []string) bool {


### PR DESCRIPTION
Related issue is https://github.com/tektoncd/cli/issues/748

taskrun's logreader and pipelinerun's logreader has a few same logic.
moving these code into same package.

and remove reference from ```pkg/helper/taskrun/taskrun.go``` to ```cmd``` package.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
