### PR TITLE
Add workspace option to task start

### DIFF
--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -42,6 +42,7 @@ like cat,foo,bar
       --showlog                  show logs right after starting the task
       --timeout string           timeout for taskrun (default "1h")
       --use-taskrun string       specify a taskrun name to use its values to re-run the taskrun
+  -w, --workspace stringArray    pass the workspace.
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -75,6 +75,10 @@ Start tasks
 \fB\-\-use\-taskrun\fP=""
     specify a taskrun name to use its values to re\-run the taskrun
 
+.PP
+\fB\-w\fP, \fB\-\-workspace\fP=[]
+    pass the workspace.
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Emptydir, PVC, Configmap, and secret can be passed as workspace to task start.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
