### PR TITLE
Use text/template Instead of html/template for PipelineRun Describe

### DIFF
--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
@@ -10,7 +10,7 @@ STARTED          DURATION    STATUS
 
 Message
 
-PipelineRun &#34;pipeline-run&#34; was cancelled
+PipelineRun "pipeline-run" was cancelled
 
 Resources
 

--- a/pkg/pipelinerun/description/description.go
+++ b/pkg/pipelinerun/description/description.go
@@ -2,9 +2,9 @@ package description
 
 import (
 	"fmt"
-	"html/template"
 	"sort"
 	"text/tabwriter"
+	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -168,13 +168,13 @@ func hasFailed(pr *v1alpha1.PipelineRun) string {
 	}
 
 	if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
-		for _, taskrunStatus := range pr.Status.TaskRuns {
-			if len(taskrunStatus.Status.Conditions) == 0 {
+		for _, tr := range pr.Status.TaskRuns {
+			if len(tr.Status.Conditions) == 0 {
 				continue
 			}
-			if taskrunStatus.Status.Conditions[0].Status == corev1.ConditionFalse {
+			if tr.Status.Conditions[0].Status == corev1.ConditionFalse {
 				return fmt.Sprintf("%s (%s)", pr.Status.Conditions[0].Message,
-					taskrunStatus.Status.Conditions[0].Message)
+					tr.Status.Conditions[0].Message)
 			}
 		}
 		return pr.Status.Conditions[0].Message


### PR DESCRIPTION
Closes #776 

We should be using `text/template` not `html/template` to avoid html codes showing up in describe commands. An example of this issue is actually showing up in one of our tests, which I have changed backed to text.

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Correct message output for tkn pipelinerun describe
```
