### PR TITLE
Bump taskrun describe to v1beta1

### DIFF
--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -70,7 +70,7 @@ func cancelTaskRun(p cli.Params, s *cli.Stream, trName string) error {
 		return fmt.Errorf("failed to create tekton client")
 	}
 
-	tr, err := taskrun.Get(cs, trName, metav1.GetOptions{}, p.Namespace())
+	tr, err := taskrun.GetV1beta1(cs, trName, metav1.GetOptions{}, p.Namespace())
 	if err != nil {
 		return fmt.Errorf("failed to find taskrun: %s", trName)
 	}

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
+	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	tb "github.com/tektoncd/pipeline/test/builder"
@@ -71,14 +72,21 @@ func TestTaskRunDescribe_not_found(t *testing.T) {
 			},
 		},
 	})
-	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+
+	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client()
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
 
 	taskrun := Command(p)
-	_, err := test.ExecuteCommand(taskrun, "desc", "bar", "-n", "ns")
+	_, err = test.ExecuteCommand(taskrun, "desc", "bar", "-n", "ns")
 	if err == nil {
 		t.Errorf("Expected error but did not get one")
 	}
-	expected := "failed to find taskrun \"bar\""
+	expected := "taskruns.tekton.dev \"bar\" not found"
 	test.AssertOutput(t, expected, err.Error())
 }
 
