### PR TITLE
Provides an interactive Prompt to select a PipelineRun/TaskRun 

### DIFF
--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -29,7 +29,9 @@ or
 
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -F, --fzf                           use fzf to select a pipelinerun to describe
   -h, --help                          help for describe
+      --limit int                     lists number of pipelineruns when selecting a pipelinerun to describe (default 5)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -29,7 +29,9 @@ or
 
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -F, --fzf                           use fzf to select a taskrun to describe
   -h, --help                          help for describe
+      --limit int                     lists number of taskruns when selecting a taskrun to describe (default 5)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -24,8 +24,16 @@ Describe a pipelinerun in a namespace
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
+\fB\-F\fP, \fB\-\-fzf\fP[=false]
+    use fzf to select a pipelinerun to describe
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for describe
+
+.PP
+\fB\-\-limit\fP=5
+    lists number of pipelineruns when selecting a pipelinerun to describe
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -24,8 +24,16 @@ Describe a taskrun in a namespace
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
+\fB\-F\fP, \fB\-\-fzf\fP[=false]
+    use fzf to select a taskrun to describe
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for describe
+
+.PP
+\fB\-\-limit\fP=5
+    lists number of taskruns when selecting a taskrun to describe
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/clustertask"
 	"github.com/tektoncd/cli/pkg/formatted"
+	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/task"
 	"github.com/tektoncd/cli/pkg/taskrun/list"
 	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
@@ -114,6 +115,7 @@ NAME	STARTED	DURATION	STATUS
 
 func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
+	opts := &options.DescribeOptions{Params: p}
 	eg := `Describe a ClusterTask of name 'foo':
 
     tkn clustertask describe foo
@@ -131,7 +133,6 @@ or
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
@@ -145,12 +146,21 @@ or
 				return err
 			}
 
-			if output != "" {
-				clustertaskGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "clustertasks"}
-				return actions.PrintObject(clustertaskGroupResource, args[0], cmd.OutOrStdout(), p, f, "")
+			if len(args) == 0 {
+				err = askClusterTaskName(opts, p)
+				if err != nil {
+					return err
+				}
+			} else {
+				opts.ClusterTaskName = args[0]
 			}
 
-			return printClusterTaskDescription(s, p, args[0])
+			if output != "" {
+				clustertaskGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "clustertasks"}
+				return actions.PrintObject(clustertaskGroupResource, opts.ClusterTaskName, cmd.OutOrStdout(), p, f, "")
+			}
+
+			return printClusterTaskDescription(s, p, opts.ClusterTaskName)
 		},
 	}
 
@@ -233,4 +243,25 @@ func sortResourcesByTypeAndName(tres []v1beta1.TaskResource) []v1beta1.TaskResou
 	})
 
 	return tres
+}
+
+func askClusterTaskName(opts *options.DescribeOptions, p cli.Params) error {
+	cs, err := p.Clients()
+	if err != nil {
+		return err
+	}
+	clusterTaskNames, err := allClusterTaskNames(cs)
+	if err != nil {
+		return err
+	}
+	if len(clusterTaskNames) == 0 {
+		return fmt.Errorf("no clustertasks found")
+	}
+
+	err = opts.Ask(options.ResourceNameClusterTask, clusterTaskNames)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/task"
 	"github.com/tektoncd/cli/pkg/taskrun/list"
 	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
@@ -116,6 +117,7 @@ NAME	STARTED	DURATION	STATUS
 
 func describeCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("describe")
+	opts := &options.DescribeOptions{Params: p}
 	eg := `Describe a Task of name 'foo' in namespace 'bar':
 
     tkn task describe foo -n bar
@@ -133,7 +135,6 @@ or
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
@@ -151,12 +152,21 @@ or
 				return err
 			}
 
-			if output != "" {
-				taskGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "tasks"}
-				return actions.PrintObject(taskGroupResource, args[0], cmd.OutOrStdout(), p, f, p.Namespace())
+			if len(args) == 0 {
+				err = askTaskName(opts, p)
+				if err != nil {
+					return err
+				}
+			} else {
+				opts.TaskName = args[0]
 			}
 
-			return printTaskDescription(s, p, args[0])
+			if output != "" {
+				taskGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "tasks"}
+				return actions.PrintObject(taskGroupResource, opts.TaskName, cmd.OutOrStdout(), p, f, p.Namespace())
+			}
+
+			return printTaskDescription(s, p, opts.TaskName)
 		},
 	}
 
@@ -239,4 +249,21 @@ func sortResourcesByTypeAndName(tres []v1beta1.TaskResource) []v1beta1.TaskResou
 	})
 
 	return tres
