### PR TITLE
Add support for yubikey in debbuild 🦌

### DIFF
--- a/tekton/debbuild/container/Dockerfile
+++ b/tekton/debbuild/container/Dockerfile
@@ -5,19 +5,21 @@ RUN set -ex \
     && sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-               build-essential \
-		 	   dput \
-               cdbs \
-			   git \
-			   curl \
-               equivs \
-               vim \
-               libdistro-info-perl \
-			   golang-any \
-               devscripts \
-			   debhelper \
-			   dh-golang \
-               fakeroot \
+    build-essential \
+    dput \
+    cdbs \
+    git \
+    curl \
+    equivs \
+    vim \
+    libdistro-info-perl \
+    golang-any \
+    devscripts \
+    debhelper \
+    dh-golang \
+    fakeroot \
+    pcscd \
+    scdaemon \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/tekton/debbuild/container/buildpackage.sh
+++ b/tekton/debbuild/container/buildpackage.sh
@@ -38,7 +38,9 @@ cd cli-${version}
 
 dch -M -v ${version}-${RELEASE} -D $(sed -n '/DISTRIB_CODENAME/ { s/.*=//;p;;}' /etc/lsb-release) "new update"
 
+pcscd
 gpgconf --kill gpg-agent && gpg-agent --pinentry-program /usr/bin/pinentry-curses --verbose --daemon
+gpg --card-status || true
 debuild -S --force-sign -k${GPG_KEY}
 
 cd ..

--- a/tekton/debbuild/run.sh
+++ b/tekton/debbuild/run.sh
@@ -7,12 +7,21 @@ set -eux
 # and have your gpg setup in your profile
 PPATARGET=tektoncd/cli
 GPG_KEY=${GPG_KEY}
+YUBIKEY=${YUBIKEY:-}
+ADDITIONAL_ARGS=${ADDITIONAL_ARGS:-}
 
 [[ -n ${GPG_KEY} ]] || {
-	echo "You need to setup your GPG_KEY"
-	exit 1
+    echo "You need to setup your GPG_KEY"
+    exit 1
 }
 
+[[ -n ${YUBIKEY} ]] && {
+    ADDITIONAL_ARGS="${ADDITIONAL_ARGS} -v /dev/bus/usb:/dev/bus/usb \
+     -v /sys/bus/usb:/sys/bus/usb \
+     -v /sys/devices:/sys/devices \
+     -v ${YUBIKEY}:${YUBIKEY} \
+     --privileged"
+}
 
 gpg --list-secret-keys >/dev/null || { echo "You need to have a secret GPG key"; exit 1 ;}
 
@@ -22,9 +31,10 @@ docker build -t ubuntu-build-deb .
 cd ..
 fpath=$(readlink -f control)
 docker run --rm \
-	 -v ~/.gnupg:/root/.gnupg \
-	 -v ${fpath}:/debian --name ubuntu-build-deb \
-	 --env PPATARGET=${PPATARGET} \
-	 --env GPG_KEY=${GPG_KEY} \
-	 -it ubuntu-build-deb \
-	/run.sh
+       -v ~/.gnupg:/root/.gnupg \
+       $ADDITIONAL_ARGS \
+       -v ${fpath}:/debian --name ubuntu-build-deb \
+       --env PPATARGET=${PPATARGET} \
+       --env GPG_KEY=${GPG_KEY} \
+       -it ubuntu-build-deb \
+       /run.sh


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If the release captain passes `YUBIKEY` environment variable with the
`/dev/…` as value, it will add the correct flag to let the container
being able to see and use it.

Example: `YUBIKEY=/dev/hidraw11 ./run.sh`

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @chmouel @danielhelfand 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

