### PR TITLE
Remove the name param in cluster resource creation

### DIFF
--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -1484,14 +1484,6 @@ func TestPipelineStart_Interactive(t *testing.T) {
 						return err
 					}
 
-					if _, err := c.ExpectString("Enter a value for name :"); err != nil {
-						return err
-					}
-
-					if _, err := c.SendLine("some-cluster"); err != nil {
-						return err
-					}
-
 					if _, err := c.ExpectString("Enter a value for url :"); err != nil {
 						return err
 					}

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -284,13 +284,6 @@ func (res *Resource) AskImageParams() error {
 }
 
 func (res *Resource) AskClusterParams() error {
-	nameParam, err := askParam("name", res.AskOpts)
-	if err != nil {
-		return err
-	}
-	if nameParam.Name != "" {
-		res.PipelineResource.Spec.Params = append(res.PipelineResource.Spec.Params, nameParam)
-	}
 
 	urlParam, err := askParam("url", res.AskOpts)
 	if err != nil {

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -391,14 +391,6 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 					return err
 				}
 
-				if _, err := c.ExpectString("Enter a value for name :"); err != nil {
-					return err
-				}
-
-				if _, err := c.SendLine("some-cluster"); err != nil {
-					return err
-				}
-
 				if _, err := c.ExpectString("Enter a value for url :"); err != nil {
 					return err
 				}
@@ -536,14 +528,6 @@ func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T)
 				}
 
 				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
-					return err
-				}
-
-				if _, err := c.ExpectString("Enter a value for name :"); err != nil {
-					return err
-				}
-
-				if _, err := c.SendLine("some-cluster"); err != nil {
 					return err
 				}
 
@@ -894,14 +878,6 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 					return err
 				}
 
-				if _, err := c.ExpectString("Enter a value for name :"); err != nil {
-					return err
-				}
-
-				if _, err := c.SendLine("some-cluster"); err != nil {
-					return err
-				}
-
 				if _, err := c.ExpectString("Enter a value for url :"); err != nil {
 					return err
 				}
@@ -1055,14 +1031,6 @@ func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.
 				}
 
 				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
-					return err
-				}
-
-				if _, err := c.ExpectString("Enter a value for name :"); err != nil {
-					return err
-				}
-
-				if _, err := c.SendLine("some-cluster"); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
This will fix the issue of asking of name param
while creating cluster resource interactively
as it has been removed from pipeline

Fix #767 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Remove name param from cluster resource creation
```
