### PR TITLE
Add flag to list pipelineruns and taskruns from all namespaces

### DIFF
--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -28,6 +28,7 @@ List all PipelineRuns in a namespace 'foo':
 ### Options
 
 ```
+  -A, --all-namespaces                list pipelineruns from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -28,6 +28,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 ### Options
 
 ```
+  -A, --all-namespaces                list taskruns from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -20,6 +20,10 @@ Lists pipelineruns in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
+    list pipelineruns from all namespaces
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -20,6 +20,10 @@ Lists TaskRuns in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
+    list taskruns from all namespaces
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -87,6 +87,17 @@ func TestListPipelineRuns(t *testing.T) {
 		),
 	}
 
+	prsMultipleNs := []*v1alpha1.PipelineRun{
+		tb.PipelineRun("pr4-1", "namespace-tout",
+			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
+			tb.PipelineRunStatus(),
+		),
+		tb.PipelineRun("pr4-2", "namespace-lacher",
+			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
+			tb.PipelineRunStatus(),
+		),
+	}
+
 	ns := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -186,6 +197,12 @@ func TestListPipelineRuns(t *testing.T) {
 			args:      []string{"list", "--reverse", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
+		{
+			name:      "print pipelineruns in all namespaces",
+			command:   command(t, prsMultipleNs, clock.Now(), ns),
+			args:      []string{"list", "--all-namespaces"},
+			wantError: false,
+		},
 	}
 
 	for _, td := range tests {
@@ -218,7 +235,7 @@ func TestListPipeline_empty(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	test.AssertOutput(t, emptyMsg+"\n", output)
+	test.AssertOutput(t, "No PipelineRuns found\n", output)
 }
 
 func command(t *testing.T, prs []*v1alpha1.PipelineRun, now time.Time, ns []*corev1.Namespace) *cobra.Command {

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-all_in_namespace.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-all_in_namespace.golden
@@ -1,6 +1,6 @@
-NAME    STARTED          DURATION   STATUS               
-pr0-1   ---              ---        ---                  
-pr3-1   ---              ---        ---                  
-pr1-1   59 minutes ago   1 minute   Succeeded            
-pr2-2   2 hours ago      1 minute   Failed               
-pr2-1   3 hours ago      ---        Succeeded(Running)   
+NAME    STARTED          DURATION   STATUS
+pr0-1   ---              ---        ---
+pr3-1   ---              ---        ---
+pr1-1   59 minutes ago   1 minute   Succeeded
+pr2-2   2 hours ago      1 minute   Failed
+pr2-1   3 hours ago      ---        Succeeded(Running)

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-by_pipeline_name.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-by_pipeline_name.golden
@@ -1,2 +1,2 @@
-NAME    STARTED          DURATION   STATUS      
-pr1-1   59 minutes ago   1 minute   Succeeded   
+NAME    STARTED          DURATION   STATUS
+pr1-1   59 minutes ago   1 minute   Succeeded

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-filter_pipelineruns_by_label.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-filter_pipelineruns_by_label.golden
@@ -1,2 +1,2 @@
-NAME    STARTED   DURATION   STATUS   
-pr3-1   ---       ---        ---      
+NAME    STARTED   DURATION   STATUS
+pr3-1   ---       ---        ---

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-filter_pipelineruns_by_label_with_in_query.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-filter_pipelineruns_by_label_with_in_query.golden
@@ -1,3 +1,3 @@
-NAME    STARTED       DURATION   STATUS   
-pr3-1   ---           ---        ---      
-pr2-2   2 hours ago   1 minute   Failed   
+NAME    STARTED       DURATION   STATUS
+pr3-1   ---           ---        ---
+pr2-2   2 hours ago   1 minute   Failed

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-limit_pipelineruns_greater_than_maximum_case.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-limit_pipelineruns_greater_than_maximum_case.golden
@@ -1,6 +1,6 @@
-NAME    STARTED          DURATION   STATUS               
-pr0-1   ---              ---        ---                  
-pr3-1   ---              ---        ---                  
-pr1-1   59 minutes ago   1 minute   Succeeded            
-pr2-2   2 hours ago      1 minute   Failed               
-pr2-1   3 hours ago      ---        Succeeded(Running)   
+NAME    STARTED          DURATION   STATUS
+pr0-1   ---              ---        ---
+pr3-1   ---              ---        ---
+pr1-1   59 minutes ago   1 minute   Succeeded
+pr2-2   2 hours ago      1 minute   Failed
+pr2-1   3 hours ago      ---        Succeeded(Running)

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-limit_pipelineruns_returned_to_1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-limit_pipelineruns_returned_to_1.golden
@@ -1,2 +1,2 @@
-NAME    STARTED   DURATION   STATUS   
-pr0-1   ---       ---        ---      
+NAME    STARTED   DURATION   STATUS
+pr0-1   ---       ---        ---

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-print_in_reverse.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-print_in_reverse.golden
@@ -1,6 +1,6 @@
-NAME    STARTED          DURATION   STATUS               
-pr2-1   3 hours ago      ---        Succeeded(Running)   
-pr2-2   2 hours ago      1 minute   Failed               
-pr1-1   59 minutes ago   1 minute   Succeeded            
-pr3-1   ---              ---        ---                  
-pr0-1   ---              ---        ---                  
+NAME    STARTED          DURATION   STATUS
+pr2-1   3 hours ago      ---        Succeeded(Running)
+pr2-2   2 hours ago      1 minute   Failed
+pr1-1   59 minutes ago   1 minute   Succeeded
+pr3-1   ---              ---        ---
+pr0-1   ---              ---        ---

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-print_pipelineruns_in_all_namespaces.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-print_pipelineruns_in_all_namespaces.golden
@@ -1,0 +1,3 @@
+NAMESPACE          NAME    STARTED   DURATION   STATUS
+namespace-lacher   pr4-2   ---       ---        ---
+namespace-tout     pr4-1   ---       ---        ---

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -98,6 +98,29 @@ func TestListTaskRuns(t *testing.T) {
 		),
 	}
 
+	trsMultipleNs := []*v1alpha1.TaskRun{
+		tb.TaskRun("tr4-1", "tout",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		tb.TaskRun("tr4-2", "lacher",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+	}
+
 	ns := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -204,6 +227,12 @@ func TestListTaskRuns(t *testing.T) {
 			name:      "print in reverse with output flag",
 			command:   command(t, trs, now, ns),
 			args:      []string{"list", "--reverse", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
+			wantError: false,
+		},
+		{
+			name:      "print taskrunsruns in all namespaces",
+			command:   command(t, trsMultipleNs, now, ns),
+			args:      []string{"list", "--all-namespaces", "-n", "foo"},
 			wantError: false,
 		},
 	}

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-all_in_namespace.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-all_in_namespace.golden
@@ -1,6 +1,6 @@
-NAME    STARTED          DURATION   STATUS      
-tr0-1   ---              ---        Succeeded   
-tr3-1   ---              ---        Failed      
-tr2-2   59 minutes ago   1 minute   Failed      
-tr1-1   1 hour ago       1 minute   Succeeded   
-tr2-1   1 hour ago       ---        Running     
+NAME    STARTED          DURATION   STATUS
+tr0-1   ---              ---        Succeeded
+tr3-1   ---              ---        Failed
+tr2-2   59 minutes ago   1 minute   Failed
+tr1-1   1 hour ago       1 minute   Succeeded
+tr2-1   1 hour ago       ---        Running

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-by_Task_name.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-by_Task_name.golden
@@ -1,2 +1,2 @@
-NAME    STARTED      DURATION   STATUS      
-tr1-1   1 hour ago   1 minute   Succeeded   
+NAME    STARTED      DURATION   STATUS
+tr1-1   1 hour ago   1 minute   Succeeded

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label.golden
@@ -1,2 +1,2 @@
-NAME    STARTED   DURATION   STATUS   
-tr3-1   ---       ---        Failed   
+NAME    STARTED   DURATION   STATUS
+tr3-1   ---       ---        Failed

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label_with_in_query.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label_with_in_query.golden
@@ -1,3 +1,3 @@
-NAME    STARTED          DURATION   STATUS   
-tr3-1   ---              ---        Failed   
-tr2-2   59 minutes ago   1 minute   Failed   
+NAME    STARTED          DURATION   STATUS
+tr3-1   ---              ---        Failed
+tr2-2   59 minutes ago   1 minute   Failed

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_greater_than_maximum_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_greater_than_maximum_case.golden
@@ -1,6 +1,6 @@
-NAME    STARTED          DURATION   STATUS      
-tr0-1   ---              ---        Succeeded   
-tr3-1   ---              ---        Failed      
-tr2-2   59 minutes ago   1 minute   Failed      
-tr1-1   1 hour ago       1 minute   Succeeded   
-tr2-1   1 hour ago       ---        Running     
+NAME    STARTED          DURATION   STATUS
+tr0-1   ---              ---        Succeeded
+tr3-1   ---              ---        Failed
+tr2-2   59 minutes ago   1 minute   Failed
+tr1-1   1 hour ago       1 minute   Succeeded
+tr2-1   1 hour ago       ---        Running

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_returned_to_1.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_returned_to_1.golden
@@ -1,2 +1,2 @@
-NAME    STARTED   DURATION   STATUS      
-tr0-1   ---       ---        Succeeded   
+NAME    STARTED   DURATION   STATUS
+tr0-1   ---       ---        Succeeded

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_in_reverse.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_in_reverse.golden
@@ -1,6 +1,6 @@
-NAME    STARTED          DURATION   STATUS      
-tr2-1   1 hour ago       ---        Running     
-tr1-1   1 hour ago       1 minute   Succeeded   
-tr2-2   59 minutes ago   1 minute   Failed      
-tr3-1   ---              ---        Failed      
-tr0-1   ---              ---        Succeeded   
+NAME    STARTED          DURATION   STATUS
+tr2-1   1 hour ago       ---        Running
+tr1-1   1 hour ago       1 minute   Succeeded
+tr2-2   59 minutes ago   1 minute   Failed
+tr3-1   ---              ---        Failed
+tr0-1   ---              ---        Succeeded

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_taskrunsruns_in_all_namespaces.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_taskrunsruns_in_all_namespaces.golden
@@ -1,0 +1,3 @@
+NAMESPACE   NAME    STARTED   DURATION   STATUS
+lacher      tr4-2   ---       ---        Succeeded
+tout        tr4-1   ---       ---        Succeeded

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_no_condition.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_no_condition.golden
@@ -1,2 +1,2 @@
-NAME    STARTED      DURATION   STATUS   
-tr1-1   1 hour ago   1 minute   ---      
+NAME    STARTED      DURATION   STATUS
+tr1-1   1 hour ago   1 minute   ---

--- a/pkg/pipelinerun/sort/by_namespace.go
+++ b/pkg/pipelinerun/sort/by_namespace.go
@@ -1,0 +1,48 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"sort"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+func SortByNamespace(prs []v1alpha1.PipelineRun) {
+	sort.Sort(byNamespace(prs))
+}
+
+type byNamespace []v1alpha1.PipelineRun
+
+func (prs byNamespace) compareNamespace(ins, jns string) (lt, eq bool) {
+	lt, eq = ins < jns, ins == jns
+	return lt, eq
+}
+
+func (prs byNamespace) Len() int      { return len(prs) }
+func (prs byNamespace) Swap(i, j int) { prs[i], prs[j] = prs[j], prs[i] }
+func (prs byNamespace) Less(i, j int) bool {
+	var lt, eq bool
+	if lt, eq = prs.compareNamespace(prs[i].Namespace, prs[j].Namespace); eq {
+		if prs[j].Status.StartTime == nil {
+			return false
+		}
+		if prs[i].Status.StartTime == nil {
+			return true
+		}
+		return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
+	}
+	return lt
+}

--- a/pkg/pipelinerun/sort/by_namespace_test.go
+++ b/pkg/pipelinerun/sort/by_namespace_test.go
@@ -1,0 +1,177 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_PipelineRunsByNamespace(t *testing.T) {
+	pr1 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "abc",
+			Name:      "pr0-1",
+		},
+	}
+
+	pr2 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "def",
+			Name:      "pr1-1",
+		},
+	}
+
+	pr3 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ghi",
+			Name:      "pr2-1",
+		},
+	}
+
+	prs := []v1alpha1.PipelineRun{
+		pr2,
+		pr3,
+		pr1,
+	}
+
+	SortByNamespace(prs)
+
+	element1 := prs[0].Name
+	if element1 != "pr0-1" {
+		t.Errorf("SortPipelineRunsByNamespace should be pr0-1 but returned: %s", element1)
+	}
+
+	element2 := prs[1].Name
+	if element2 != "pr1-1" {
+		t.Errorf("SortPipelineRunsByNamespace should be pr1-1 but returned: %s", element2)
+	}
+
+	element3 := prs[2].Name
+	if element3 != "pr2-1" {
+		t.Errorf("SortPipelineRunsByNamespace should be pr2-1 but returned: %s", element3)
+	}
+}
+
+func Test_PipelineRunsByNamespaceWithStartTime(t *testing.T) {
+
+	clock := clockwork.NewFakeClock()
+
+	pr00Started := clock.Now().Add(10 * time.Second)
+	pr01Started := clock.Now().Add(-1 * time.Hour)
+	pr10Started := clock.Now().Add(10 * time.Second)
+	pr11Started := clock.Now().Add(-1 * time.Hour)
+	pr20Started := clock.Now().Add(10 * time.Second)
+	pr21Started := clock.Now().Add(-1 * time.Hour)
+
+	pr00 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "abc",
+			Name:      "pr0-0",
+		},
+	}
+
+	pr00.Status.StartTime = &metav1.Time{Time: pr00Started}
+
+	pr01 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "abc",
+			Name:      "pr0-1",
+		},
+	}
+
+	pr01.Status.StartTime = &metav1.Time{Time: pr01Started}
+
+	pr10 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "def",
+			Name:      "pr1-0",
+		},
+	}
+
+	pr10.Status.StartTime = &metav1.Time{Time: pr10Started}
+
+	pr11 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "def",
+			Name:      "pr1-1",
+		},
+	}
+
+	pr11.Status.StartTime = &metav1.Time{Time: pr11Started}
+
+	pr20 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ghi",
+			Name:      "pr2-0",
+		},
+	}
+
+	pr20.Status.StartTime = &metav1.Time{Time: pr20Started}
+
+	pr21 := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ghi",
+			Name:      "pr2-1",
+		},
+	}
+
+	pr21.Status.StartTime = &metav1.Time{Time: pr21Started}
+
+	prs := []v1alpha1.PipelineRun{
+		pr11,
+		pr21,
+		pr01,
+		pr10,
+		pr20,
+		pr00,
+	}
+
+	SortByNamespace(prs)
+
+	element1 := prs[0].Name
+	if element1 != "pr0-0" {
+		t.Errorf("SortPipelineRunsByNamespaceWithStartTime should be pr0-0 but returned: %s", element1)
+	}
+
+	element2 := prs[1].Name
+	if element2 != "pr0-1" {
+		t.Errorf("SortPipelineRunsByNamespaceWithStartTime should be pr0-1 but returned: %s", element2)
+	}
+
+	element3 := prs[2].Name
+	if element3 != "pr1-0" {
+		t.Errorf("SortPipelineRunsByNamespaceWithStartTime should be pr1-0 but returned: %s", element3)
+	}
+
+	element4 := prs[3].Name
+	if element4 != "pr1-1" {
+		t.Errorf("SortPipelineRunsByNamespaceWithStartTime should be pr1-1 but returned: %s", element4)
+	}
+
+	element5 := prs[4].Name
+	if element5 != "pr2-0" {
+		t.Errorf("SortPipelineRunsByNamespaceWithStartTime should be pr2-0 but returned: %s", element5)
+	}
+
+	element6 := prs[5].Name
+	if element6 != "pr2-1" {
+		t.Errorf("SortPipelineRunsByNamespaceWithStartTime should be pr2-1 but returned: %s", element6)
+	}
+}

