### PR TITLE
fix tasrun cancel command

### DIFF
--- a/pkg/actions/patch.go
+++ b/pkg/actions/patch.go
@@ -19,18 +19,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-func Update(gr schema.GroupVersionResource, clients *cli.Clients, obj *unstructured.Unstructured, opts metav1.UpdateOptions, ns string) (*unstructured.Unstructured, error) {
+func Patch(gr schema.GroupVersionResource, clients *cli.Clients, objName string, data []byte, opt metav1.PatchOptions, ns string) (*unstructured.Unstructured, error) {
 	gvr, err := GetGroupVersionResource(gr, clients.Tekton.Discovery())
 	if err != nil {
 		return nil, err
 	}
-
-	updatedObj, err := clients.Dynamic.Resource(*gvr).Namespace(ns).Update(obj, opts)
+	patchedObj, err := clients.Dynamic.Resource(*gvr).Namespace(ns).Patch(objName, types.JSONPatchType, data, opt)
 	if err != nil {
 		return nil, err
 	}
 
-	return updatedObj, nil
+	return patchedObj, nil
 }

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -753,7 +753,7 @@ func (opt *startOptions) getInputWorkspaces(pipeline *v1alpha1.Pipeline) error {
 			if err != nil {
 				return err
 			}
-			workspace = workspace + items
+			workspace += items
 		case "secret":
 			secret, err := askParam("Name of the secret :", opt.askOpts)
 			if err != nil {
@@ -764,7 +764,7 @@ func (opt *startOptions) getInputWorkspaces(pipeline *v1alpha1.Pipeline) error {
 			if err != nil {
 				return err
 			}
-			workspace = workspace + items
+			workspace += items
 		}
 		opt.Workspaces = append(opt.Workspaces, workspace)
 

--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -20,9 +20,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
-	traction "github.com/tektoncd/cli/pkg/taskrun"
+	"github.com/tektoncd/cli/pkg/taskrun"
 	"github.com/tektoncd/cli/pkg/validate"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -71,7 +70,7 @@ func cancelTaskRun(p cli.Params, s *cli.Stream, trName string) error {
 		return fmt.Errorf("failed to create tekton client")
 	}
 
-	tr, err := traction.Get(cs, trName, metav1.GetOptions{}, p.Namespace())
+	tr, err := taskrun.Get(cs, trName, metav1.GetOptions{}, p.Namespace())
 	if err != nil {
 		return fmt.Errorf("failed to find taskrun: %s", trName)
 	}
@@ -81,8 +80,7 @@ func cancelTaskRun(p cli.Params, s *cli.Stream, trName string) error {
 		return fmt.Errorf("failed to cancel taskrun %s: taskrun has already finished execution", trName)
 	}
 
-	tr.Spec.Status = v1beta1.TaskRunSpecStatusCancelled
-	if _, err := traction.Update(cs, tr, metav1.UpdateOptions{}, p.Namespace()); err != nil {
+	if _, err := taskrun.Patch(cs, trName, metav1.PatchOptions{}, p.Namespace()); err != nil {
 		return fmt.Errorf("failed to cancel taskrun %q: %s", trName, err)
 	}
 

--- a/pkg/cmd/taskrun/cancel_test.go
+++ b/pkg/cmd/taskrun/cancel_test.go
@@ -112,7 +112,7 @@ func TestTaskRunCancel(t *testing.T) {
 
 	cs2, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs2, Namespaces: ns})
 	cs2.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun"})
-	tdc2 := testDynamic.Options{Verb: "update", Resource: "taskruns", Action: func(action k8stest.Action) (bool, runtime.Object, error) {
+	tdc2 := testDynamic.Options{Verb: "patch", Resource: "taskruns", Action: func(action k8stest.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("test error")
 	}}
 	dc2, err := tdc2.Client(
@@ -131,10 +131,6 @@ func TestTaskRunCancel(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
-
-	cs2.Pipeline.PrependReactor("update", "taskruns", func(action k8stest.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("test error")
-	})
 
 	seeds = append(seeds, clients{pipelineClient: cs, dynamicClient: dc})
 	failures = append(failures, clients{pipelineClient: cs2, dynamicClient: dc2})
@@ -298,7 +294,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 
 	cs2, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs2, Namespaces: ns})
 	cs2.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun"})
-	tdc2 := testDynamic.Options{Verb: "update", Resource: "taskruns", Action: func(action k8stest.Action) (bool, runtime.Object, error) {
+	tdc2 := testDynamic.Options{Verb: "patch", Resource: "taskruns", Action: func(action k8stest.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("test error")
 	}}
 	dc2, err := tdc2.Client(
@@ -317,10 +313,6 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic clinet: %v", err)
 	}
-
-	cs2.Pipeline.PrependReactor("update", "taskruns", func(action k8stest.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("test error")
-	})
 
 	seeds = append(seeds, clients{pipelineClient: cs, dynamicClient: dc})
 	failures = append(failures, clients{pipelineClient: cs2, dynamicClient: dc2})


### PR DESCRIPTION
fix #876

to cancel a taskrun earlier cli was updating the taskrun
update with dynamic clinet sometimes failed while marshelling

the current fix use patch instead of update

fix linting issue in pipeline start command

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
