### PR TITLE
Improve --keep Description and Unit Tests for Prompts

### DIFF
--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -32,7 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-      --keep int                      Keep n least recent number of pipelineruns when deleting alls
+      --keep int                      Keep n least recent number of pipelineruns when using --all with delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -p, --pipeline string               The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -37,7 +37,7 @@ Delete pipelineruns in a namespace
 
 .PP
 \fB\-\-keep\fP=0
-    Keep n least recent number of pipelineruns when deleting alls
+    Keep n least recent number of pipelineruns when using \-\-all with delete
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -71,7 +71,7 @@ or
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().StringVarP(&opts.ParentResourceName, "pipeline", "p", "", "The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)")
-	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n least recent number of pipelineruns when deleting alls")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n least recent number of pipelineruns when using --all with delete")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all pipelineruns in a namespace (default: false)")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
 	return c

--- a/pkg/helper/options/delete_test.go
+++ b/pkg/helper/options/delete_test.go
@@ -138,6 +138,20 @@ func TestDeleteOptions(t *testing.T) {
 			wantError:      true,
 			want:           "must provide Condition name(s) or use --all flag with delete",
 		},
+		{
+			name:           "Error when using --keep without --all",
+			opt:            &DeleteOptions{Keep: 7, DeleteAllNs: false, DeleteAll: false},
+			resourcesNames: []string{},
+			wantError:      true,
+			want:           "must use --all flag with --keep",
+		},
+		{
+			name:           "Error --keep < 0",
+			opt:            &DeleteOptions{Keep: -1, DeleteAllNs: true},
+			resourcesNames: []string{},
+			wantError:      true,
+			want:           "keep option should not be lower than 0",
+		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
Minor cleanup of `--keep` flag for `tkn pr delete`. This pull request improves the description of the command and adds some unit tests for prompts associated with the command.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Improve tkn pr delete --keep description
```
