### PR TITLE
Read defaultTimeout for TaskRun and PipelineRun set in config-defaults

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -39,7 +39,7 @@ like cat,foo,bar
   -p, --param stringArray        pass the param as key=value or key=value1,value2
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the clustertask
-  -t, --timeout int              timeout for taskrun in seconds (default 3600)
+  -t, --timeout string           timeout for taskrun (default "1h")
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -60,8 +60,8 @@ Start clustertasks
     show logs right after starting the clustertask
 
 .PP
-\fB\-t\fP, \fB\-\-timeout\fP=3600
-    timeout for taskrun in seconds
+\fB\-t\fP, \fB\-\-timeout\fP="1h"
+    timeout for taskrun
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
@@ -47,5 +47,6 @@ spec:
       image: gcr.io/kaniko-project/executor:v0.14.0
       name: build-and-push
       resources: {}
+  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -18,5 +18,6 @@ spec:
   serviceAccountName: svc1
   taskRef:
     name: task-1
+  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -11,6 +11,7 @@
 		"taskRef": {
 			"name": "task-1"
 		},
+		"timeout": "1h0m0s",
 		"inputs": {
 			"resources": [
 				{

--- a/pkg/config/config-defaults.go
+++ b/pkg/config/config-defaults.go
@@ -1,0 +1,46 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tektoncd/cli/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const pipelineNamespace = "tekton-pipelines"
+const configDefaultsName = "config-defaults"
+
+// GetPipelineVersion Get pipeline version, functions imported from Dashboard
+func getConfigDefaults(c *cli.Clients) (*v1.ConfigMap, error) {
+	configDefaults, err := c.Kube.CoreV1().ConfigMaps(pipelineNamespace).Get(configDefaultsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return configDefaults, nil
+}
+
+func GetDefaultTimeout(c *cli.Clients) (string, error) {
+	defaultTimeoutKey := "default-timeout-minutes"
+	onehour := "1h"
+	configDefaults, err := getConfigDefaults(c)
+	if err != nil {
+		return onehour, err
+	}
+
+	defaultTimeout := configDefaults.Data[defaultTimeoutKey]
+	return defaultTimeout, nil
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Read defaultTimeout for TaskRun and PipelineRun set in config-defaults

When `tkn task/pipeline start` is used, the default timeout value
configured in the config-defaults template is not consumed, and
the default timeout is taken as "1h".
To avoid this, we are reading the config-defaults ConfigMap in the
tekton-pipelines namespace and reading from key "default-timeout-minutes"
for the value of the default timeout set byt the user for their
instance of the pipeline controller.

# Changes
- Added `/pkg/config/config-default.go` which helps get the configMap `config-defaults` to check the TaskRun. 
- Used the above in `/pkg/cmd/{task,clustertask,pipeline}/start.go
- Removed support for `int64` typed timeout values and added support for `string` typed timeout values as it is done in task and clustertask

fixes #865 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
