### PR TITLE
v1beta1 support for task and taskrun logs command

### DIFF
--- a/pkg/actions/get/get.go
+++ b/pkg/actions/get/get.go
@@ -1,0 +1,37 @@
+// Copyright © 2019-2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"github.com/tektoncd/cli/pkg/actions"
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Get(gr schema.GroupVersionResource, clients *cli.Clients, objname, ns string, op metav1.GetOptions) (*unstructured.Unstructured, error) {
+	gvr, err := actions.GetGroupVersionResource(gr, clients.Tekton.Discovery())
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := clients.Dynamic.Resource(*gvr).Namespace(ns).Get(objname, op)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}

--- a/pkg/actions/watch/watch.go
+++ b/pkg/actions/watch/watch.go
@@ -1,0 +1,23 @@
+package watch
+
+import (
+	"github.com/tektoncd/cli/pkg/actions"
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func Watch(gr schema.GroupVersionResource, clients *cli.Clients, ns string, op metav1.ListOptions) (watch.Interface, error) {
+	gvr, err := actions.GetGroupVersionResource(gr, clients.Tekton.Discovery())
+	if err != nil {
+		return nil, err
+	}
+
+	watch, err := clients.Dynamic.Resource(*gvr).Namespace(ns).Watch(op)
+	if err != nil {
+		return nil, err
+	}
+
+	return watch, nil
+}

--- a/pkg/actions/watch/watch.go
+++ b/pkg/actions/watch/watch.go
@@ -1,3 +1,17 @@
+// Copyright © 2019-2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package watch
 
 import (

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -48,7 +48,8 @@ func TestClusterTaskDelete(t *testing.T) {
 		}
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"clustertask"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredCT(clustertasks[0], version),
 			cb.UnstructuredCT(clustertasks[1], version),
 			cb.UnstructuredCT(clustertasks[2], version),
@@ -221,7 +222,8 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 		}
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"clustertask"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredCT(clustertasks[0], version),
 			cb.UnstructuredCT(clustertasks[1], version),
 			cb.UnstructuredCT(clustertasks[2], version),

--- a/pkg/cmd/clustertask/list_test.go
+++ b/pkg/cmd/clustertask/list_test.go
@@ -32,8 +32,8 @@ import (
 func TestClusterTaskList_Empty(t *testing.T) {
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
 	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"clustertask"})
-
-	dynamic, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -61,8 +61,8 @@ func TestClusterTaskListOnlyClusterTasksv1alpha1(t *testing.T) {
 	}
 
 	version := "v1alpha1"
-
-	dynamic, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
 		cb.UnstructuredCT(clustertasks[0], version),
 		cb.UnstructuredCT(clustertasks[1], version),
 		cb.UnstructuredCT(clustertasks[2], version),
@@ -97,8 +97,8 @@ func TestClusterTaskListOnlyClusterTasksv1beta1(t *testing.T) {
 	}
 
 	version := "v1beta1"
-
-	dynamic, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
 		cb.UnstructuredCT(clustertasks[0], version),
 		cb.UnstructuredCT(clustertasks[1], version),
 		cb.UnstructuredCT(clustertasks[2], version),

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -100,7 +100,8 @@ func TestPipelineDelete(t *testing.T) {
 		})
 
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredP(pdata[0], version),
 			cb.UnstructuredP(pdata[1], version),
 			cb.UnstructuredPR(prdata[0], version),
@@ -350,7 +351,8 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 		})
 
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredP(pdata[0], version),
 			cb.UnstructuredP(pdata[1], version),
 			cb.UnstructuredPR(prdata[0], version),

