### PR TITLE
Fix Test Failure from go v1.14.0 Update

### DIFF
--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -17,6 +17,7 @@ package file
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -61,5 +62,10 @@ func TestGetError(t *testing.T) {
 	target := "httpz://foo.com/task.yaml"
 
 	_, err := LoadFileContent(p, target, IsYamlFile(), fmt.Errorf("invalid file format for %s: .yaml or .yml file extension and format required", target))
-	assert.Error(t, err, `Get httpz://foo.com/task.yaml: unsupported protocol scheme "httpz"`)
+
+	if strings.Contains(err.Error(), `"httpz://foo.com/task.yaml"`) {
+		assert.Error(t, err, `Get "httpz://foo.com/task.yaml": unsupported protocol scheme "httpz"`)
+	} else {
+		assert.Error(t, err, `Get httpz://foo.com/task.yaml: unsupported protocol scheme "httpz"`)
+	}
 }


### PR DESCRIPTION
Updating to go v1.14.0 breaks `TestGetError` in `file/file_test.go`. This pull request adds quotes around the invalid url for the error message.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
N/A
```
