### PR TITLE
Add Sidecar Status to tkn taskrun describe

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tektoncd/pipeline v0.10.1 h1:pDsYK2b70o/Ze/CE1nisELwKVVE54FxwyfLznsW1JiE=
 github.com/tektoncd/pipeline v0.11.0-rc1 h1:NBX/PE9K6EkCyPg8psqErj8Lv2dwBsfgmliEMVzTUhQ=
 github.com/tektoncd/pipeline v0.11.0-rc1/go.mod h1:nXK3nCiNJQ/LDbRsJvo+3LU3MJIthNIomRI3xogsJqc=
 github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2 h1:BksmpUwtap3THXJ8Z4KGcotsvpRdFQKySjDHgtc22lA=

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
@@ -34,4 +34,6 @@ Steps
 
 Sidecars
 
-No sidecars
+ NAME       STATUS
+ sidecar1   Error
+ sidecar2   ---

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
@@ -34,5 +34,5 @@ Steps
 
 Sidecars
 
- NAME
- sidecar1
+ NAME       STATUS
+ sidecar1   PodInitializing

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
@@ -34,6 +34,6 @@ Steps
 
 Sidecars
 
- NAME
- sidecar1
- sidecar2
+ NAME       STATUS
+ sidecar1   Running
+ sidecar2   Running

--- a/pkg/taskrun/description/taskrun_description.go
+++ b/pkg/taskrun/description/taskrun_description.go
@@ -102,9 +102,10 @@ No steps
 {{- $l := len $sidecars }}{{ if eq $l 0 }}
 No sidecars
 {{- else }}
- NAME
+ NAME	STATUS
 {{- range $sidecar := $sidecars }}
- {{decorate "bullet" $sidecar.Name }}
+{{- $reason := sidecarReasonExists $sidecar }}
+ {{decorate "bullet" $sidecar.Name }}	{{ $reason }}
 {{- end }}
 {{- end }}
 `
@@ -178,6 +179,7 @@ func PrintTaskRunDescription(s *cli.Stream, trName string, p cli.Params) error {
 		"taskRefExists":         validate.TaskRefExists,
 		"taskResourceRefExists": validate.TaskResourceRefExists,
 		"stepReasonExists":      validate.StepReasonExists,
+		"sidecarReasonExists":   validate.SidecarReasonExists,
 		"decorate":              formatted.DecorateAttr,
 		"sortStepStates":        sortStepStatesByStartTime,
 		"getTimeout":            getTimeoutValue,

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -107,3 +107,22 @@ func StepReasonExists(state v1alpha1.StepState) string {
 
 	return formatted.ColorStatus(state.Waiting.Reason)
 }
+
+// Check if sidecar is in waiting, running, or terminated state by checking SidecarState of the sidecar.
+func SidecarReasonExists(state v1alpha1.SidecarState) string {
+
+	if state.Waiting == nil {
+
+		if state.Running != nil {
+			return formatted.ColorStatus("Running")
+		}
+
+		if state.Terminated != nil {
+			return formatted.ColorStatus(state.Terminated.Reason)
+		}
+
+		return formatted.ColorStatus(pendingState)
+	}
+
+	return formatted.ColorStatus(state.Waiting.Reason)
+}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -187,3 +187,51 @@ func TestStepReasonExists_Waiting_Present(t *testing.T) {
 	output := StepReasonExists(state)
 	test.AssertOutput(t, "PodInitializing", output)
 }
+
+func TestSidecarReasonExists_Terminated_Not_Present(t *testing.T) {
+	state := v1alpha1.SidecarState{}
+
+	output := SidecarReasonExists(state)
+	test.AssertOutput(t, "---", output)
+}
+
+func TestSidecarReasonExists_Terminated_Present(t *testing.T) {
+	state := v1alpha1.SidecarState{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Completed",
+			},
+		},
+	}
+
+	output := SidecarReasonExists(state)
+	test.AssertOutput(t, "Completed", output)
+}
+
+func TestSidecarReasonExists_Running_Present(t *testing.T) {
+	state := v1alpha1.SidecarState{
+		ContainerState: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{
+				StartedAt: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+		},
+	}
+
+	output := SidecarReasonExists(state)
+	test.AssertOutput(t, "Running", output)
+}
+
+func TestSidecarReasonExists_Waiting_Present(t *testing.T) {
+	state := v1alpha1.SidecarState{
+		ContainerState: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{
+				Reason: "PodInitializing",
+			},
+		},
+	}
+
+	output := SidecarReasonExists(state)
+	test.AssertOutput(t, "PodInitializing", output)
+}


### PR DESCRIPTION
Closes #655 

This pull request adds sidecar status information to `tkn taskrun decribe`. It also makes use of sidecar features added to test builder for pipeline v0.11.0-rc. 

As of now, I do am not sure if there is a particular sorting pattern that makes sense for sidecars so I have decided to not sort the statuses in any way at this point. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add sidecar status to tkn taskrun describe 
```
