### PR TITLE
Change Status Check for PipelineRun and TaskRun Cancel for Color Formatting

### DIFF
--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -25,10 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	succeeded   = "Succeeded"
-	failed      = "Failed"
-	prCancelled = "Cancelled(PipelineRunCancelled)"
+var (
+	succeeded   = formatted.ColorStatus("Succeeded")
+	failed      = formatted.ColorStatus("Failed")
+	prCancelled = formatted.ColorStatus("Cancelled") + "(PipelineRunCancelled)"
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {

--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -25,10 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	succeeded     = "Succeeded"
-	failed        = "Failed"
-	taskCancelled = "Cancelled(TaskRunCancelled)"
+var (
+	succeeded        = formatted.ColorStatus("Succeeded")
+	failed           = formatted.ColorStatus("Failed")
+	taskrunCancelled = formatted.ColorStatus("Cancelled") + "(TaskRunCancelled)"
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
@@ -76,7 +76,7 @@ func cancelTaskRun(p cli.Params, s *cli.Stream, trName string) error {
 	}
 
 	taskrunCond := formatted.Condition(tr.Status.Conditions)
-	if taskrunCond == succeeded || taskrunCond == failed || taskrunCond == taskCancelled {
+	if taskrunCond == succeeded || taskrunCond == failed || taskrunCond == taskrunCancelled {
 		return fmt.Errorf("failed to cancel taskrun %s: taskrun has already finished execution", trName)
 	}
 

--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -68,7 +68,6 @@ func Condition(c v1beta1.Conditions) string {
 	cstatus := ColorStatus(status)
 
 	if c[0].Reason != "" && c[0].Reason != status {
-
 		if c[0].Reason == "PipelineRunCancelled" || c[0].Reason == "TaskRunCancelled" {
 			status = ColorStatus("Cancelled") + "(" + c[0].Reason + ")"
 		} else if c[0].Reason != status {


### PR DESCRIPTION
Closes #794 

Since color was introduced to statuses for list and describe commands, it has broken an error message used for pipelinerun cancel and taskrun cancel. This pull request adds the color formatting to this check to see if pipelineruns/taskruns have already been cancelled. 

It also adds tests for cases when PipelineRuns/TaskRuns have been cancelled. Of curiosity to me when adding these cases is whether adding `TaskRunCancelled` or `PipelineRunCancelled` adds much information to the status? Should the CLI just use `Cancelled` like pipelines?

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Fix status check for cancelling pipelineruns/taskruns to display error message if already finished
```
