### PR TITLE
Bump tektoncd/triggers to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/pipeline v0.11.0
 	github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2
-	github.com/tektoncd/triggers v0.4.0-rc1
+	github.com/tektoncd/triggers v0.4.0
 	github.com/tidwall/gjson v1.6.0 // indirect
 	github.com/tidwall/sjson v1.0.4 // indirect
 	go.opencensus.io v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,8 @@ github.com/tektoncd/pipeline v0.11.0/go.mod h1:hlkH32S92+/UODROH0dmxzyuMxfRFp/Nc
 github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2 h1:BksmpUwtap3THXJ8Z4KGcotsvpRdFQKySjDHgtc22lA=
 github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2/go.mod h1:QZHgU07PRBTRF6N57w4+ApRu8OgfYLFNqCDlfEZaD9Y=
 github.com/tektoncd/plumbing/pipelinerun-logs v0.0.0-20191206114338-712d544c2c21/go.mod h1:S62EUWtqmejjJgUMOGB1CCCHRp6C706laH06BoALkzU=
-github.com/tektoncd/triggers v0.4.0-rc1 h1:IAMJfKRz6H32wahxQD036y58zPROU0A5jj6IqvtckHg=
-github.com/tektoncd/triggers v0.4.0-rc1/go.mod h1:sf5zayuDu6gUI4JsCYDunukfrb1ng/Lz0FoWcJ0cFt4=
+github.com/tektoncd/triggers v0.4.0 h1:pTH/EoiexafOiOmN6pvCJDxXQPzkH2p4woJqXdIXj38=
+github.com/tektoncd/triggers v0.4.0/go.mod h1:sf5zayuDu6gUI4JsCYDunukfrb1ng/Lz0FoWcJ0cFt4=
 github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
 github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_types.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_types.go
@@ -43,7 +43,7 @@ type ClusterTriggerBinding struct {
 	Spec TriggerBindingSpec `json:"spec,omitempty"`
 
 	// +optional
-	Status TriggerBindingStatus `json:"status"`
+	Status TriggerBindingStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -47,7 +47,7 @@ type EventListener struct {
 	// +optional
 	Spec EventListenerSpec `json:"spec"`
 	// +optional
-	Status EventListenerStatus `json:"status"`
+	Status EventListenerStatus `json:"status,omitempty"`
 }
 
 // EventListenerSpec defines the desired state of the EventListener, represented

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_binding_types.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_binding_types.go
@@ -62,7 +62,7 @@ type TriggerBinding struct {
 	// +optional
 	Spec TriggerBindingSpec `json:"spec"`
 	// +optional
-	Status TriggerBindingStatus `json:"status"`
+	Status TriggerBindingStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -70,7 +70,7 @@ type TriggerTemplate struct {
 	// +optional
 	Spec TriggerTemplateSpec `json:"spec"`
 	// +optional
-	Status TriggerTemplateStatus `json:"status"`
+	Status TriggerTemplateStatus `json:"status,omitempty"`
 }
 
 // TriggerTemplateList contains a list of TriggerTemplate

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -328,7 +328,7 @@ github.com/tektoncd/pipeline/test/builder
 github.com/tektoncd/pipeline/test/v1alpha1
 # github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2
 github.com/tektoncd/plumbing/scripts
-# github.com/tektoncd/triggers v0.4.0-rc1
+# github.com/tektoncd/triggers v0.4.0
 github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1
 github.com/tektoncd/triggers/pkg/client/clientset/versioned
 github.com/tektoncd/triggers/pkg/client/clientset/versioned/fake


### PR DESCRIPTION
This will bump tektoncd/triggers dependency
in cli to v0.4.0

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Bumping tektoncd/triggers to v0.4.0
```
