### PR TITLE
Start PipelineRun from Local or Remote File

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -35,6 +35,7 @@ two parameters (foo and bar)
 
 ```
       --dry-run                       preview pipelinerun without running it
+  -f, --filename string               local or remote file name containing a pipeline definition to start a pipelinerun
   -h, --help                          help for start
   -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the pipeline using last pipelinerun values

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -29,7 +29,7 @@ like cat,foo,bar
 
 ```
       --dry-run                  preview taskrun without running it
-  -f, --filename string          local or remote file name containing a task definition
+  -f, --filename string          local or remote file name containing a task definition to start a taskrun
   -h, --help                     help for start
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -32,6 +32,10 @@ Parameters, at least those that have no default value
     preview pipelinerun without running it
 
 .PP
+\fB\-f\fP, \fB\-\-filename\fP=""
+    local or remote file name containing a pipeline definition to start a pipelinerun
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for start
 

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -25,7 +25,7 @@ Start tasks
 
 .PP
 \fB\-f\fP, \fB\-\-filename\fP=""
-    local or remote file name containing a task definition
+    local or remote file name containing a task definition to start a taskrun
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_using_--filename.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_using_--filename.golden
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  namespace: ns
+spec:
+  pipelineSpec:
+    resources:
+    - name: source-repo
+      type: git
+    - name: web-image
+      type: image
+    tasks:
+    - name: build-skaffold-web
+      params:
+      - name: pathToDockerFile
+        value: Dockerfile
+      - name: pathToContext
+        value: /workspace/docker-source/examples/microservices/leeroy-web
+      resources:
+        inputs:
+        - name: docker-source
+          resource: source-repo
+        outputs:
+        - name: builtImage
+          resource: web-image
+      taskRef:
+        name: build-docker-image-from-git-source
+    - name: deploy-web
+      params:
+      - name: path
+        value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+      - name: yamlPathToImage
+        value: spec.template.spec.containers[0].image
+      resources:
+        inputs:
+        - name: source
+          resource: source-repo
+        - from:
+          - build-skaffold-web
+          name: image
+          resource: web-image
+      taskRef:
+        name: deploy-using-kubectl
+  resources:
+  - name: source-repo
+    resourceRef:
+      name: scaffold-git
+  - name: web-image
+    resourceRef:
+      name: imageres
+  timeout: 1h0m0s
+status: {}

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -150,7 +150,7 @@ like cat,foo,bar
 	flags.AddShellCompletion(c.Flags().Lookup("use-taskrun"), "__tkn_get_taskrun")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the task")
-	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a task definition")
+	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a task definition to start a taskrun")
 	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "1h", "timeout for taskrun")
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview taskrun without running it")
 	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of taskrun dry-run (yaml or json)")


### PR DESCRIPTION
Closes #738 

This pull request adds the ability to start a PipelineRun from a Pipeline defined in a local or remote file. This follows a similar pattern to `tkn task start -f`.

It also slightly reorganizes functions in `pipeline/start.go` so that helper functions are all beneath the actual command function, which is the more common organization throughout the CLI.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Adds the ability to start a PipelineRun from a Pipeline defined in a local or remote file definition
```
