### PR TITLE
Remove trigger alias for start subcommands 🚉

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -2,8 +2,6 @@
 
 Start pipelines
 
-***Aliases**: trigger*
-
 ### Usage
 
 ```

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -2,8 +2,6 @@
 
 Start tasks
 
-***Aliases**: trigger*
-
 ### Usage
 
 ```

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -118,9 +118,8 @@ func startCommand(p cli.Params) *cobra.Command {
 	}
 
 	c := &cobra.Command{
-		Use:     "start pipeline [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
-		Aliases: []string{"trigger"},
-		Short:   "Start pipelines",
+		Use:   "start pipeline [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
+		Short: "Start pipelines",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -96,9 +96,8 @@ func startCommand(p cli.Params) *cobra.Command {
 	}
 
 	c := &cobra.Command{
-		Use:     "start task [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
-		Aliases: []string{"trigger"},
-		Short:   "Start tasks",
+		Use:   "start task [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
+		Short: "Start tasks",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

It's gonna be quite confusing with `trigger`'s object getting in.
This removes it from `tkn pipeline start` and `tkn task start`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Closes #531 

/cc @danielhelfand @piyush-garg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Remove start alias named "trigger" for pipeline and task subcommand
```