--- a/pkg/cmd/pipeline/list_test.go
+++ b/pkg/cmd/pipeline/list_test.go
@@ -68,7 +68,8 @@ func TestPipelinesList_empty(t *testing.T) {
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: nsList})
 	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"pipeline"})
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -102,7 +103,8 @@ func TestPipelineList_only_pipelines(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	cs, pdata := seedPipelines(t, clock, pipelines, "namespace", nsList)
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline"})
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredP(pdata[0], version),
 		cb.UnstructuredP(pdata[1], version),
 		cb.UnstructuredP(pdata[2], version),
@@ -138,7 +140,8 @@ func TestPipelineList_only_pipelines_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	cs, pdata := seedPipelines(t, clock, pipelines, "namespace", nsList)
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline"})
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredP(pdata[0], version),
 		cb.UnstructuredP(pdata[1], version),
 		cb.UnstructuredP(pdata[2], version),
@@ -195,8 +198,8 @@ func TestPipelinesList_with_single_run(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline"})
-
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredP(pdata[0], version),
 	)
 	if err != nil {
@@ -288,7 +291,8 @@ func TestPipelinesList_latest_run(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline"})
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredP(pdata[0], version),
 	)
 	if err != nil {

--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -68,7 +68,8 @@ func TestPipelineLog(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -86,7 +87,8 @@ func TestPipelineLog(t *testing.T) {
 		},
 	})
 	cs2.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc2, err := testDynamic.Client()
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -140,7 +142,8 @@ func TestPipelineLog(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc3, err := testDynamic.Client(
+	tdc3 := testDynamic.Options{}
+	dc3, err := tdc3.Client(
 		cb.UnstructuredPR(prdata3[0], version),
 		cb.UnstructuredPR(prdata3[1], version),
 	)
@@ -263,7 +266,8 @@ func TestPipelineLog_v1beta1(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -281,7 +285,8 @@ func TestPipelineLog_v1beta1(t *testing.T) {
 		},
 	})
 	cs2.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc2, err := testDynamic.Client()
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -335,7 +340,8 @@ func TestPipelineLog_v1beta1(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc3, err := testDynamic.Client(
+	tdc3 := testDynamic.Options{}
+	dc3, err := tdc3.Client(
 		cb.UnstructuredPR(prdata3[0], version),
 		cb.UnstructuredPR(prdata3[1], version),
 	)
@@ -832,7 +838,8 @@ func TestLogs_Auto_Select_FirstPipeline(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredPR(prdata[0], version),
 	)
 	if err != nil {

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -97,7 +97,7 @@ Create a PipelineResource defined by foo.yaml in namespace 'bar':
 	}
 	f.AddFlags(c)
 	c.Flags().StringVarP(&opts.from, "from", "f", "", "local or remote filename to use to create the pipeline resource")
-	c.Flags().MarkDeprecated("from", "from and -f will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816")
+	_ = c.Flags().MarkDeprecated("from", "from and -f will be removed in v1.0.0. Use kubectl create -f instead. Learn more here: https://github.com/tektoncd/cli/issues/816")
 	return c
 }
 

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -114,7 +114,8 @@ func TestPipelineRunDelete(t *testing.T) {
 			Namespaces:   ns,
 		})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredPR(prdata[0], version),
 			cb.UnstructuredPR(prdata[1], version),
 			cb.UnstructuredPR(prdata[2], version),
@@ -368,7 +369,8 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			Namespaces:   ns,
 		})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredPR(prdata[0], version),
 			cb.UnstructuredPR(prdata[1], version),
 			cb.UnstructuredPR(prdata[2], version),

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -109,7 +109,8 @@ func TestListPipelineRuns(t *testing.T) {
 		},
 	}
 
-	dc1, err := testDynamic.Client(
+	tdc1 := testDynamic.Options{}
+	dc1, err := tdc1.Client(
 		cb.UnstructuredPR(prs[0], version),
 		cb.UnstructuredPR(prs[1], version),
 		cb.UnstructuredPR(prs[2], version),
@@ -119,7 +120,8 @@ func TestListPipelineRuns(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
-	dc2, err := testDynamic.Client(
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client(
 		cb.UnstructuredPR(prsMultipleNs[0], version),
 		cb.UnstructuredPR(prsMultipleNs[1], version),
 	)
@@ -311,7 +313,8 @@ func TestListPipelineRuns_v1beta1(t *testing.T) {
 		},
 	}
 
-	dc1, err := testDynamic.Client(
+	tdc1 := testDynamic.Options{}
+	dc1, err := tdc1.Client(
 		cb.UnstructuredPR(prs[0], version),
 		cb.UnstructuredPR(prs[1], version),
 		cb.UnstructuredPR(prs[2], version),
@@ -456,7 +459,8 @@ func TestListPipeline_empty(t *testing.T) {
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"pipelinerun"})
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -87,7 +87,8 @@ func TestTaskDelete(t *testing.T) {
 		})
 
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task", "taskrun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredT(tdata[0], version),
 			cb.UnstructuredT(tdata[1], version),
 			cb.UnstructuredTR(trdata[0], version),
@@ -325,7 +326,8 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 		})
 
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task", "taskrun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredT(tdata[0], version),
 			cb.UnstructuredT(tdata[1], version),
 			cb.UnstructuredTR(trdata[0], version),

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -57,8 +57,8 @@ func TestTaskList_Empty(t *testing.T) {
 	}
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"task"})
-
-	dynamic, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -92,7 +92,8 @@ func TestTaskList_Only_Tasks_v1alpha1(t *testing.T) {
 	}
 
 	version := "v1alpha1"
