### PR TITLE
Use -mod=vendor during the release 👼

### DIFF
--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -37,6 +37,8 @@ spec:
           value: $(params.package)
         - name: version
           value: 1.13.8
+        - name: flags
+          value: -v -mod=vendor
       resources:
         inputs:
           - name: source
@@ -50,6 +52,8 @@ spec:
           value: $(params.package)
         - name: version
           value: 1.13.8
+        - name: flags
+          value: -v -mod=vendor
       resources:
         inputs:
           - name: source


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It should speed the process up, and use only the `vendor` folder to
build, so no surprises.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @danielhelfand @piyush-garg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
