### PR TITLE
Convert --all to Delete all Pipelines/Tasks in Namespace

### DIFF
--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -28,11 +28,12 @@ or
 ### Options
 
 ```
-  -a, --all                           Whether to also delete related resources (pipelineruns) (default: false)
+      --all                           Delete all Pipelines in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
+      --prs                           Whether to delete pipeline(s) and related resources (pipelineruns) (default: false)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -28,12 +28,13 @@ or
 ### Options
 
 ```
-  -a, --all                           Whether to also delete related resources (taskruns) (default: false)
+      --all                           Delete all Tasks in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+      --trs                           Whether to delete Task(s) and related resources (TaskRuns) (default: false)
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -20,8 +20,8 @@ Delete pipelines in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-a\fP, \fB\-\-all\fP[=false]
-    Whether to also delete related resources (pipelineruns) (default: false)
+\fB\-\-all\fP[=false]
+    Delete all Pipelines in a namespace (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
@@ -38,6 +38,10 @@ Delete pipelines in a namespace
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
+
+.PP
+\fB\-\-prs\fP[=false]
+    Whether to delete pipeline(s) and related resources (pipelineruns) (default: false)
 
 .PP
 \fB\-\-template\fP=""

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -20,8 +20,8 @@ Delete task resources in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-a\fP, \fB\-\-all\fP[=false]
-    Whether to also delete related resources (taskruns) (default: false)
+\fB\-\-all\fP[=false]
+    Delete all Tasks in a namespace (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
@@ -43,6 +43,10 @@ Delete task resources in a namespace
 \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].
+
+.PP
+\fB\-\-trs\fP[=false]
+    Whether to delete Task(s) and related resources (TaskRuns) (default: false)
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -16,7 +16,6 @@ package pipeline
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -28,7 +27,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteRelated: false}
+	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteRelated: false, DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete Pipelines with names 'foo' and 'bar' in namespace 'quux'
 
@@ -44,7 +43,7 @@ or
 		Aliases:      []string{"rm"},
 		Short:        "Delete pipelines in a namespace",
 		Example:      eg,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -54,10 +53,6 @@ or
 				In:  cmd.InOrStdin(),
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
-			}
-
-			if opts.DeleteRelated {
-				log.Println("WARNING: The behavior of --all will change in v0.9.0, and the current --all flag will be given a new name.")
 			}
 
 			if err := validate.NamespaceExists(p); err != nil {
@@ -73,7 +68,8 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteRelated, "all", "a", false, "Whether to also delete related resources (pipelineruns) (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteRelated, "prs", "", false, "Whether to delete pipeline(s) and related resources (pipelineruns) (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all Pipelines in a namespace (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 	return c
@@ -87,14 +83,29 @@ func deletePipelines(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, p
 	d := deleter.New("Pipeline", func(pipelineName string) error {
 		return cs.Tekton.TektonV1alpha1().Pipelines(p.Namespace()).Delete(pipelineName, &metav1.DeleteOptions{})
 	})
-	d.WithRelated("PipelineRun", pipelineRunLister(p, cs), func(pipelineRunName string) error {
-		return cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Delete(pipelineRunName, &metav1.DeleteOptions{})
-	})
-	deletedPipelineNames := d.Delete(s, pNames)
-	if opts.DeleteRelated {
+	switch {
+	case opts.DeleteAllNs:
+		pNames, err = allPipelineNames(p, cs)
+		if err != nil {
+			return err
+		}
+		d.Delete(s, pNames)
+	case opts.DeleteRelated:
+		d.WithRelated("PipelineRun", pipelineRunLister(p, cs), func(pipelineRunName string) error {
+			return cs.Tekton.TektonV1alpha1().PipelineRuns(p.Namespace()).Delete(pipelineRunName, &metav1.DeleteOptions{})
+		})
+		deletedPipelineNames := d.Delete(s, pNames)
 		d.DeleteRelated(s, deletedPipelineNames)
+	default:
+		d.Delete(s, pNames)
 	}
-	d.PrintSuccesses(s)
+	if !opts.DeleteAllNs {
+		d.PrintSuccesses(s)
+	} else if opts.DeleteAllNs {
+		if d.Errors() == nil {
+			fmt.Fprintf(s.Out, "All Pipelines deleted in namespace %q\n", p.Namespace())
+		}
+	}
 	return d.Errors()
 }
 
@@ -113,4 +124,16 @@ func pipelineRunLister(p cli.Params, cs *cli.Clients) func(string) ([]string, er
 		}
 		return names, nil
 	}
+}
+
+func allPipelineNames(p cli.Params, cs *cli.Clients) ([]string, error) {
+	ps, err := cs.Tekton.TektonV1alpha1().Pipelines(p.Namespace()).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, p := range ps.Items {
+		names = append(names, p.Name)
+	}
+	return names, nil
 }

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -38,8 +38,9 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	if o.Keep > 0 && !(o.DeleteAllNs || o.DeleteAll) {
 		return fmt.Errorf("must use --all flag with --keep")
 	}
+
 	// make sure no resource names are provided when using --all flag
-	if len(resourceNames) > 0 && (o.DeleteAllNs || o.DeleteAll) {
+	if len(resourceNames) > 0 && (o.DeleteAllNs || o.DeleteAll) || o.DeleteAllNs && o.DeleteRelated {
 		return fmt.Errorf("--all flag should not have any arguments or flags specified with it")
 	}
 

--- a/pkg/options/delete_test.go
+++ b/pkg/options/delete_test.go
@@ -118,6 +118,13 @@ func TestDeleteOptions(t *testing.T) {
 			want:           "--all flag should not have any arguments or flags specified with it",
 		},
 		{
+			name:           "Error when DeleteRelated with DeleteAllNs",
+			opt:            &DeleteOptions{DeleteAllNs: true, DeleteRelated: true},
+			resourcesNames: []string{"test1"},
+			wantError:      true,
+			want:           "--all flag should not have any arguments or flags specified with it",
+		},
+		{
 			name:           "Specify DeleteAll option",
 			opt:            &DeleteOptions{DeleteAll: true},
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},


### PR DESCRIPTION
Closes #634 

This pull request changes the behavior of `--all` to delete all pipelines/tasks in a namespace. It converts the name of the original `--all` flags to `--prs` and `--trs` (but I can easily change this to something else). The thought behind having the flag be named `--prs`/`--trs` is because it also deletes pipelineruns/taskruns associated with a pipeline/task that is also going to be deleted.

This pull request also removes the warning flag about the `--all` flag behavior/name changing in v0.9.0. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Convert --all to --prs and --trs for tkn pipeline/task delete so --all can be used to delete all pipelines/tasks in a namespace
```