-	dynamic, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
 		cb.UnstructuredT(tasks[0], version),
 		cb.UnstructuredT(tasks[1], version),
 		cb.UnstructuredT(tasks[2], version),
@@ -138,7 +139,8 @@ func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 	}
 
 	version := "v1beta1"
-	dynamic, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
 		cb.UnstructuredT(tasks[0], version),
 		cb.UnstructuredT(tasks[1], version),
 		cb.UnstructuredT(tasks[2], version),

--- a/pkg/cmd/task/logs.go
+++ b/pkg/cmd/task/logs.go
@@ -25,7 +25,7 @@ import (
 	"github.com/tektoncd/cli/pkg/options"
 	thelper "github.com/tektoncd/cli/pkg/task"
 	trlist "github.com/tektoncd/cli/pkg/taskrun/list"
-	validate "github.com/tektoncd/cli/pkg/validate"
+	"github.com/tektoncd/cli/pkg/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,7 +36,7 @@ func nameArg(args []string, p cli.Params) error {
 			return err
 		}
 		name, ns := args[0], p.Namespace()
-		if _, err = c.Tekton.TektonV1alpha1().Tasks(ns).Get(name, metav1.GetOptions{}); err != nil {
+		if _, err = thelper.Get(c, name, metav1.GetOptions{}, ns); err != nil {
 			return err
 		}
 	}
@@ -189,7 +189,7 @@ func initLastRunName(opts *options.LogOptions) error {
 	if err != nil {
 		return err
 	}
-	lastrun, err := thelper.LastRun(cs.Tekton, opts.TaskName, opts.Params.Namespace(), "task")
+	lastrun, err := thelper.DynamicLastRun(cs, opts.TaskName, opts.Params.Namespace(), "task")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/task/logs_test.go
+++ b/pkg/cmd/task/logs_test.go
@@ -58,8 +58,8 @@ func TestTaskLog(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"task", "taskrun"})
-
-	dc1, err := testDynamic.Client(
+	tdc1 := testDynamic.Options{}
+	dc1, err := tdc1.Client(
 		cb.UnstructuredT(task1[0], "v1alpha1"),
 	)
 	if err != nil {
@@ -79,8 +79,9 @@ func TestTaskLog(t *testing.T) {
 			},
 		},
 	})
