### PR TITLE
Change timeout to string for tkn task start

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -40,7 +40,7 @@ like cat,foo,bar
       --prefix-name string       specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the task
-      --timeout int              timeout for taskrun in seconds (default 3600)
+      --timeout string           timeout for taskrun (default "1h")
       --use-taskrun string       specify a taskrun name to use its values to re-run the taskrun
 ```
 

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -68,8 +68,8 @@ Start tasks
     show logs right after starting the task
 
 .PP
-\fB\-\-timeout\fP=3600
-    timeout for taskrun in seconds
+\fB\-\-timeout\fP="1h"
+    timeout for taskrun
 
 .PP
 \fB\-\-use\-taskrun\fP=""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
@@ -47,6 +47,5 @@ spec:
       image: gcr.io/kaniko-project/executor:v0.14.0
       name: build-and-push
       resources: {}
-  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -18,6 +18,5 @@ spec:
   serviceAccountName: svc1
   taskRef:
     name: task-1
-  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -30,8 +30,7 @@
 		"serviceAccountName": "svc1",
 		"taskRef": {
 			"name": "task-1"
-		},
-		"timeout": "1h0m0s"
+		}
 	},
 	"status": {
 		"podName": ""


### PR DESCRIPTION
Close #730

this change timeout type from `int64` to string for tkn task start
command which enables user to give input as string like `1h2m3s`
default value set is `1h`

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
