### PR TITLE
Sort PipelineRuns by Start Time for Pipeline Describe

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tektoncd/pipeline v0.11.0 h1:kGeWm53R5ggajD/L2KU8kcsZ2lVd4ruN3kdqK1A/NwQ=
 github.com/tektoncd/pipeline v0.11.0/go.mod h1:hlkH32S92+/UODROH0dmxzyuMxfRFp/Nc3e29MewLn8=
+github.com/tektoncd/pipeline v0.11.1 h1:0o48G/JLiPlJu3F7+HGmuynkzEYyTzHWr2LwxIbiyyE=
 github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2 h1:BksmpUwtap3THXJ8Z4KGcotsvpRdFQKySjDHgtc22lA=
 github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2/go.mod h1:QZHgU07PRBTRF6N57w4+ApRu8OgfYLFNqCDlfEZaD9Y=
 github.com/tektoncd/plumbing/pipelinerun-logs v0.0.0-20191206114338-712d544c2c21/go.mod h1:S62EUWtqmejjJgUMOGB1CCCHRp6C706laH06BoALkzU=

--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/pipeline"
 	"github.com/tektoncd/cli/pkg/pipelinerun"
+	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
 	"github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,6 +152,7 @@ func printPipelineDescription(out io.Writer, p cli.Params, pname string) error {
 	if err != nil {
 		return err
 	}
+	prsort.SortByStartTime(pipelineRuns.Items)
 
 	var data = struct {
 		Pipeline     *v1beta1.Pipeline

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_v1alpha1_pipelineruns.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_v1alpha1_pipelineruns.golden
@@ -1,0 +1,25 @@
+Name:          pipeline
+Namespace:     ns
+Description:   a test description
+
+Resources
+
+ NAME   TYPE
+ name   git
+
+Params
+
+ NAME             TYPE     DEFAULT VALUE
+ pipeline-param   string   somethingdifferent
+
+Tasks
+
+ NAME   TASKREF   RUNAFTER
+ task   taskref   one, two
+
+PipelineRuns
+
+ NAME             STARTED          DURATION     STATUS
+ pipeline-run-1   15 minutes ago   10 minutes   Succeeded
+ pipeline-run-3   25 minutes ago   20 minutes   Succeeded
+ pipeline-run-2   30 minutes ago   25 minutes   Succeeded


### PR DESCRIPTION
Part of #839 

This pull request changes the sorting of PipelineRuns for `tkn pipeline desc` to being sorted by start time instead of by name. Also adds a test with multiple pipelineruns since there wasn't one previously to show proper sorting of pipelineruns.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Sort PipelineRuns by start time as part of tkn pipeline describe 
```