-	cs2.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"task"})
-	dc2, err := testDynamic.Client(
+	cs2.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"task", "taskrun"})
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client(
 		cb.UnstructuredT(task2[0], "v1alpha1"),
 	)
 	if err != nil {

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -84,7 +84,8 @@ func TestTaskRunDelete(t *testing.T) {
 		trs := trdata
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredTR(trdata[0], version),
 			cb.UnstructuredTR(trdata[1], version),
 			cb.UnstructuredTR(trdata[2], version),
@@ -310,7 +311,8 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 		trs := trdata
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
-		dc, err := testDynamic.Client(
+		tdc := testDynamic.Options{}
+		dc, err := tdc.Client(
 			cb.UnstructuredTR(trdata[0], version),
 			cb.UnstructuredTR(trdata[1], version),
 			cb.UnstructuredTR(trdata[2], version),

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -137,8 +137,8 @@ func TestListTaskRuns(t *testing.T) {
 			},
 		},
 	}
-
-	dc1, err := testDynamic.Client(
+	tdc1 := testDynamic.Options{}
+	dc1, err := tdc1.Client(
 		cb.UnstructuredTR(trs[0], version),
 		cb.UnstructuredTR(trs[1], version),
 		cb.UnstructuredTR(trs[2], version),
@@ -150,7 +150,8 @@ func TestListTaskRuns(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
-	dc2, err := testDynamic.Client(
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client(
 		cb.UnstructuredTR(trsMultipleNs[0], version),
 		cb.UnstructuredTR(trsMultipleNs[1], version),
 	)
@@ -386,8 +387,8 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 			},
 		},
 	}
-
-	dc1, err := testDynamic.Client(
+	tdc1 := testDynamic.Options{}
+	dc1, err := tdc1.Client(
 		cb.UnstructuredTR(trs[0], version),
 		cb.UnstructuredTR(trs[1], version),
 		cb.UnstructuredTR(trs[2], version),
@@ -399,7 +400,8 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
-	dc2, err := testDynamic.Client(
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client(
 		cb.UnstructuredTR(trsMultipleNs[0], version),
 		cb.UnstructuredTR(trsMultipleNs[1], version),
 	)
@@ -545,7 +547,8 @@ func TestListTaskRuns_no_condition(t *testing.T) {
 			},
 		},
 	}
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredTR(trs[0], version),
 	)
 	if err != nil {

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -76,8 +76,8 @@ func TestLog_no_taskrun_arg(t *testing.T) {
 		},
 	})
 	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"taskrun"})
-
-	dc1, err := testDynamic.Client()
+	tdc := testDynamic.Options{}
+	dc1, err := tdc.Client()
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -124,7 +124,10 @@ func TestLog_no_taskrun_arg(t *testing.T) {
 		},
 	})
 	cs2.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"taskrun"})
-	dc2, err := testDynamic.Client(cb.UnstructuredTR(taskrun2[0], "v1alpha1"))
+	tdc2 := testDynamic.Options{}
+	dc2, err := tdc2.Client(
+		cb.UnstructuredTR(taskrun2[0], "v1alpha1"),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -178,13 +181,15 @@ func TestLog_missing_taskrun(t *testing.T) {
 			},
 		},
 	}
-
-	dc, err := testDynamic.Client(cb.UnstructuredTR(tr[0], "v1alpha1"))
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(tr[0], "v1alpha1"),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: tr, Namespaces: nsList})
-	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"TaskRun"})
+	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"taskrun"})
 	watcher := watch.NewFake()
 	cs.Kube.PrependWatchReactor("pods", k8stest.DefaultWatchReactor(watcher, nil))
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc}
@@ -214,6 +219,7 @@ func TestLog_invalid_flags(t *testing.T) {
 }
 
 func TestLog_taskrun_logs(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		ns          = "namespace"
 		taskName    = "output-task"
@@ -276,7 +282,11 @@ func TestLog_taskrun_logs(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: ps, Namespaces: nsList})
-	dc, err := testDynamic.Client()
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -293,6 +303,7 @@ func TestLog_taskrun_logs(t *testing.T) {
 }
 
 func TestLog_taskrun_logs_no_pod_name(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		ns          = "namespace"
 		taskName    = "output-task"
@@ -338,7 +349,11 @@ func TestLog_taskrun_logs_no_pod_name(t *testing.T) {
 	logs := fake.Logs()
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: ps, Namespaces: nsList})
-	dc, err := testDynamic.Client()
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -354,6 +369,7 @@ func TestLog_taskrun_logs_no_pod_name(t *testing.T) {
 }
 
 func TestLog_taskrun_all_steps(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		prstart  = clockwork.NewFakeClock()
 		ns       = "namespace"
@@ -426,7 +442,11 @@ func TestLog_taskrun_all_steps(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
-	dc, err := testDynamic.Client()
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -445,6 +465,7 @@ func TestLog_taskrun_all_steps(t *testing.T) {
 }
 
 func TestLog_taskrun_given_steps(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		ns       = "namespace"
 		taskName = "output-task"
@@ -516,7 +537,10 @@ func TestLog_taskrun_given_steps(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
-	dc, err := testDynamic.Client()
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version))
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -533,6 +557,7 @@ func TestLog_taskrun_given_steps(t *testing.T) {
 }
 
 func TestLog_taskrun_follow_mode(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		prstart     = clockwork.NewFakeClock()
 		ns          = "namespace"
@@ -604,7 +629,11 @@ func TestLog_taskrun_follow_mode(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
-	dc, err := testDynamic.Client()
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -689,7 +718,8 @@ func TestLog_taskrun_last(t *testing.T) {
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: taskruns, Namespaces: namespaces})
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredTR(taskruns[0], "v1alpha1"),
 		cb.UnstructuredTR(taskruns[1], "v1alpha1"),
 	)
@@ -716,6 +746,7 @@ func TestLog_taskrun_last(t *testing.T) {
 }
 
 func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		prstart     = clockwork.NewFakeClock()
 		ns          = "namespace"
@@ -786,7 +817,11 @@ func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
-	dc, err := testDynamic.Client()
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -803,6 +838,7 @@ func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 }
 
 func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		prstart     = clockwork.NewFakeClock()
 		ns          = "namespace"
@@ -873,9 +909,12 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 	watcher := watch.NewRaceFreeFake()
-	cs.Pipeline.PrependWatchReactor("taskruns", k8stest.DefaultWatchReactor(watcher, nil))
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{WatchResource: "taskruns", Watcher: watcher}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -887,7 +926,7 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 		trs[0].Status.PodName = trPod
 		watcher.Modify(trs[0])
 	}()