+}
+
+func askTaskName(opts *options.DescribeOptions, p cli.Params) error {
+	taskNames, err := task.GetAllTaskNames(p)
+	if err != nil {
+		return err
+	}
+	if len(taskNames) == 0 {
+		return fmt.Errorf("No tasks found")
+	}
+
+	err = opts.Ask(options.ResourceNameTask, taskNames)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/options/describe_test.go
+++ b/pkg/options/describe_test.go
@@ -1,0 +1,433 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	goexpect "github.com/Netflix/go-expect"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/test"
+	"github.com/tektoncd/cli/test/prompt"
+)
+
+func TestDescribeOptions_ValidateOpts(t *testing.T) {
+
+	testParams := []struct {
+		name      string
+		limit     int
+		wantError bool
+		want      string
+	}{
+		{
+			name:      "valid limit",
+			limit:     1,
+			wantError: false,
+			want:      "",
+		},
+		{
+			name:      "invalid limit",
+			limit:     0,
+			wantError: true,
+			want:      "limit was 0 but must be a positive number",
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			opts := NewDescribeOptions(&cli.TektonParams{})
+			opts.Limit = tp.limit
+
+			err := opts.ValidateOpts()
+			if tp.wantError {
+				if err == nil {
+					t.Errorf("Error expected here")
+				}
+				test.AssertOutput(t, tp.want, err.Error())
+			} else if err != nil {
+				t.Errorf("unexpected Error")
+			}
+		})
+	}
+}
+
+func TestDescribeOptions_Ask(t *testing.T) {
+	options := []string{
+		"pipeline1",
+		"pipeline2",
+		"pipeline3",
+	}
+
+	options2 := []string{
+		"sample-pipeline-run1 started 1 minutes ago",
+		"sample-pipeline-run2 started 2 minutes ago",
+		"sample-pipeline-run3 started 3 minutes ago",
+	}
+
+	options3 := []string{
+		"task1",
+		"task2",
+		"task3",
+	}
+
+	options4 := []string{
+		"sample-task-run1 started 1 minutes ago",
+		"sample-task-run2 started 2 minutes ago",
+		"sample-task-run3 started 3 minutes ago",
+	}
+
+	options5 := []string{
+		"pipeline-resource1",
+		"pipeline-resource2",
+		"pipeline-resource3",
+	}
+	options6 := []string{
+		"clustertask1",
+		"clustertask2",
+		"clustertask3",
+	}
+
+	testParams := []struct {
+		name     string
+		resource string
+		prompt   prompt.Prompt
+		options  []string
+		want     DescribeOptions
+	}{
+		{
+			name:     "select pipelinerun name",
+			resource: ResourceNamePipelineRun,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options2[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options2,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "sample-pipeline-run1",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select pipelinerun name option 3",
+			resource: ResourceNamePipelineRun,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options2[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options2,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "sample-pipeline-run3",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select taskrun name",
+			resource: ResourceNameTaskRun,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select taskrun:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options4[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options4,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "sample-task-run1",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select taskrun name option 3",
+			resource: ResourceNameTaskRun,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select taskrun:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options4[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options4,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "sample-task-run3",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select task name",
+			resource: ResourceNameTask,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select task:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options3[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options3,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "task1",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select task name option 3",
+			resource: ResourceNameTask,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select task:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options3[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options3,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "task3",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select pipeline name",
+			resource: ResourceNamePipeline,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select pipeline:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options,
+			want: DescribeOptions{
+				PipelineName:         "pipeline1",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select pipeline name option 3",
+			resource: ResourceNamePipeline,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select pipeline:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options,
+			want: DescribeOptions{
+				PipelineName:         "pipeline3",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select pipelineresource name",
+			resource: ResourceNamePipelineResource,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select pipelineresource:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options5[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options5,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "pipeline-resource1",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select pipelineresource name option 3",
+			resource: ResourceNamePipelineResource,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select pipelineresource:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options5[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options5,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "pipeline-resource3",
+				ClusterTaskName:      "",
+			},
+		},
+		{
+			name:     "select clustertask name",
+			resource: ResourceNameClusterTask,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select clustertask:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options6[0]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options6,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "clustertask1",
+			},
+		},
+		{
+			name:     "select clustertask name option 3",
+			resource: ResourceNameClusterTask,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select clustertask:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options6[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options6,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "clustertask3",
+			},
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			opts := &DescribeOptions{}
+			tp.prompt.RunTest(t, tp.prompt.Procedure, func(stdio terminal.Stdio) error {
+				opts.AskOpts = prompt.WithStdio(stdio)
+				return opts.Ask(tp.resource, tp.options)
+			})
+			if opts.PipelineName != tp.want.PipelineName {
+				t.Errorf("Unexpected Pipeline Name")
+			}
+			if opts.PipelineRunName != tp.want.PipelineRunName {
+				t.Errorf("Unexpected PipelineRun Name")
+			}
+			if opts.TaskName != tp.want.TaskName {
+				t.Errorf("Unexpected Task Name")
+			}
+			if opts.TaskrunName != tp.want.TaskrunName {
+				t.Errorf("Unexpected TaskRun Name")
+			}
+		})
+	}
+}

--- a/pkg/options/resource_names.go
+++ b/pkg/options/resource_names.go
@@ -1,0 +1,10 @@
+package options
+
+const (
+	ResourceNamePipeline         = "pipeline"
+	ResourceNamePipelineRun      = "pipelinerun"
+	ResourceNamePipelineResource = "pipelineresource"
+	ResourceNameTask             = "task"
+	ResourceNameTaskRun          = "taskrun"
+	ResourceNameClusterTask      = "clustertask"
+)


### PR DESCRIPTION
Provides an interactive Prompt to select a PipelineRun/TaskRun to describe just like what is there in `logs` subcommand.
~~~
$ ./tkn pr desc
? Select pipelinerun:  [Use arrows to move, type to filter]
> sequential-pipeline-run-t4jmp started 1 hour ago
   sequential-pipeline-run-xwcxr started 1 hour ago
   sequential-pipeline-run-kfqfh started 1 hour ago
   sequential-pipeline-run-87jh2 started 1 hour ago
   sequential-pipeline-run-lvcwh started 1 hour ago
    
$ ./tkn tr desc
? Select taskrun:  [Use arrows to move, type to filter]
> sequential-pipeline-run-xwcxr-echo-8vqjv started 1 hour ago
   sequential-pipeline-run-87jh2-echo-gwwsj started 1 hour ago
   sequential-pipeline-run-t4jmp-echo-cz7t6 started 1 hour ago
   sequential-pipeline-run-kfqfh-echo-pfstb started 1 hour ago
   sequential-pipeline-run-lvcwh-echo-dbzc6 started 1 hour ago
~~~
    
Resolves Issue - [#872](https://github.com/tektoncd/cli/issues/872)
cc @danielhelfand 


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
