### PR TITLE
Add s390x target to Makefile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
   goarch:
   - amd64
   - arm64
+  - s390x
   ldflags:
   - -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}
 archives:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ vendor:
 	@go mod vendor
 
 .PHONY: cross
-cross: amd64 386 arm arm64 ## build cross platform binaries
+cross: amd64 386 arm arm64 s390x ## build cross platform binaries
 
 .PHONY: amd64
 amd64:
@@ -37,6 +37,10 @@ arm:
 .PHONY: arm64
 arm64:
 	GOOS=linux GOARCH=arm64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-arm64 ./cmd/tkn
+
+.PHONY: s390x
+s390x:
+	GOOS=linux GOARCH=s390x go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-s390x ./cmd/tkn
 
 bin/%: cmd/% FORCE
 	go build -mod=vendor $(LDFLAGS) -v -o $@ ./$<


### PR DESCRIPTION
This will add s390x option for cross compilation builds

Signed-off-by: Yulia Gaponenko <yulia.gaponenko1@de.ibm.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
