### PR TITLE
Change PipelineRuns to TaskRuns for tkn tr delete --keep Description

### DIFF
--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -32,7 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-      --keep int                      Keep n least recent number of pipelineruns when deleting alls
+      --keep int                      Keep n least recent number of taskruns when using --all with delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -t, --task string                   The name of a task whose taskruns should be deleted (does not delete the task)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -37,7 +37,7 @@ Delete taskruns in a namespace
 
 .PP
 \fB\-\-keep\fP=0
-    Keep n least recent number of pipelineruns when deleting alls
+    Keep n least recent number of taskruns when using \-\-all with delete
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -71,7 +71,7 @@ or
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().StringVarP(&opts.ParentResourceName, "task", "t", "", "The name of a task whose taskruns should be deleted (does not delete the task)")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all taskruns in a namespace (default: false)")
-	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n least recent number of pipelineruns when deleting alls")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n least recent number of taskruns when using --all with delete")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_taskrun")
 	return c
 }


### PR DESCRIPTION
Correcting typo in `tkn tr delete --keep` description: `pipelineruns` -> `taskruns`. Also changing wording to keep consistent with `--keep` description for pipelineruns. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Change pipelineruns -> taskruns in tkn taskrun delete --keep description 
```