@@ -109,8 +117,19 @@ func TestTaskRunDescribe_empty_taskrun(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
-
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
 	actual, err := test.ExecuteCommand(taskrun, "desc", "tr-1", "-n", "ns")
@@ -163,7 +182,19 @@ func TestTaskRunDescribe_only_taskrun(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -205,7 +236,19 @@ func TestTaskRunDescribe_failed(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -244,7 +287,19 @@ func TestTaskRunDescribe_no_taskref(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -298,7 +353,19 @@ func TestTaskRunDescribe_no_resourceref(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -358,7 +425,19 @@ func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures(t *testing.T)
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -417,7 +496,19 @@ func TestTaskRunDescribe_step_status_pending_one_sidecar(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -480,7 +571,19 @@ func TestTaskRunDescribe_step_status_running_multiple_sidecars(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -519,7 +622,19 @@ func TestTaskRunDescribe_cancel_taskrun(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
 
 	taskrun := Command(p)
 	clock.Advance(10 * time.Minute)
@@ -530,7 +645,7 @@ func TestTaskRunDescribe_cancel_taskrun(t *testing.T) {
 	golden.Assert(t, actual, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineRunsDescribe_custom_output(t *testing.T) {
+func TestTaskRunDescribe_custom_output(t *testing.T) {
 	name := "task-run"
 	expected := "taskrun.tekton.dev/" + name
 
@@ -551,10 +666,22 @@ func TestPipelineRunsDescribe_custom_output(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube}
-	pipelinerun := Command(p)
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic, Clock: clock}
+	taskrun := Command(p)
 
-	got, err := test.ExecuteCommand(pipelinerun, "desc", "-o", "name", "-n", "ns", name)
+	got, err := test.ExecuteCommand(taskrun, "desc", "-o", "name", "-n", "ns", name)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -565,7 +692,7 @@ func TestPipelineRunsDescribe_custom_output(t *testing.T) {
 	}
 }
 
-func TestTaskRunDescribe_custom_timeout(t *testing.T) {
+func TestTaskRunWithSpecDescribe_custom_timeout(t *testing.T) {
 	trs := []*v1alpha1.TaskRun{
 		tb.TaskRun("tr-custom-timeout", "ns",
 			tb.TaskRunSpec(tb.TaskRunTimeout(time.Minute)),
@@ -583,7 +710,19 @@ func TestTaskRunDescribe_custom_timeout(t *testing.T) {
 		},
 	})
 
-	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredTR(trs[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
 
 	taskrun := Command(p)
 	actual, err := test.ExecuteCommand(taskrun, "desc", "tr-custom-timeout", "-n", "ns")

--- a/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
@@ -1,0 +1,28 @@
+Name:        tr-custom-timeout
+Namespace:   ns
+Timeout:     1m0s
+
+Status
+
+STARTED    DURATION    STATUS
+---        ---         ---
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Steps
+
+No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/log/task_reader.go
+++ b/pkg/log/task_reader.go
@@ -45,7 +45,7 @@ func (s *step) hasStarted() bool {
 }
 
 func (r *Reader) readTaskLog() (<-chan Log, <-chan error, error) {
-	tr, err := tr.Get(r.clients, r.run, metav1.GetOptions{}, r.ns)
+	tr, err := tr.GetV1beta1(r.clients, r.run, metav1.GetOptions{}, r.ns)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s: %s", MsgTRNotFoundErr, err)
 	}
@@ -191,7 +191,7 @@ func (r *Reader) waitUntilTaskPodNameAvailable(timeout time.Duration) (*v1beta1.
 	opts := metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("metadata.name", r.run).String(),
 	}
-	run, err := tr.Get(r.clients, r.run, metav1.GetOptions{}, r.ns)
+	run, err := tr.GetV1beta1(r.clients, r.run, metav1.GetOptions{}, r.ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -68,7 +68,7 @@ func List(c *cli.Clients, opts metav1.ListOptions, ns string) (*v1beta1.TaskList
 
 // It will fetch the resource based on the api available and return v1beta1 form
 func Get(c *cli.Clients, taskname string, opts metav1.GetOptions, ns string) (*v1beta1.Task, error) {
-	gvr, err := actions.GetGroupVersionResource(schema.GroupVersionResource{Group: "tekton.dev", Resource: "tasks"}, c.Tekton.Discovery())
+	gvr, err := actions.GetGroupVersionResource(taskGroupResource, c.Tekton.Discovery())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/taskrun/description/description_test.go
+++ b/pkg/taskrun/description/description_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_SortStepStatesByStartTime_Waiting_Not_Nil(t *testing.T) {
-	stepStates := []v1alpha1.StepState{
+	stepStates := []v1beta1.StepState{
 		{
 			Name: "step1",
 			ContainerState: corev1.ContainerState{
@@ -57,7 +57,7 @@ func Test_SortStepStatesByStartTime_Waiting_Not_Nil(t *testing.T) {
 }
 
 func Test_SortStepStatesByStartTime_Step1_Running(t *testing.T) {
-	stepStates := []v1alpha1.StepState{
+	stepStates := []v1beta1.StepState{
 		{
 			Name: "step1",
 			ContainerState: corev1.ContainerState{
@@ -90,7 +90,7 @@ func Test_SortStepStatesByStartTime_Step1_Running(t *testing.T) {
 }
 
 func Test_SortStepStatesByStartTime_Step2_Running(t *testing.T) {
-	stepStates := []v1alpha1.StepState{
+	stepStates := []v1beta1.StepState{
 		{
 			Name: "step1",
 			ContainerState: corev1.ContainerState{
@@ -123,7 +123,7 @@ func Test_SortStepStatesByStartTime_Step2_Running(t *testing.T) {
 }
 
 func Test_SortStepStatesByStartTime_Both_Steps_Running(t *testing.T) {
-	stepStates := []v1alpha1.StepState{
+	stepStates := []v1beta1.StepState{
 		{
 			Name: "step1",
 			ContainerState: corev1.ContainerState{
@@ -156,7 +156,7 @@ func Test_SortStepStatesByStartTime_Both_Steps_Running(t *testing.T) {
 }
 
 func Test_SortStepStatesByStartTime_Steps_Terminated_And_Running(t *testing.T) {
-	stepStates := []v1alpha1.StepState{
+	stepStates := []v1beta1.StepState{
 		{
 			Name: "step1",
 			ContainerState: corev1.ContainerState{

--- a/pkg/taskrun/get.go
+++ b/pkg/taskrun/get.go
@@ -15,19 +15,45 @@
 package taskrun
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var trGroupResource = schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
+
+// It will fetch the resource based on the api available and return v1beta1 form
 func Get(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1beta1.TaskRun, error) {
-	trGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
+	gvr, err := actions.GetGroupVersionResource(trGroupResource, c.Tekton.Discovery())
+	if err != nil {
+		return nil, err
+	}
+
+	if gvr.Version == "v1alpha1" {
+		taskrun, err := getV1alpha1(c, trname, opts, ns)
+		if err != nil {
+			return nil, err
+		}
+		var taskrunConverted v1beta1.TaskRun
+		err = taskrun.ConvertUp(context.Background(), &taskrunConverted)
+		if err != nil {
+			return nil, err
+		}
+		return &taskrunConverted, nil
+	}
+	return GetV1beta1(c, trname, opts, ns)
+}
+
+// It will fetch the resource in v1beta1 struct format
+func GetV1beta1(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1beta1.TaskRun, error) {
 	unstructuredTR, err := actions.Get(trGroupResource, c, trname, ns, opts)
 	if err != nil {
 		return nil, err
@@ -35,9 +61,21 @@ func Get(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1b
 
 	var taskrun *v1beta1.TaskRun
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTR.UnstructuredContent(), &taskrun); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get taskrun from %s namespace \n", ns)
 		return nil, err
 	}
+	return taskrun, nil
+}
+
+// It will fetch the resource in v1alpha1 struct format
+func getV1alpha1(c *cli.Clients, trname string, opts metav1.GetOptions, ns string) (*v1alpha1.TaskRun, error) {
+	unstructuredTR, err := actions.Get(trGroupResource, c, trname, ns, opts)
 	if err != nil {
+		return nil, err
+	}
+
+	var taskrun *v1alpha1.TaskRun
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTR.UnstructuredContent(), &taskrun); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get taskrun from %s namespace \n", ns)
 		return nil, err
 	}

--- a/pkg/taskrun/get_test.go
+++ b/pkg/taskrun/get_test.go
@@ -1,0 +1,181 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskrun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
+	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+func TestTaskRunGet(t *testing.T) {
+	version := "v1alpha1"
+	clock := clockwork.NewFakeClock()
+	tr1Started := clock.Now().Add(10 * time.Second)
+	runDuration := 1 * time.Minute
+
+	trdata := []*v1alpha1.TaskRun{
+		tb.TaskRun("taskrun1", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "task"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind("Task"))),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+				tb.TaskRunStartTime(tr1Started),
+				cb.TaskRunCompletionTime(tr1Started.Add(runDuration)),
+			),
+		),
+		tb.TaskRun("taskrun2", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "task"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind("Task"))),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+				tb.TaskRunStartTime(tr1Started),
+				cb.TaskRunCompletionTime(tr1Started.Add(runDuration)),
+			),
+		),
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		TaskRuns: trdata,
+	})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredTR(trdata[0], version),
+		cb.UnstructuredTR(trdata[1], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic clinet: %v", err)
+	}
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
+	c, err := p.Clients()
+	if err != nil {
+		t.Errorf("unable to create client: %v", err)
+	}
+
+	got, err := Get(c, "taskrun1", metav1.GetOptions{}, "ns")
+	if err != nil {
+		t.Errorf("unexpected Error")
+	}
+	test.AssertOutput(t, "taskrun1", got.Name)
+}
+
+func TestTaskGet_v1beta1(t *testing.T) {
+	version := "v1beta1"
+	clock := clockwork.NewFakeClock()
+	tr1Started := clock.Now().Add(10 * time.Second)
+	runDuration := 1 * time.Minute
+
+	trdata := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrun1",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "task"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task",
+					Kind: "Task",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: tr1Started},
+					CompletionTime: &metav1.Time{Time: tr1Started.Add(runDuration)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrun2",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "task"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task",
+					Kind: "Task",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: tr1Started},
+					CompletionTime: &metav1.Time{Time: tr1Started.Add(runDuration)},
+				},
+			},
+		},
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
+		TaskRuns: trdata,
+	})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredV1beta1TR(trdata[0], version),
+		cb.UnstructuredV1beta1TR(trdata[1], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic clinet: %v", err)
+	}
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
+	c, err := p.Clients()
+	if err != nil {
+		t.Errorf("unable to create client: %v", err)
+	}
+
+	got, err := Get(c, "taskrun1", metav1.GetOptions{}, "ns")
+	if err != nil {
+		t.Errorf("unexpected Error")
+	}
+	test.AssertOutput(t, "taskrun1", got.Name)
+}

--- a/pkg/taskrun/sort/by_namespace.go
+++ b/pkg/taskrun/sort/by_namespace.go
@@ -1,3 +1,17 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package taskrun
 
 import (

--- a/pkg/taskrun/sort/by_namespace_test.go
+++ b/pkg/taskrun/sort/by_namespace_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package taskrun
 
 import (

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/cli/pkg/formatted"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
@@ -51,7 +50,7 @@ func NamespaceExists(p params) error {
 }
 
 // Check if TaskRef exists on a TaskRunSpec. Returns empty string if not present.
-func TaskRefExists(spec v1alpha1.TaskRunSpec) string {
+func TaskRefExists(spec v1beta1.TaskRunSpec) string {
 
 	if spec.TaskRef == nil {
 		return fieldNotPresent
@@ -81,7 +80,7 @@ func PipelineResourceRefExists(res v1beta1.PipelineResourceBinding) string {
 }
 
 // Check if TaskResourceRef exists on a TaskResourceBinding. Returns empty string if not present.
-func TaskResourceRefExists(res v1alpha1.TaskResourceBinding) string {
+func TaskResourceRefExists(res v1beta1.TaskResourceBinding) string {
 
 	if res.ResourceRef == nil {
 		return fieldNotPresent
@@ -91,7 +90,7 @@ func TaskResourceRefExists(res v1alpha1.TaskResourceBinding) string {
 }
 
 // Check if step is in waiting, running, or terminated state by checking StepState of the step.
-func StepReasonExists(state v1alpha1.StepState) string {
+func StepReasonExists(state v1beta1.StepState) string {
 
 	if state.Waiting == nil {
 
@@ -110,7 +109,7 @@ func StepReasonExists(state v1alpha1.StepState) string {
 }
 
 // Check if sidecar is in waiting, running, or terminated state by checking SidecarState of the sidecar.
-func SidecarReasonExists(state v1alpha1.SidecarState) string {
+func SidecarReasonExists(state v1beta1.SidecarState) string {
 
 	if state.Waiting == nil {
 

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -19,9 +19,8 @@ import (
 	"time"
 
 	"github.com/tektoncd/cli/pkg/test"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,7 +33,7 @@ func TestNamespaceExists_Invalid_Namespace(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns})
 	p := &test.Params{Kube: cs.Kube}
 	p.SetNamespace("foo")
 
@@ -50,7 +49,7 @@ func TestNamespaceExists_Valid_Namespace(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns})
 	p := &test.Params{Kube: cs.Kube}
 
 	err := NamespaceExists(p)
@@ -58,8 +57,8 @@ func TestNamespaceExists_Valid_Namespace(t *testing.T) {
 }
 
 func TestTaskRefExists_Present(t *testing.T) {
-	spec := v1alpha1.TaskRunSpec{
-		TaskRef: &v1alpha1.TaskRef{
+	spec := v1beta1.TaskRunSpec{
+		TaskRef: &v1beta1.TaskRef{
 			Name: "Task",
 		},
 	}
@@ -69,7 +68,7 @@ func TestTaskRefExists_Present(t *testing.T) {
 }
 
 func TestTaskRefExists_Not_Present(t *testing.T) {
-	spec := v1alpha1.TaskRunSpec{
+	spec := v1beta1.TaskRunSpec{
 		TaskRef: nil,
 	}
 
@@ -118,9 +117,9 @@ func TestPipelineResourceRefExists_Not_Present(t *testing.T) {
 }
 
 func TestTaskResourceRefExists_Present(t *testing.T) {
-	res := v1alpha1.TaskResourceBinding{
-		PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-			ResourceRef: &v1alpha1.PipelineResourceRef{
+	res := v1beta1.TaskResourceBinding{
+		PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+			ResourceRef: &v1beta1.PipelineResourceRef{
 				Name: "Resource",
 			},
 		},
@@ -131,8 +130,8 @@ func TestTaskResourceRefExists_Present(t *testing.T) {
 }
 
 func TestTaskResourceRefExists_Not_Present(t *testing.T) {
-	res := v1alpha1.TaskResourceBinding{
-		PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+	res := v1beta1.TaskResourceBinding{
+		PipelineResourceBinding: v1beta1.PipelineResourceBinding{
 			ResourceRef: nil,
 		},
 	}
@@ -142,14 +141,14 @@ func TestTaskResourceRefExists_Not_Present(t *testing.T) {
 }
 
 func TestStepReasonExists_Terminated_Not_Present(t *testing.T) {
-	state := v1alpha1.StepState{}
+	state := v1beta1.StepState{}
 
 	output := StepReasonExists(state)
 	test.AssertOutput(t, "---", output)
 }
 
 func TestStepReasonExists_Terminated_Present(t *testing.T) {
-	state := v1alpha1.StepState{
+	state := v1beta1.StepState{
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
 				Reason: "Completed",
@@ -162,7 +161,7 @@ func TestStepReasonExists_Terminated_Present(t *testing.T) {
 }
 
 func TestStepReasonExists_Running_Present(t *testing.T) {
-	state := v1alpha1.StepState{
+	state := v1beta1.StepState{
 		ContainerState: corev1.ContainerState{
 			Running: &corev1.ContainerStateRunning{
 				StartedAt: metav1.Time{
@@ -177,7 +176,7 @@ func TestStepReasonExists_Running_Present(t *testing.T) {
 }
 
 func TestStepReasonExists_Waiting_Present(t *testing.T) {
-	state := v1alpha1.StepState{
+	state := v1beta1.StepState{
 		ContainerState: corev1.ContainerState{
 			Waiting: &corev1.ContainerStateWaiting{
 				Reason: "PodInitializing",
@@ -190,14 +189,14 @@ func TestStepReasonExists_Waiting_Present(t *testing.T) {
 }
 
 func TestSidecarReasonExists_Terminated_Not_Present(t *testing.T) {
-	state := v1alpha1.SidecarState{}
+	state := v1beta1.SidecarState{}
 
 	output := SidecarReasonExists(state)
 	test.AssertOutput(t, "---", output)
 }
 
 func TestSidecarReasonExists_Terminated_Present(t *testing.T) {
-	state := v1alpha1.SidecarState{
+	state := v1beta1.SidecarState{
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
 				Reason: "Completed",
@@ -210,7 +209,7 @@ func TestSidecarReasonExists_Terminated_Present(t *testing.T) {
 }
 
 func TestSidecarReasonExists_Running_Present(t *testing.T) {
-	state := v1alpha1.SidecarState{
+	state := v1beta1.SidecarState{
 		ContainerState: corev1.ContainerState{
 			Running: &corev1.ContainerStateRunning{
 				StartedAt: metav1.Time{
@@ -225,7 +224,7 @@ func TestSidecarReasonExists_Running_Present(t *testing.T) {
 }
 
 func TestSidecarReasonExists_Waiting_Present(t *testing.T) {
-	state := v1alpha1.SidecarState{
+	state := v1beta1.SidecarState{
 		ContainerState: corev1.ContainerState{
 			Waiting: &corev1.ContainerStateWaiting{
 				Reason: "PodInitializing",


### PR DESCRIPTION
This will bump taskrun describe for v1beta1
make the necessary changes in template
and do other refactoring for supporting
both v1alpha1 and v1beta1

Fix e2e

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Bump taskrun describe to v1beta1
```