-
+	//time.Sleep(time.Second * 2)
 	output, err := fetchLogs(trlo)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -902,6 +941,7 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 }
 
 func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		prstart     = clockwork.NewFakeClock()
 		ns          = "namespace"
@@ -972,9 +1012,12 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 	watcher := watch.NewRaceFreeFake()
-	cs.Pipeline.PrependWatchReactor("taskruns", k8stest.DefaultWatchReactor(watcher, nil))
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{WatchResource: "taskruns", Watcher: watcher}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
@@ -999,6 +1042,7 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 }
 
 func TestLog_taskrun_follow_mode_no_output_provided(t *testing.T) {
+	version := "v1alpha1"
 	var (
 		prstart     = clockwork.NewFakeClock()
 		ns          = "namespace"
@@ -1065,9 +1109,12 @@ func TestLog_taskrun_follow_mode_no_output_provided(t *testing.T) {
 	)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Pods: p, Namespaces: nsList})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 	watcher := watch.NewRaceFreeFake()
-	cs.Pipeline.PrependWatchReactor("taskruns", k8stest.DefaultWatchReactor(watcher, nil))
-	dc, err := testDynamic.Client()
+	tdc := testDynamic.Options{WatchResource: "taskruns", Watcher: watcher}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}

--- a/pkg/pipelinerun/pipelinerun_test.go
+++ b/pkg/pipelinerun/pipelinerun_test.go
@@ -69,8 +69,8 @@ func TestPipelinesList_with_single_run(t *testing.T) {
 		PipelineRuns: prdata,
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredPR(prdata[0], version),
 		cb.UnstructuredPR(prdata[1], version),
 		cb.UnstructuredPR(prdata[2], version),
@@ -166,8 +166,8 @@ func TestPipelinesList_with_single_run_v1beta1(t *testing.T) {
 		PipelineRuns: prdata,
 	})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-
-	dc, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
 		cb.UnstructuredPR(prdata[0], version),
 		cb.UnstructuredPR(prdata[1], version),
 		cb.UnstructuredPR(prdata[2], version),

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -76,7 +76,7 @@ func Get(c *cli.Clients, taskname string, opts metav1.GetOptions, ns string) (*v
 		return nil, err
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to list task from %s namespace \n", ns)
+		fmt.Fprintf(os.Stderr, "Failed to get task from %s namespace \n", ns)
 		return nil, err
 	}
 	return task, nil

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -26,7 +26,7 @@ import (
 )
 
 //Todo
