### PR TITLE
Add feature of getting condition pod log.

### DIFF
--- a/pkg/taskrun/taskrun.go
+++ b/pkg/taskrun/taskrun.go
@@ -61,11 +61,21 @@ func SortTasksBySpecOrder(pipelineTasks []v1alpha1.PipelineTask, pipelinesTaskRu
 	trNames := map[string]string{}
 
 	for name, t := range pipelinesTaskRuns {
+		// making mapping of (condtion name : pod name) if task has conditions.
+		for podName, cond := range t.ConditionChecks {
+			trNames[cond.ConditionName] = podName
+		}
 		trNames[t.PipelineTaskName] = name
 	}
 
 	trs := []Run{}
 	for _, ts := range pipelineTasks {
+		// checking conditions before appending task, pod names.
+		for _, cond := range ts.Conditions {
+			if podName, ok := trNames[cond.ConditionRef]; ok {
+				trs = append(trs, Run{Task: cond.ConditionRef, Name: podName})
+			}
+		}
 		if n, ok := trNames[ts.Name]; ok {
 			trs = append(trs, Run{
 				Task: ts.Name,

--- a/pkg/taskrun/taskrun.go
+++ b/pkg/taskrun/taskrun.go
@@ -28,9 +28,12 @@ func IsFiltered(tr Run, allowed []string) bool {
 	return len(Filter(trs, allowed)) == 0
 }
 
-func HasScheduled(trs *v1alpha1.PipelineRunTaskRunStatus) bool {
-	if trs.Status != nil {
-		return trs.Status.PodName != ""
+func HasScheduled(status interface{}) bool {
+	switch s := status.(type) {
+	case *v1alpha1.PipelineRunTaskRunStatus:
+		return s.Status != nil && s.Status.PodName != ""
+	case *v1alpha1.PipelineRunConditionCheckStatus:
+		return s.Status != nil && s.Status.PodName != ""
 	}
 	return false
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related issue is https://github.com/tektoncd/cli/issues/782
when running ```tkn pr logs``` without ```-f``` flag and pr tasks has conditions,
collecting condition pod logs before collecting tr pod logs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