--- a/pkg/taskrun/sort/by_namespace.go
+++ b/pkg/taskrun/sort/by_namespace.go
@@ -1,0 +1,33 @@
+package taskrun
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"sort"
+)
+
+func SortByNamespace(trs []v1alpha1.TaskRun) {
+	sort.Sort(byNamespace(trs))
+}
+
+type byNamespace []v1alpha1.TaskRun
+
+func (prs byNamespace) compareNamespace(ins, jns string) (lt, eq bool) {
+	lt, eq = ins < jns, ins == jns
+	return lt, eq
+}
+
+func (trs byNamespace) Len() int      { return len(trs) }
+func (trs byNamespace) Swap(i, j int) { trs[i], trs[j] = trs[j], trs[i] }
+func (trs byNamespace) Less(i, j int) bool {
+	var lt, eq bool
+	if lt, eq = trs.compareNamespace(trs[i].Namespace, trs[j].Namespace); eq {
+		if trs[j].Status.StartTime == nil {
+			return false
+		}
+		if trs[i].Status.StartTime == nil {
+			return true
+		}
+		return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
+	}
+	return lt
+}

--- a/pkg/taskrun/sort/by_namespace_test.go
+++ b/pkg/taskrun/sort/by_namespace_test.go
@@ -1,0 +1,162 @@
+package taskrun
+
+import (
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func Test_TaskRunsByNamespace(t *testing.T) {
+	tr1 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "abc",
+			Name:      "tr0-1",
+		},
+	}
+
+	tr2 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "def",
+			Name:      "tr1-1",
+		},
+	}
+
+	tr3 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ghi",
+			Name:      "tr2-1",
+		},
+	}
+
+	trs := []v1alpha1.TaskRun{
+		tr2,
+		tr3,
+		tr1,
+	}
+
+	SortByNamespace(trs)
+
+	element1 := trs[0].Name
+	if element1 != "tr0-1" {
+		t.Errorf("SortTaskRunsByNamespace should be tr0-1 but returned: %s", element1)
+	}
+
+	element2 := trs[1].Name
+	if element2 != "tr1-1" {
+		t.Errorf("SortTaskRunsByNamespace should be tr1-1 but returned: %s", element2)
+	}
+
+	element3 := trs[2].Name
+	if element3 != "tr2-1" {
+		t.Errorf("SortTaskRunsByNamespace should be tr2-1 but returned: %s", element3)
+	}
+}
+
+func Test_PipelineRunsByNamespaceWithStartTime(t *testing.T) {
+
+	clock := clockwork.NewFakeClock()
+
+	tr00Started := clock.Now().Add(10 * time.Second)
+	tr01Started := clock.Now().Add(-1 * time.Hour)
+	tr10Started := clock.Now().Add(10 * time.Second)
+	tr11Started := clock.Now().Add(-1 * time.Hour)
+	tr20Started := clock.Now().Add(10 * time.Second)
+	tr21Started := clock.Now().Add(-1 * time.Hour)
+
+	tr00 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "abc",
+			Name:      "tr0-0",
+		},
+	}
+
+	tr00.Status.StartTime = &metav1.Time{Time: tr00Started}
+
+	tr01 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "abc",
+			Name:      "tr0-1",
+		},
+	}
+
+	tr01.Status.StartTime = &metav1.Time{Time: tr01Started}
+
+	tr10 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "def",
+			Name:      "tr1-0",
+		},
+	}
+
+	tr10.Status.StartTime = &metav1.Time{Time: tr10Started}
+
+	tr11 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "def",
+			Name:      "tr1-1",
+		},
+	}
+
+	tr11.Status.StartTime = &metav1.Time{Time: tr11Started}
+
+	tr20 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ghi",
+			Name:      "tr2-0",
+		},
+	}
+
+	tr20.Status.StartTime = &metav1.Time{Time: tr20Started}
+
+	tr21 := v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ghi",
+			Name:      "tr2-1",
+		},
+	}
+
+	tr21.Status.StartTime = &metav1.Time{Time: tr21Started}
+
+	trs := []v1alpha1.TaskRun{
+		tr11,
+		tr21,
+		tr01,
+		tr10,
+		tr20,
+		tr00,
+	}
+
+	SortByNamespace(trs)
+
+	element1 := trs[0].Name
+	if element1 != "tr0-0" {
+		t.Errorf("SortTaskRunsByNamespaceWithStartTime should be tr0-0 but returned: %s", element1)
+	}
+
+	element2 := trs[1].Name
+	if element2 != "tr0-1" {
+		t.Errorf("SortTaskRunsByNamespaceWithStartTime should be tr0-1 but returned: %s", element2)
+	}
+
+	element3 := trs[2].Name
+	if element3 != "tr1-0" {
+		t.Errorf("SortTaskRunsByNamespaceWithStartTime should be tr1-0 but returned: %s", element3)
+	}
+
+	element4 := trs[3].Name
+	if element4 != "tr1-1" {
+		t.Errorf("SortTaskRunsByNamespaceWithStartTime should be tr1-1 but returned: %s", element4)
+	}
+
+	element5 := trs[4].Name
+	if element5 != "tr2-0" {
+		t.Errorf("SortTaskRunsByNamespaceWithStartTime should be tr2-0 but returned: %s", element5)
+	}
+
+	element6 := trs[5].Name
+	if element6 != "tr2-1" {
+		t.Errorf("SortTaskRunsByNamespaceWithStartTime should be tr2-1 but returned: %s", element6)
+	}
+}

--- a/test/e2e/pipeline_e2e_test.go
+++ b/test/e2e/pipeline_e2e_test.go
@@ -222,7 +222,7 @@ Waiting for logs to be available...
 
 		res := icmd.RunCmd(run("taskrun", "list", "-n", namespace))
 
-		expected := ListAllTaskRunsOutput(t, c, map[int]interface{}{
+		expected := ListAllTaskRunsOutput(t, c, false, map[int]interface{}{
 			0: &TaskRunData{
 				Name:   "output-pipeline-run-",
 				Status: "Succeeded",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

partly fixes https://github.com/tektoncd/cli/issues/785

Add `--all-namespaces` flag to `list` subcommands for TaskRun and PipelineRun.
This allows the user to list taskruns and pipelineruns in all namespaces respectively.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
