### PR TITLE
Sort TaskRuns based on StartTime before deletion with keep

### DIFF
--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -18,13 +18,15 @@ import (
 	"errors"
 	"fmt"
 
+	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
+
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/deleter"
 	"github.com/tektoncd/cli/pkg/options"
 	trlist "github.com/tektoncd/cli/pkg/taskrun/list"
-	validate "github.com/tektoncd/cli/pkg/validate"
+	"github.com/tektoncd/cli/pkg/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -147,6 +149,7 @@ func allTaskRunNames(cs *cli.Clients, keep int, ns string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	trsort.SortByStartTime(taskRuns.Items)
 	var names []string
 	var counter = 0
 	for _, tr := range taskRuns.Items {


### PR DESCRIPTION
fixes https://github.com/tektoncd/cli/issues/802

When using --keep with `tkn tr delete` TaskRuns should be
sorted based on StartTime, which promotes deletion based
on the Age of the TaskRun. With only the older TaskRuns
deleted and the newer ones kept, as should be the case.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
