### PR TITLE
Sort resources in start subcommands 🌮

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -256,6 +257,7 @@ func mergeRes(r []v1alpha1.TaskResourceBinding, optRes []string) ([]v1alpha1.Tas
 	for _, v := range res {
 		r = append(r, v)
 	}
+	sort.Slice(r, func(i, j int) bool { return r[i].Name < r[j].Name })
 	return r, nil
 }
 

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -509,6 +510,7 @@ func mergeRes(pr *v1alpha1.PipelineRun, optRes []string) error {
 	for _, v := range res {
 		pr.Spec.Resources = append(pr.Spec.Resources, v)
 	}
+	sort.Slice(pr.Spec.Resources, func(i, j int) bool { return pr.Spec.Resources[i].Name < pr.Spec.Resources[j].Name })
 	return nil
 }
 

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -332,6 +333,7 @@ func mergeRes(r []v1alpha1.TaskResourceBinding, optRes []string) ([]v1alpha1.Tas
 	for _, v := range res {
 		r = append(r, v)
 	}
+	sort.Slice(r, func(i, j int) bool { return r[i].Name < r[j].Name })
 	return r, nil
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Otherwise, `--dry-run` might generate a struct with different order,
making tests flaky.

This should fix the `make generated` diff that appear sometimes.

Closes #838

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @danielhelfand @piyush-garg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Sort PipelineResource in `*Run`'s resources generate by `start` sub-commands
```
