### PR TITLE
v1beta1 support for taskrun delete

### DIFF
--- a/pkg/actions/delete/delete.go
+++ b/pkg/actions/delete/delete.go
@@ -1,0 +1,36 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delete
+
+import (
+	"github.com/tektoncd/cli/pkg/actions"
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Delete(gr schema.GroupVersionResource, clients *cli.Clients, trname, n string, op *metav1.DeleteOptions) error {
+	gvr, err := actions.GetGVR(gr, clients.Tekton.Discovery())
+	if err != nil {
+		return err
+	}
+
+	err = clients.Dynamic.Resource(*gvr).Namespace(n).Delete(trname, op)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/actions/gvr.go
+++ b/pkg/actions/gvr.go
@@ -1,0 +1,36 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/restmapper"
+)
+
+func GetGVR(gr schema.GroupVersionResource, discovery discovery.DiscoveryInterface) (*schema.GroupVersionResource, error) {
+	apiGroupRes, err := restmapper.GetAPIGroupResources(discovery)
+	if err != nil {
+		return nil, err
+	}
+
+	rm := restmapper.NewDiscoveryRESTMapper(apiGroupRes)
+	gvr, err := rm.ResourceFor(gr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gvr, nil
+}

--- a/pkg/actions/list/list.go
+++ b/pkg/actions/list/list.go
@@ -17,14 +17,13 @@ package list
 import (
 	"io"
 
+	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/printer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/restmapper"
 )
 
 func PrintObject(groupResource schema.GroupVersionResource, w io.Writer, p cli.Params, f *cliopts.PrintFlags, ns string) error {
@@ -42,7 +41,7 @@ func PrintObject(groupResource schema.GroupVersionResource, w io.Writer, p cli.P
 }
 
 func AllObjecs(gr schema.GroupVersionResource, clients *cli.Clients, n string, op metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	gvr, err := getGVR(gr, clients.Tekton.Discovery())
+	gvr, err := actions.GetGVR(gr, clients.Tekton.Discovery())
 	if err != nil {
 		return nil, err
 	}
@@ -53,19 +52,4 @@ func AllObjecs(gr schema.GroupVersionResource, clients *cli.Clients, n string, o
 	}
 
 	return allRes, nil
-}
-
-func getGVR(gr schema.GroupVersionResource, discovery discovery.DiscoveryInterface) (*schema.GroupVersionResource, error) {
-	apiGroupRes, err := restmapper.GetAPIGroupResources(discovery)
-	if err != nil {
-		return nil, err
-	}
-
-	rm := restmapper.NewDiscoveryRESTMapper(apiGroupRes)
-	gvr, err := rm.ResourceFor(gr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &gvr, nil
 }

--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -20,9 +20,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/actions/list"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	"github.com/tektoncd/cli/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -21,9 +21,9 @@ import (
 	"text/template"
 
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/actions/list"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	"github.com/tektoncd/cli/pkg/list"
 	"github.com/tektoncd/cli/pkg/pipeline"
 	validate "github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -20,9 +20,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/actions/list"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	"github.com/tektoncd/cli/pkg/list"
 	validate "github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -20,16 +20,20 @@ import (
 	"testing"
 
 	"github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
+	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/apis"
 )
 
 func TestTaskRunDelete(t *testing.T) {
+	version := "v1alpha1"
 	ns := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -38,47 +42,63 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 	}
 
-	seeds := make([]pipelinetest.Clients, 0)
+	trdata := []*v1alpha1.TaskRun{
+		tb.TaskRun("tr0-1", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		tb.TaskRun("tr0-2", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		tb.TaskRun("tr0-3", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+	}
+	type clients struct {
+		pipelineClient pipelinetest.Clients
+		dynamicClient  dynamic.Interface
+	}
+
+	seeds := make([]clients, 0)
 	for i := 0; i < 5; i++ {
-		trs := []*v1alpha1.TaskRun{
-			tb.TaskRun("tr0-1", "ns",
-				tb.TaskRunLabel("tekton.dev/task", "random"),
-				tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
-				tb.TaskRunStatus(
-					tb.StatusCondition(apis.Condition{
-						Status: corev1.ConditionTrue,
-						Reason: resources.ReasonSucceeded,
-					}),
-				),
-			),
-			tb.TaskRun("tr0-2", "ns",
-				tb.TaskRunLabel("tekton.dev/task", "random"),
-				tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
-				tb.TaskRunStatus(
-					tb.StatusCondition(apis.Condition{
-						Status: corev1.ConditionTrue,
-						Reason: resources.ReasonSucceeded,
-					}),
-				),
-			),
-			tb.TaskRun("tr0-3", "ns",
-				tb.TaskRunLabel("tekton.dev/task", "random"),
-				tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
-				tb.TaskRunStatus(
-					tb.StatusCondition(apis.Condition{
-						Status: corev1.ConditionTrue,
-						Reason: resources.ReasonSucceeded,
-					}),
-				),
-			),
-		}
+		trs := trdata
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
-		seeds = append(seeds, cs)
+		cs.Pipeline.Resources = cb.APIResourceList(version, "taskrun")
+		dc, err := testDynamic.Client(
+			cb.UnstructuredTR(trdata[0], version),
+			cb.UnstructuredTR(trdata[1], version),
+			cb.UnstructuredTR(trdata[2], version),
+		)
+		if err != nil {
+			t.Errorf("unable to create dynamic clinet: %v", err)
+		}
+		seeds = append(seeds, clients{cs, dc})
 	}
 
 	testParams := []struct {
 		name        string
 		command     []string
+		dynamic     dynamic.Interface
 		input       pipelinetest.Clients
 		inputStream io.Reader
 		wantError   bool
@@ -87,7 +107,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Invalid namespace",
 			command:     []string{"rm", "tr0-1", "-n", "invalid"},
-			input:       seeds[0],
+			dynamic:     seeds[0].dynamicClient,
+			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "namespaces \"invalid\" not found",
@@ -95,7 +116,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "With force delete flag (shorthand)",
 			command:     []string{"rm", "tr0-1", "-n", "ns", "-f"},
-			input:       seeds[0],
+			dynamic:     seeds[0].dynamicClient,
+			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
 			want:        "TaskRuns deleted: \"tr0-1\"\n",
@@ -103,7 +125,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "With force delete flag",
 			command:     []string{"rm", "tr0-1", "-n", "ns", "--force"},
-			input:       seeds[1],
+			dynamic:     seeds[1].dynamicClient,
+			input:       seeds[1].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
 			want:        "TaskRuns deleted: \"tr0-1\"\n",
@@ -111,7 +134,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Without force delete flag, reply no",
 			command:     []string{"rm", "tr0-1", "-n", "ns"},
-			input:       seeds[2],
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
 			want:        "canceled deleting taskrun \"tr0-1\"",
@@ -119,7 +143,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Without force delete flag, reply yes",
 			command:     []string{"rm", "tr0-1", "-n", "ns"},
-			input:       seeds[2],
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
 			want:        "Are you sure you want to delete taskrun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
@@ -127,7 +152,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Remove non existent resource",
 			command:     []string{"rm", "nonexistent", "-n", "ns"},
-			input:       seeds[2],
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
@@ -135,7 +161,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Remove multiple non existent resources",
 			command:     []string{"rm", "nonexistent", "nonexistent2", "-n", "ns"},
-			input:       seeds[2],
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete taskrun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
@@ -143,7 +170,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Attempt remove forgetting to include taskrun names",
 			command:     []string{"rm", "-n", "ns"},
-			input:       seeds[2],
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide taskrun name(s) or use --task flag or --all flag to use delete",
@@ -151,7 +179,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Remove taskruns of a task",
 			command:     []string{"rm", "--task", "task", "-n", "ns"},
-			input:       seeds[0],
+			dynamic:     seeds[0].dynamicClient,
+			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
 			want:        `Are you sure you want to delete all taskruns related to task "task" (y/n): `,
@@ -159,7 +188,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Delete all with prompt",
 			command:     []string{"delete", "--all", "-n", "ns"},
-			input:       seeds[3],
+			dynamic:     seeds[3].dynamicClient,
+			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
 			want:        "Are you sure you want to delete all taskruns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
@@ -167,7 +197,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Delete all with -f",
 			command:     []string{"delete", "--all", "-f", "-n", "ns"},
-			input:       seeds[4],
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
 			want:        "All TaskRuns deleted in namespace \"ns\"\n",
@@ -175,7 +206,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Delete all keeping 2",
 			command:     []string{"delete", "--all", "-f", "--keep", "2", "-n", "ns"},
-			input:       seeds[4],
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
 			want:        "All but 2 TaskRuns deleted in namespace \"ns\"\n",
@@ -183,7 +215,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Keep -1 is a no go",
 			command:     []string{"delete", "--all", "-f", "--keep", "-1", "-n", "ns"},
-			input:       seeds[4],
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "keep option should not be lower than 0",
@@ -191,7 +224,8 @@ func TestTaskRunDelete(t *testing.T) {
 		{
 			name:        "Error from using taskrun name with --all",
 			command:     []string{"delete", "taskrun", "--all", "-n", "ns"},
-			input:       seeds[4],
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -200,7 +234,233 @@ func TestTaskRunDelete(t *testing.T) {
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			p := &test.Params{Tekton: tp.input.Pipeline, Kube: tp.input.Kube}
+			p := &test.Params{Tekton: tp.input.Pipeline, Kube: tp.input.Kube, Dynamic: tp.dynamic}
+			taskrun := Command(p)
+
+			if tp.inputStream != nil {
+				taskrun.SetIn(tp.inputStream)
+			}
+
+			out, err := test.ExecuteCommand(taskrun, tp.command...)
+			if tp.wantError {
+				if err == nil {
+					t.Errorf("error expected here")
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected Error")
+				}
+				test.AssertOutput(t, tp.want, out)
+			}
+		})
+	}
+}
+
+func TestTaskRunDelete_v1beta1(t *testing.T) {
+	version := "v1beta1"
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	trdata := []*v1alpha1.TaskRun{
+		tb.TaskRun("tr0-1", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		tb.TaskRun("tr0-2", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		tb.TaskRun("tr0-3", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "random"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("random")),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+	}
+	type clients struct {
+		pipelineClient pipelinetest.Clients
+		dynamicClient  dynamic.Interface
+	}
+
+	seeds := make([]clients, 0)
+	for i := 0; i < 5; i++ {
+		trs := trdata
+		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
+		cs.Pipeline.Resources = cb.APIResourceList(version, "taskrun")
+		dc, err := testDynamic.Client(
+			cb.UnstructuredTR(trdata[0], version),
+			cb.UnstructuredTR(trdata[1], version),
+			cb.UnstructuredTR(trdata[2], version),
+		)
+		if err != nil {
+			t.Errorf("unable to create dynamic clinet: %v", err)
+		}
+		seeds = append(seeds, clients{cs, dc})
+	}
+
+	testParams := []struct {
+		name        string
+		command     []string
+		dynamic     dynamic.Interface
+		input       pipelinetest.Clients
+		inputStream io.Reader
+		wantError   bool
+		want        string
+	}{
+		{
+			name:        "Invalid namespace",
+			command:     []string{"rm", "tr0-1", "-n", "invalid"},
+			dynamic:     seeds[0].dynamicClient,
+			input:       seeds[0].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "namespaces \"invalid\" not found",
+		},
+		{
+			name:        "With force delete flag (shorthand)",
+			command:     []string{"rm", "tr0-1", "-n", "ns", "-f"},
+			dynamic:     seeds[0].dynamicClient,
+			input:       seeds[0].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "TaskRuns deleted: \"tr0-1\"\n",
+		},
+		{
+			name:        "With force delete flag",
+			command:     []string{"rm", "tr0-1", "-n", "ns", "--force"},
+			dynamic:     seeds[1].dynamicClient,
+			input:       seeds[1].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "TaskRuns deleted: \"tr0-1\"\n",
+		},
+		{
+			name:        "Without force delete flag, reply no",
+			command:     []string{"rm", "tr0-1", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: strings.NewReader("n"),
+			wantError:   true,
+			want:        "canceled deleting taskrun \"tr0-1\"",
+		},
+		{
+			name:        "Without force delete flag, reply yes",
+			command:     []string{"rm", "tr0-1", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete taskrun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
+		},
+		{
+			name:        "Remove non existent resource",
+			command:     []string{"rm", "nonexistent", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
+		},
+		{
+			name:        "Remove multiple non existent resources",
+			command:     []string{"rm", "nonexistent", "nonexistent2", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete taskrun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
+		},
+		{
+			name:        "Attempt remove forgetting to include taskrun names",
+			command:     []string{"rm", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "must provide taskrun name(s) or use --task flag or --all flag to use delete",
+		},
+		{
+			name:        "Remove taskruns of a task",
+			command:     []string{"rm", "--task", "task", "-n", "ns"},
+			dynamic:     seeds[0].dynamicClient,
+			input:       seeds[0].pipelineClient,
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        `Are you sure you want to delete all taskruns related to task "task" (y/n): `,
+		},
+		{
+			name:        "Delete all with prompt",
+			command:     []string{"delete", "--all", "-n", "ns"},
+			dynamic:     seeds[3].dynamicClient,
+			input:       seeds[3].pipelineClient,
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete all taskruns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all with -f",
+			command:     []string{"delete", "--all", "-f", "-n", "ns"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all keeping 2",
+			command:     []string{"delete", "--all", "-f", "--keep", "2", "-n", "ns"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 2 TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Keep -1 is a no go",
+			command:     []string{"delete", "--all", "-f", "--keep", "-1", "-n", "ns"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "keep option should not be lower than 0",
+		},
+		{
+			name:        "Error from using taskrun name with --all",
+			command:     []string{"delete", "taskrun", "--all", "-n", "ns"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--all flag should not have any arguments or flags specified with it",
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			p := &test.Params{Tekton: tp.input.Pipeline, Kube: tp.input.Kube, Dynamic: tp.dynamic}
 			taskrun := Command(p)
 
 			if tp.inputStream != nil {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"os"
 
+	plist "github.com/tektoncd/cli/pkg/actions/list"
 	"github.com/tektoncd/cli/pkg/cli"
-	plist "github.com/tektoncd/cli/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/taskrun/list/list.go
+++ b/pkg/taskrun/list/list.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"os"
 
+	trlist "github.com/tektoncd/cli/pkg/actions/list"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	trlist "github.com/tektoncd/cli/pkg/list"
 	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
this adds v1beta1 support for taskrun delete cammand
also puts list and delete in `actions/list` `actions/delete` so
that upcoming actions like `create`, `get` etc can be addes to
actions

may get some refactors in upcoming pr's

Signed-off-by: Pradeep Kumar pradkuma@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