-// changing this LastRun to use dynamic clinet leads to multiple other change in start commands
+// changing this LastRun to use dynamic client leads to multiple other change in start commands
 // keeping this as it is, will change this while working on start commands
 //LastRun returns the last taskrun for a given task
 func LastRun(tekton versioned.Interface, task string, ns string, kind string) (*v1alpha1.TaskRun, error) {

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -17,11 +17,17 @@ package task
 import (
 	"fmt"
 
+	"github.com/tektoncd/cli/pkg/cli"
+	trlist "github.com/tektoncd/cli/pkg/taskrun/list"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+//Todo
+// changing this LastRun to use dynamic clinet leads to multiple other change in start commands
+// keeping this as it is, will change this while working on start commands
 //LastRun returns the last taskrun for a given task
 func LastRun(tekton versioned.Interface, task string, ns string, kind string) (*v1alpha1.TaskRun, error) {
 	options := metav1.ListOptions{}
@@ -32,6 +38,34 @@ func LastRun(tekton versioned.Interface, task string, ns string, kind string) (*
 	}
 
 	runs, err := tekton.TektonV1alpha1().TaskRuns(ns).List(options)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(runs.Items) == 0 {
+		return nil, fmt.Errorf("no taskruns related to %s %s found in namespace %s", kind, task, ns)
+	}
+
+	latest := runs.Items[0]
+	for _, run := range runs.Items {
+		if run.CreationTimestamp.Time.After(latest.CreationTimestamp.Time) {
+			latest = run
+		}
+	}
+
+	return &latest, nil
+}
+
+//DynamicLastRun returns the last taskrun for a given task
+func DynamicLastRun(cs *cli.Clients, task string, ns string, kind string) (*v1beta1.TaskRun, error) {
+	options := metav1.ListOptions{}
+	if task != "" {
+		options = metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("tekton.dev/task=%s", task),
+		}
+	}
+
+	runs, err := trlist.TaskRuns(cs, options, ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/taskrun/get.go
+++ b/pkg/taskrun/get.go
@@ -1,0 +1,45 @@
+// Copyright © 2019-2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskrun
+
+import (
+	"fmt"
+	"os"
+
+	trget "github.com/tektoncd/cli/pkg/actions/get"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Get(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1beta1.TaskRun, error) {
+	trGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
+	unstructuredTR, err := trget.Get(trGroupResource, c, trname, ns, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var taskrun *v1beta1.TaskRun
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTR.UnstructuredContent(), &taskrun); err != nil {
+		return nil, err
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to list task from %s namespace \n", ns)
+		return nil, err
+	}
+	return taskrun, nil
+}

--- a/pkg/taskrun/get.go
+++ b/pkg/taskrun/get.go
@@ -38,7 +38,7 @@ func Get(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1b
 		return nil, err
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to list task from %s namespace \n", ns)
+		fmt.Fprintf(os.Stderr, "Failed to get taskrun from %s namespace \n", ns)
 		return nil, err
 	}
 	return taskrun, nil

--- a/pkg/taskrun/list/list_test.go
+++ b/pkg/taskrun/list/list_test.go
@@ -68,8 +68,8 @@ func TestPipelinesList_GetAllTaskRuns(t *testing.T) {
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
-
-	dynamic, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
 		cb.UnstructuredTR(trs[0], version),
 		cb.UnstructuredTR(trs[1], version),
 	)
@@ -160,8 +160,8 @@ func TestPipelinesList_GetAllTaskRuns_v1beta1(t *testing.T) {
 	version := "v1beta1"
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
-
-	dynamic, err := testDynamic.Client(
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
 		cb.UnstructuredTR(trs[0], version),
 		cb.UnstructuredTR(trs[1], version),
 	)

--- a/pkg/taskrun/watch.go
+++ b/pkg/taskrun/watch.go
@@ -1,0 +1,19 @@
+package taskrun
+
+import (
+	trwatch "github.com/tektoncd/cli/pkg/actions/watch"
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func Watch(c *cli.Clients, opts metav1.ListOptions, ns string) (watch.Interface, error) {
+	trGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
+	watch, err := trwatch.Watch(trGroupResource, c, ns, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return watch, nil
+}


### PR DESCRIPTION
this adds v1beta1 support for task and taskrun
adds option for dynmaic client creation

pipeline and pipelinerun logs with dynamic version detect is not
supported in this PR, only the test are modefied to work with
current change.

Signed-off-by: Pradeep Kumar pradkuma@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
