### PR TITLE
Warning Messages About Removing create -f

### DIFF
--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -21,7 +21,6 @@ Manage pipelines
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn pipeline create](tkn_pipeline_create.md)	 - Create a pipeline in a namespace
 * [tkn pipeline delete](tkn_pipeline_delete.md)	 - Delete pipelines in a namespace
 * [tkn pipeline describe](tkn_pipeline_describe.md)	 - Describes a pipeline in a namespace
 * [tkn pipeline list](tkn_pipeline_list.md)	 - Lists pipelines in a namespace

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -27,7 +27,6 @@ Create a PipelineResource defined by foo.yaml in namespace 'bar':
 
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
-  -f, --from string                   local or remote filename to use to create the pipeline resource
   -h, --help                          help for create
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -21,7 +21,6 @@ Manage tasks
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn task create](tkn_task_create.md)	 - Create a task in a namespace
 * [tkn task delete](tkn_task_delete.md)	 - Delete task resources in a namespace
 * [tkn task describe](tkn_task_describe.md)	 - Describes a task in a namespace
 * [tkn task list](tkn_task_list.md)	 - Lists tasks in a namespace

--- a/docs/man/man1/tkn-pipeline.1
+++ b/docs/man/man1/tkn-pipeline.1
@@ -42,4 +42,4 @@ Manage pipelines
 
 .SH SEE ALSO
 .PP
-\fBtkn(1)\fP, \fBtkn\-pipeline\-create(1)\fP, \fBtkn\-pipeline\-delete(1)\fP, \fBtkn\-pipeline\-describe(1)\fP, \fBtkn\-pipeline\-list(1)\fP, \fBtkn\-pipeline\-logs(1)\fP, \fBtkn\-pipeline\-start(1)\fP
+\fBtkn(1)\fP, \fBtkn\-pipeline\-delete(1)\fP, \fBtkn\-pipeline\-describe(1)\fP, \fBtkn\-pipeline\-list(1)\fP, \fBtkn\-pipeline\-logs(1)\fP, \fBtkn\-pipeline\-start(1)\fP

--- a/docs/man/man1/tkn-resource-create.1
+++ b/docs/man/man1/tkn-resource-create.1
@@ -24,10 +24,6 @@ Create a pipeline resource in a namespace
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
-\fB\-f\fP, \fB\-\-from\fP=""
-    local or remote filename to use to create the pipeline resource
-
-.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for create
 

--- a/docs/man/man1/tkn-task.1
+++ b/docs/man/man1/tkn-task.1
@@ -42,4 +42,4 @@ Manage tasks
 
 .SH SEE ALSO
 .PP
-\fBtkn(1)\fP, \fBtkn\-task\-create(1)\fP, \fBtkn\-task\-delete(1)\fP, \fBtkn\-task\-describe(1)\fP, \fBtkn\-task\-list(1)\fP, \fBtkn\-task\-logs(1)\fP, \fBtkn\-task\-start(1)\fP
+\fBtkn(1)\fP, \fBtkn\-task\-delete(1)\fP, \fBtkn\-task\-describe(1)\fP, \fBtkn\-task\-list(1)\fP, \fBtkn\-task\-logs(1)\fP, \fBtkn\-task\-start(1)\fP

--- a/pkg/cmd/pipeline/create.go
+++ b/pkg/cmd/pipeline/create.go
@@ -62,6 +62,7 @@ func createCommand(p cli.Params) *cobra.Command {
 	}
 	f.AddFlags(c)
 	c.Flags().StringVarP(&opts.from, "from", "f", "", "local or remote filename to use to create the pipeline")
+	c.Deprecated = "tkn pipeline create will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816"
 	return c
 }
 

--- a/pkg/cmd/pipeline/create_test.go
+++ b/pkg/cmd/pipeline/create_test.go
@@ -62,7 +62,7 @@ func Test_Pipeline_Create(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Pipeline created: test-pipeline\n",
+			want:        "Command \"create\" is deprecated, tkn pipeline create will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816\nPipeline created: test-pipeline\n",
 		},
 		{
 			name:        "Filename does not exist",

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -97,6 +97,7 @@ Create a PipelineResource defined by foo.yaml in namespace 'bar':
 	}
 	f.AddFlags(c)
 	c.Flags().StringVarP(&opts.from, "from", "f", "", "local or remote filename to use to create the pipeline resource")
+	c.Flags().MarkDeprecated("from", "from and -f will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816")
 	return c
 }
 

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -1633,7 +1633,7 @@ func Test_Pipeline_Resource_Create(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineResource created: test-resource\n",
+			want:        "Flag --from has been deprecated, from and -f will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816\nPipelineResource created: test-resource\n",
 		},
 		{
 			name:        "Filename does not exist",

--- a/pkg/cmd/task/create.go
+++ b/pkg/cmd/task/create.go
@@ -62,6 +62,7 @@ func createCommand(p cli.Params) *cobra.Command {
 	}
 	f.AddFlags(c)
 	c.Flags().StringVarP(&opts.from, "from", "f", "", "local or remote filename to use to create the task")
+	c.Deprecated = "tkn task create will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816"
 	return c
 }
 

--- a/pkg/cmd/task/create_test.go
+++ b/pkg/cmd/task/create_test.go
@@ -62,7 +62,7 @@ func Test_Task_Create(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "Task created: test-task\n",
+			want:        "Command \"create\" is deprecated, tkn task create will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816\nTask created: test-task\n",
 		},
 		{
 			name:        "Filename does not exist",


### PR DESCRIPTION
Part of #816 

Adding warning messages about removing `tkn task create`, `tkn pipeline create`, and `tkn resource create -f`.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Warning message about removing task create, pipeline create, and resource create -f
```
