### PR TITLE
Add RELEASE_VERSION build-arg to the image 📟

### DIFF
--- a/contrib/tkn-image/Dockerfile
+++ b/contrib/tkn-image/Dockerfile
@@ -2,9 +2,10 @@ ARG GOLANG_VERSION=1.13.8
 ARG DEBIAN_VERSION=10
 
 FROM golang:${GOLANG_VERSION} as builder
+ARG RELEASE_VERSION=
 COPY . /go/src/github.com/tektoncd/cli
 WORKDIR /go/src/github.com/tektoncd/cli
-RUN make bin/tkn
+RUN make RELEASE_VERSION=${RELEASE_VERSION} bin/tkn
 
 FROM debian:${DEBIAN_VERSION} as tkn
 COPY --from=builder /go/src/github.com/tektoncd/cli/bin/tkn /usr/bin


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This will allow to build release version of the image, by default the
arg is empty, making it a `dev` version.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @chmouel @danielhelfand 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

