### PR TITLE
Change TaskRun and PipelineRun Sorting from sort.Slice to sort.Sort

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tektoncd/pipeline v0.10.1 h1:pDsYK2b70o/Ze/CE1nisELwKVVE54FxwyfLznsW1JiE=
 github.com/tektoncd/pipeline v0.11.0-rc2 h1:dMdrmxGt5J+BpDf6uv1QyvfnJBmjd/7X5fEQLcCmu+Q=
 github.com/tektoncd/pipeline v0.11.0-rc2/go.mod h1:QL3YmLzeKBdKk1THeQ6zmq2UXoPN+KdxeiU/7ynPtqY=
 github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2 h1:BksmpUwtap3THXJ8Z4KGcotsvpRdFQKySjDHgtc22lA=

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -22,7 +22,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/deleter"
 	"github.com/tektoncd/cli/pkg/options"
-	prhsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
+	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
 	validate "github.com/tektoncd/cli/pkg/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -145,7 +145,8 @@ func allPipelineRunNames(p cli.Params, cs *cli.Clients, keep int) ([]string, err
 	}
 	var names []string
 	var counter = 0
-	for _, pr := range prhsort.SortPipelineRunsByStartTime(pipelineRuns.Items) {
+	prsort.SortByStartTime(pipelineRuns.Items)
+	for _, pr := range pipelineRuns.Items {
 		if keep > 0 && counter != keep {
 			counter++
 			continue

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	prhsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
+	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
 	"github.com/tektoncd/cli/pkg/printer"
 	"github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -165,7 +165,7 @@ func list(p cli.Params, pipeline string, limit int, labelselector string) (*v1al
 	prslen := len(prs.Items)
 
 	if prslen != 0 {
-		prs.Items = prhsort.SortPipelineRunsByStartTime(prs.Items)
+		prsort.SortByStartTime(prs.Items)
 	}
 
 	// If greater than maximum amount of pipelineruns, return all pipelineruns by setting limit to default

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -24,7 +24,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/printer"
-	trhsort "github.com/tektoncd/cli/pkg/taskrun/sort"
+	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
 	"github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -178,7 +178,7 @@ func list(p cli.Params, task string, limit int, labelselector string) (*v1alpha1
 	trslen := len(trs.Items)
 
 	if trslen != 0 {
-		trs.Items = trhsort.SortTaskRunsByStartTime(trs.Items)
+		trsort.SortByStartTime(trs.Items)
 	}
 
 	// If greater than maximum amount of taskruns, return all taskruns by setting limit to default

--- a/pkg/pipelinerun/pipelinerun.go
+++ b/pkg/pipelinerun/pipelinerun.go
@@ -17,7 +17,7 @@ package pipelinerun
 import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	prhsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
+	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,7 +50,7 @@ func GetAllPipelineRuns(p cli.Params, opts metav1.ListOptions, limit int) ([]str
 
 	runslen := len(runs.Items)
 	if runslen > 1 {
-		runs.Items = prhsort.SortPipelineRunsByStartTime(runs.Items)
+		prsort.SortByStartTime(runs.Items)
 	}
 
 	if limit > runslen {

--- a/pkg/pipelinerun/sort/by_start_time.go
+++ b/pkg/pipelinerun/sort/by_start_time.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Tekton Authors.
+// Copyright © 2020 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,17 +20,20 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
-func SortPipelineRunsByStartTime(prs []v1alpha1.PipelineRun) []v1alpha1.PipelineRun {
-	sort.Slice(prs, func(i, j int) bool {
-		if prs[j].Status.StartTime == nil {
-			return false
-		}
+func SortByStartTime(prs []v1alpha1.PipelineRun) {
+	sort.Sort(byStartTime(prs))
+}
 
-		if prs[i].Status.StartTime == nil {
-			return true
-		}
-		return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
-	})
+type byStartTime []v1alpha1.PipelineRun
 
-	return prs
+func (prs byStartTime) Len() int      { return len(prs) }
+func (prs byStartTime) Swap(i, j int) { prs[i], prs[j] = prs[j], prs[i] }
+func (prs byStartTime) Less(i, j int) bool {
+	if prs[j].Status.StartTime == nil {
+		return false
+	}
+	if prs[i].Status.StartTime == nil {
+		return true
+	}
+	return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
 }

--- a/pkg/pipelinerun/sort/by_start_time_test.go
+++ b/pkg/pipelinerun/sort/by_start_time_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Tekton Authors.
+// Copyright © 2020 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,19 +60,19 @@ func Test_PipelineRunsByStartTime(t *testing.T) {
 		pr1,
 	}
 
-	sortResults := SortPipelineRunsByStartTime(prs)
+	SortByStartTime(prs)
 
-	element1 := sortResults[0].Name
+	element1 := prs[0].Name
 	if element1 != "pr0-1" {
 		t.Errorf("SortPipelineRunsByStartTime should be pr0-1 but returned: %s", element1)
 	}
 
-	element2 := sortResults[1].Name
+	element2 := prs[1].Name
 	if element2 != "pr2-1" {
 		t.Errorf("SortPipelineRunsByStartTime should be pr2-1 but returned: %s", element2)
 	}
 
-	element3 := sortResults[2].Name
+	element3 := prs[2].Name
 	if element3 != "pr1-1" {
 		t.Errorf("SortPipelineRunsByStartTime should be pr1-1 but returned: %s", element3)
 	}
@@ -107,19 +107,19 @@ func Test_PipelineRunsByStartTime_NilStartTime(t *testing.T) {
 		pr1,
 	}
 
-	sortResults := SortPipelineRunsByStartTime(prs)
+	SortByStartTime(prs)
 
-	element1 := sortResults[0].Name
+	element1 := prs[0].Name
 	if element1 != "pr1-1" {
 		t.Errorf("SortPipelineRunsByStartTime should be pr1-1 but returned: %s", element1)
 	}
 
-	element2 := sortResults[1].Name
+	element2 := prs[1].Name
 	if element2 != "pr2-1" {
 		t.Errorf("SortPipelineRunsByStartTime should be pr2-1 but returned: %s", element2)
 	}
 
-	element3 := sortResults[2].Name
+	element3 := prs[2].Name
 	if element3 != "pr0-1" {
 		t.Errorf("SortPipelineRunsByStartTime should be pr0-1 but returned: %s", element3)
 	}

--- a/pkg/taskrun/list/list.go
+++ b/pkg/taskrun/list/list.go
@@ -32,11 +32,8 @@ func GetAllTaskRuns(p cli.Params, opts metav1.ListOptions, limit int) ([]string,
 		return nil, err
 	}
 
+	trsort.SortByStartTime(runs.Items)
 	runslen := len(runs.Items)
-	if runslen > 1 {
-		runs.Items = trsort.SortTaskRunsByStartTime(runs.Items)
-	}
-
 	if limit > runslen {
 		limit = runslen
 	}

--- a/pkg/taskrun/sort/by_start_time.go
+++ b/pkg/taskrun/sort/by_start_time.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Tekton Authors.
+// Copyright © 2020 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,17 +20,20 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
-func SortTaskRunsByStartTime(trs []v1alpha1.TaskRun) []v1alpha1.TaskRun {
-	sort.Slice(trs, func(i, j int) bool {
-		if trs[j].Status.StartTime == nil {
-			return false
-		}
+func SortByStartTime(trs []v1alpha1.TaskRun) {
+	sort.Sort(byStartTime(trs))
+}
 
-		if trs[i].Status.StartTime == nil {
-			return true
-		}
-		return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
-	})
+type byStartTime []v1alpha1.TaskRun
 
-	return trs
+func (trs byStartTime) Len() int      { return len(trs) }
+func (trs byStartTime) Swap(i, j int) { trs[i], trs[j] = trs[j], trs[i] }
+func (trs byStartTime) Less(i, j int) bool {
+	if trs[j].Status.StartTime == nil {
+		return false
+	}
+	if trs[i].Status.StartTime == nil {
+		return true
+	}
+	return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
 }

--- a/pkg/taskrun/sort/by_start_time_test.go
+++ b/pkg/taskrun/sort/by_start_time_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Tekton Authors.
+// Copyright © 2020 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,19 +60,19 @@ func Test_TaskRunsByStartTime(t *testing.T) {
 		tr1,
 	}
 
-	sortResults := SortTaskRunsByStartTime(trs)
+	SortByStartTime(trs)
 
-	element1 := sortResults[0].Name
+	element1 := trs[0].Name
 	if element1 != "tr0-1" {
 		t.Errorf("SortTaskRunsByStartTime should be tr0-1 but returned: %s", element1)
 	}
 
-	element2 := sortResults[1].Name
+	element2 := trs[1].Name
 	if element2 != "tr2-1" {
 		t.Errorf("SortTaskRunsByStartTime should be tr2-1 but returned: %s", element2)
 	}
 
-	element3 := sortResults[2].Name
+	element3 := trs[2].Name
 	if element3 != "tr1-1" {
 		t.Errorf("SortTaskRunsByStartTime should be tr1-1 but returned: %s", element3)
 	}
@@ -107,19 +107,19 @@ func Test_TaskRunsByStartTime_NilStartTime(t *testing.T) {
 		tr1,
 	}
 
-	sortResults := SortTaskRunsByStartTime(trs)
+	SortByStartTime(trs)
 
-	element1 := sortResults[0].Name
+	element1 := trs[0].Name
 	if element1 != "tr1-1" {
 		t.Errorf("SortTaskRunsByStartTime should be tr1-1 but returned: %s", element1)
 	}
 
-	element2 := sortResults[1].Name
+	element2 := trs[1].Name
 	if element2 != "tr2-1" {
 		t.Errorf("SortTaskRunsByStartTime should be tr2-1 but returned: %s", element2)
 	}
 
-	element3 := sortResults[2].Name
+	element3 := trs[2].Name
 	if element3 != "tr0-1" {
 		t.Errorf("SortTaskRunsByStartTime should be tr0-1 but returned: %s", element3)
 	}

--- a/test/e2e/build_templates.go
+++ b/test/e2e/build_templates.go
@@ -11,11 +11,12 @@ import (
 	"text/template"
 	"time"
 
+	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/tektoncd/cli/pkg/formatted"
-	trhsort "github.com/tektoncd/cli/pkg/taskrun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -171,10 +172,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 			return emptyMsg
 		}
 		//sort by start Time
-		trslen := len(obj.Items)
-		if trslen != 0 {
-			obj.Items = trhsort.SortTaskRunsByStartTime(obj.Items)
-		}
+		trsort.SortByStartTime(obj.Items)
 
 		for _, r := range obj.Items {
 			fmt.Fprintf(w, body,
@@ -316,11 +314,7 @@ func ListAllTaskRunsOutput(t *testing.T, cs *Clients, td map[int]interface{}) st
 
 	clock := clockwork.NewFakeClockAt(time.Now())
 	taskrun := GetTaskRunListWithTestData(t, cs, td)
-
-	trslen := len(taskrun.Items)
-	if trslen != 0 {
-		taskrun.Items = trhsort.SortTaskRunsByStartTime(taskrun.Items)
-	}
+	trsort.SortByStartTime(taskrun.Items)
 
 	var tmplBytes bytes.Buffer
 	w := tabwriter.NewWriter(&tmplBytes, 0, 5, 3, ' ', tabwriter.TabIndent)


### PR DESCRIPTION
This pull request changes sorting of TaskRuns/PipelineRuns from using sort.Slice to sort.Sort to improve the performance of sorting by start time in situations with larger amounts of TaskRuns/PipelineRuns.

Since sort.Slice utilizes the reflect package for accessing elements of a slice, it doesn't perform well in situations with larger slices. Switching to sort.Sort should provide better performance since it does not rely on reflect.

The original choice to use sort.Slice was trying to make it easier to reuse across the CLI, but this can still be achieved using sort.Sort. The thought to switch sorting approaches comes after a situation where `tkn` took roughly `30s` to perform `tkn tr ls --limit 10` on the dogfooding cluster, which has roughly 5000 TaskRuns. 

The major issue with `tkn`'s list performance comes from the fact that Kubernetes doesn't offer a form of server-side sorting that would allow `tkn` to not have to pull back all TaskRuns or PipelineRuns and sort all the elements of a slice. In situations like with the dogfooding cluster, this has an enormous impact on the performance of limit.

While this pr will not address the main issue at hand, `tkn tr ls` and `tkn pr ls` should be able to have better performance than 30s in a situation of 5000+ TaskRuns or PipelineRuns. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Switch to sort.Sort to improve performance of tkn pr ls and tkn tr ls
```
