### PR TITLE
cleanup (task/start) Remove -t timeout shorthand from tkn task start

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -41,7 +41,7 @@ like cat,foo,bar
   -p, --param stringArray        pass the param as key=value or key=value1,value2
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the task
-  -t, --timeout int              timeout for taskrun in seconds (default 3600)
+      --timeout int              timeout for taskrun in seconds (default 3600)
       --use-taskrun string       specify a taskrun name to use its values to re-run the taskrun
 ```
 

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -64,7 +64,7 @@ Start tasks
     show logs right after starting the task
 
 .PP
-\fB\-t\fP, \fB\-\-timeout\fP=3600
+\fB\-\-timeout\fP=3600
     timeout for taskrun in seconds
 
 .PP

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -152,7 +152,7 @@ like cat,foo,bar
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the task")
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a task definition")
-	c.Flags().Int64VarP(&opt.TimeOut, "timeout", "t", 3600, "timeout for taskrun in seconds")
+	c.Flags().Int64VarP(&opt.TimeOut, "timeout", "", 3600, "timeout for taskrun in seconds")
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview taskrun without running it")
 	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of taskrun dry-run (yaml or json)")
 


### PR DESCRIPTION
fixes https://github.com/tektoncd/cli/issues/743

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fixes #743 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
