### PR TITLE
Sort TaskRuns by Start Time for tkn task describe

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/task"
 	"github.com/tektoncd/cli/pkg/taskrun/list"
+	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
 	"github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -189,6 +190,7 @@ func printTaskDescription(s *cli.Stream, p cli.Params, tname string) error {
 		fmt.Fprintf(s.Err, "failed to get taskruns for task %s \n", tname)
 		return err
 	}
+	trsort.SortByStartTime(taskRuns.Items)
 
 	var data = struct {
 		Task     *v1beta1.Task

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
@@ -31,6 +31,6 @@ Steps
 Taskruns
 
 NAME   STARTED          DURATION    STATUS
-tr-1   20 minutes ago   5 minutes   Failed
 tr-2   10 minutes ago   7 minutes   Succeeded
+tr-1   20 minutes ago   5 minutes   Failed
 

--- a/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
@@ -31,6 +31,6 @@ Steps
 Taskruns
 
 NAME   STARTED          DURATION    STATUS
-tr-1   20 minutes ago   5 minutes   Failed
 tr-2   10 minutes ago   7 minutes   Succeeded
+tr-1   20 minutes ago   5 minutes   Failed
 


### PR DESCRIPTION
Part of #839 

This pull request changes the sorting of TaskRuns for `tkn task desc` to being sorted by start time instead of by name. Also updates associated tests to reflect the sorting difference. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Sort TaskRuns by start time as part of tkn task describe 
```
