### PR TITLE
v1beta1 support for pipelinerun cancel

### DIFF
--- a/pkg/taskrun/get.go
+++ b/pkg/taskrun/get.go
@@ -38,7 +38,7 @@ func Get(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1b
 		return nil, err
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get taskrun from %s namespace \n", ns)
+		fmt.Fprintf(os.Stderr, "failed to get taskrun from %s namespace \n", ns)
 		return nil, err
 	}
 	return taskrun, nil


### PR DESCRIPTION
this adds v1beta1 support for tkn pipelinerun cancel subcommand
instead of update status is patched for cancelled pipelinerun

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
