### PR TITLE
Change clusterTask timeout from int to string and remove -t shorthand

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -39,7 +39,7 @@ like cat,foo,bar
   -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the clustertask
-  -t, --timeout int              timeout for taskrun in seconds (default 3600)
+      --timeout string           timeout for taskrun (default "1h")
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -60,8 +60,8 @@ Start clustertasks
     show logs right after starting the clustertask
 
 .PP
-\fB\-t\fP, \fB\-\-timeout\fP=3600
-    timeout for taskrun in seconds
+\fB\-\-timeout\fP="1h"
+    timeout for taskrun
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 	"time"
@@ -111,10 +110,6 @@ like cat,foo,bar
 		Example:      eg,
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if opt.TimeOut != 3600 {
-				log.Println("WARNING: The --timeout flag will no longer be specified in seconds in v1.0.0. Learn more here: https://github.com/tektoncd/cli/issues/784")
-				log.Println("WARNING: The -t shortand for --timeout will no longer be available in v1.0.0.")
-			}
 			if opt.DryRun {
 				format := strings.ToLower(opt.Output)
 				if format != "" && format != "json" && format != "yaml" {


### PR DESCRIPTION
Signed-off-by: kadern0 <kaderno@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Changed clusterTask timeout from int64 to string and removed the shorthand `-t` option.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

