### PR TITLE
Fix lint error and handle properly 

### DIFF
--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -538,7 +538,7 @@ func askPassword(askOpts survey.AskOpt) (v1alpha1.ResourceParam, error) {
 	var qs = []*survey.Question{{
 		Name: "value",
 		Prompt: &survey.Password{
-			Message: fmt.Sprintf("Enter a value for password :"),
+			Message: "Enter a value for password :",
 		},
 	}}
 

--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -38,8 +38,6 @@ func init() {
 }
 
 func TestPipelineResource_resource_noName(t *testing.T) {
-	t.Skip("Skipping due of flakiness")
-
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		PipelineResources: []*v1alpha1.PipelineResource{
 			tb.PipelineResource("res", "namespace",
@@ -58,8 +56,6 @@ func TestPipelineResource_resource_noName(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "no input for name",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -100,7 +96,8 @@ func TestPipelineResource_resource_noName(t *testing.T) {
 
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("no input for name", func(t *testing.T) {
+			t.Skip("Skipping due of flakiness")
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -127,8 +124,6 @@ func TestPipelineResource_resource_already_exist(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "pre-existing-resource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -157,7 +152,7 @@ func TestPipelineResource_resource_already_exist(t *testing.T) {
 
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("pre-existing-resource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -178,8 +173,6 @@ func TestPipelineResource_allResourceType(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "check all type of resource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -267,7 +260,7 @@ func TestPipelineResource_allResourceType(t *testing.T) {
 
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("check all type of resource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -288,8 +281,6 @@ func TestPipelineResource_create_cloudEventResource(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "create-cloudEventResource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -339,7 +330,7 @@ func TestPipelineResource_create_cloudEventResource(t *testing.T) {
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("create-cloudEventResource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -360,8 +351,6 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 
 	tests := []promptTest{
 		{
-			name: "clusterResource-securePasswordText",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -479,7 +468,7 @@ func TestPipelineResource_create_clusterResource_secure_password_text(t *testing
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("clusterResource-securePasswordText", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -500,8 +489,6 @@ func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T)
 
 	tests := []promptTest{
 		{
-			name: "clusterResource-secureTokenText",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -623,7 +610,7 @@ func TestPipelineResource_create_clusterResource_secure_token_text(t *testing.T)
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("clusterResource-secureTokenText", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -644,8 +631,6 @@ func TestPipelineResource_create_gitResource(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "gitResource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -722,7 +707,7 @@ func TestPipelineResource_create_gitResource(t *testing.T) {
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("gitResource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -743,8 +728,6 @@ func TestPipelineResource_create_imageResource(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "imageResource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -826,7 +809,7 @@ func TestPipelineResource_create_imageResource(t *testing.T) {
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("imageResource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -847,8 +830,6 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 
 	tests := []promptTest{
 		{
-			name: "clusterResource-securePasswordSecrets",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -982,7 +963,7 @@ func TestPipelineResource_create_clusterResource_secure_password_secret(t *testi
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("clusterResource-securePasswordSecrets", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -1003,8 +984,6 @@ func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.
 
 	tests := []promptTest{
 		{
-			name: "clusterResource-secureTokenSecrets",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -1150,7 +1129,7 @@ func TestPipelineResource_create_clusterResource_secure_token_secret(t *testing.
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("clusterResource-secureTokenSecrets", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -1171,8 +1150,6 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "pullRequestResource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -1281,7 +1258,7 @@ func TestPipelineResource_create_pullRequestResource(t *testing.T) {
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("pullRequestResource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -1302,8 +1279,6 @@ func TestPipelineResource_create_gcsStorageResource(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "gcsStorageResource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -1425,7 +1400,7 @@ func TestPipelineResource_create_gcsStorageResource(t *testing.T) {
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("gcsStorageResource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}
@@ -1446,8 +1421,6 @@ func TestPipelineResource_create_buildGCSstorageResource(t *testing.T) {
 
 	tests := []promptTest{
 		{
-			name: "buildGCSstorageResource",
-
 			procedure: func(c *goexpect.Console) error {
 				if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
 					return err
@@ -1597,7 +1570,7 @@ func TestPipelineResource_create_buildGCSstorageResource(t *testing.T) {
 	}
 	res := resOpts("namespace", cs)
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run("buildGCSstorageResource", func(t *testing.T) {
 			res.RunPromptTest(t, test)
 		})
 	}

--- a/pkg/cmd/pipelineresource/resource_testUtil.go
+++ b/pkg/cmd/pipelineresource/resource_testUtil.go
@@ -26,7 +26,6 @@ import (
 )
 
 type promptTest struct {
-	name      string
 	procedure func(*goexpect.Console) error
 }
 

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -45,27 +45,27 @@ func DecorateAttr(attrString, message string) string {
 	case "bullet":
 		return fmt.Sprintf("∙ %s", message)
 	case "resources":
-		return fmt.Sprintf("📦 ")
+		return "📦 "
 	case "params":
-		return fmt.Sprintf("⚓ ")
+		return "⚓ "
 	case "tasks":
-		return fmt.Sprintf("🗒  ")
+		return "🗒  "
 	case "pipelineruns":
-		return fmt.Sprintf("⛩  ")
+		return "⛩  "
 	case "status":
-		return fmt.Sprintf("🌡️  ")
+		return "🌡️  "
 	case "inputresources":
-		return fmt.Sprintf("📨 ")
+		return "📨 "
 	case "outputresources":
-		return fmt.Sprintf("📡 ")
+		return "📡 "
 	case "steps":
-		return fmt.Sprintf("🦶 ")
+		return "🦶 "
 	case "message":
-		return fmt.Sprintf("💌 ")
+		return "💌 "
 	case "taskruns":
-		return fmt.Sprintf("🗂  ")
+		return "🗂  "
 	case "sidecars":
-		return fmt.Sprintf("🚗 ")
+		return "🚗 "
 	}
 
 	attr := color.Reset

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -47,7 +47,7 @@ function test_documentation_has_been_generated() {
 function test_golden_has_been_generated() {
     header "Testing if golden files has been generated"
 
-    make test-unit-update-golden
+    make update-golden
 
     if [[ -n $(git status --porcelain pkg/) ]];then
         echo "-- FATAL: The golden files didn't seem to be generated, rerun 'make generated' :"
@@ -61,23 +61,39 @@ function test_golden_has_been_generated() {
 }
 
 
-function check_lint() {
-    header "Testing if golint/yamllint has been done"
+function check_go_lint() {
+    header "Testing if golint has been done"
 
-    make lint
+    make lint-go
 
-    if [[ "$?" = "1" ]]; then
-        results_banner "Lint" 1
+    if [[ $? != 0 ]]; then
+        results_banner "Go Lint" 1
         exit 1
     fi
 
-    results_banner "Lint" 0
+    results_banner "Go Lint" 0
+}
+
+function check_yaml_lint() {
+    header "Testing if yamllint has been done"
+
+    make lint-yaml
+
+    if [[ $? != 0 ]]; then
+        results_banner "YAML Lint" 1
+        exit 1
+    fi
+
+    results_banner "YAML Lint" 0
 }
 
 function post_build_tests() {
     test_golden_has_been_generated
     test_documentation_has_been_generated
-    check_lint
+    check_go_lint
+    # Skipping yaml lint because of some issue in CI
+    # https://github.com/tektoncd/plumbing/issues/307
+    # check_yaml_lint
 }
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
Lint errors were not handled properly
and CI is passing even with errors

This will fix the CI to use proper
make targets, handle error
and fix lint warnings

Skip yaml lint because of some issue
in CI

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._


