### PR TITLE
Use Timeout of --last or --use-pipelinerun/--use-taskrun for Start Commands

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -238,6 +238,7 @@ func (opt *startOptions) startPipeline(pipelineStart *v1alpha1.Pipeline) error {
 		pr.Spec.ServiceAccountName = usepr.Spec.ServiceAccountName
 		pr.Spec.ServiceAccountNames = usepr.Spec.ServiceAccountNames
 		pr.Spec.Workspaces = usepr.Spec.Workspaces
+		pr.Spec.Timeout = usepr.Spec.Timeout
 	}
 
 	if err := mergeRes(pr, opt.Resources); err != nil {

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  labels:
+    jemange: desfrites
+  namespace: ns
+spec:
+  params:
+  - name: pipeline-param
+    value: value1
+  pipelineRef:
+    name: test-pipeline
+  resources:
+  - name: source
+    resourceRef:
+      name: scaffold-git
+  serviceAccountName: svc1
+  timeout: 1s
+status: {}

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -206,6 +206,7 @@ func useTaskRunFrom(opt startOptions, tr *v1alpha1.TaskRun, cs *cli.Clients, tna
 	tr.Spec.Outputs = trUsed.Spec.Outputs
 	tr.Spec.ServiceAccountName = trUsed.Spec.ServiceAccountName
 	tr.Spec.Workspaces = trUsed.Spec.Workspaces
+	tr.Spec.Timeout = trUsed.Spec.Timeout
 
 	return nil
 }
@@ -222,13 +223,6 @@ func startTask(opt startOptions, args []string) error {
 	}
 
 	var tname string
-
-	timeoutDuration, err := time.ParseDuration(opt.TimeOut)
-	if err != nil {
-		return err
-	}
-	tr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
-
 	if len(args) > 0 {
 		tname = args[0]
 		tr.Spec = v1alpha1.TaskRunSpec{
@@ -244,6 +238,12 @@ func startTask(opt startOptions, args []string) error {
 			TaskSpec: &task.Spec,
 		}
 	}
+
+	timeoutDuration, err := time.ParseDuration(opt.TimeOut)
+	if err != nil {
+		return err
+	}
+	tr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
 
 	if opt.PrefixName == "" {
 		tr.ObjectMeta.GenerateName = tname + "-run-"

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
@@ -18,6 +18,6 @@ spec:
   serviceAccountName: svc1
   taskRef:
     name: task-1
-  timeout: 1h0m0s
+  timeout: 1s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
@@ -47,5 +47,6 @@ spec:
       image: gcr.io/kaniko-project/executor:v0.14.0
       name: build-and-push
       resources: {}
+  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -11,6 +11,7 @@
 		"taskRef": {
 			"name": "task-1"
 		},
+		"timeout": "1h0m0s",
 		"inputs": {
 			"resources": [
 				{


### PR DESCRIPTION
Closes #862
Closes #488  

# Changes

When using `tkn p start` with the `--last` flag or `--use-pipelinerun` flag, the timeout of the previous value isn't applied as described in #862. This pull request updates both `tkn p start` and `tkn t start` to use the timeout values of the previous PipelineRun or TaskRun.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Use timeout value with --last and --use-pipelinerun/--use-taskrun with start commands
```
