### PR TITLE
Remove Default Timeout of 1h for Pipeline and Task start

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -51,7 +51,7 @@ my-secret and my-empty-dir)
   -s, --serviceaccount string         pass the serviceaccount name
       --showlog                       show logs right after starting the pipeline
       --task-serviceaccount strings   pass the service account corresponding to the task
-      --timeout string                timeout for pipelinerun (default "1h")
+      --timeout string                timeout for pipelinerun
       --use-param-defaults            use default parameter values without prompting for input
       --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
   -w, --workspace stringArray         pass the workspace.

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -40,7 +40,7 @@ like cat,foo,bar
       --prefix-name string       specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the task
-      --timeout string           timeout for taskrun (default "1h")
+      --timeout string           timeout for taskrun
       --use-taskrun string       specify a taskrun name to use its values to re-run the taskrun
   -w, --workspace stringArray    pass the workspace.
 ```

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -76,7 +76,7 @@ Parameters, at least those that have no default value
     pass the service account corresponding to the task
 
 .PP
-\fB\-\-timeout\fP="1h"
+\fB\-\-timeout\fP=""
     timeout for pipelinerun
 
 .PP

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -68,7 +68,7 @@ Start tasks
     show logs right after starting the task
 
 .PP
-\fB\-\-timeout\fP="1h"
+\fB\-\-timeout\fP=""
     timeout for taskrun
 
 .PP

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -161,7 +161,7 @@ like cat,foo,bar
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview pipelinerun without running it")
 	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of pipelinerun dry-run (yaml or json)")
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)")
-	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "1h", "timeout for pipelinerun")
+	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for pipelinerun")
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a pipeline definition to start a pipelinerun")
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
 
@@ -227,11 +227,13 @@ func (opt *startOptions) startPipeline(pipelineStart *v1alpha1.Pipeline) error {
 		}
 	}
 
-	timeoutDuration, err := time.ParseDuration(opt.TimeOut)
-	if err != nil {
-		return err
+	if opt.TimeOut != "" {
+		timeoutDuration, err := time.ParseDuration(opt.TimeOut)
+		if err != nil {
+			return err
+		}
+		pr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
 	}
-	pr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
 
 	if opt.Last || opt.UsePipelineRun != "" {
 		var usepr *v1alpha1.PipelineRun

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_using_--filename_v1alpha1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_using_--filename_v1alpha1.golden
@@ -50,5 +50,4 @@ spec:
   - name: web-image
     resourceRef:
       name: imageres
-  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_using_--filename_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_using_--filename_v1beta1.golden
@@ -50,5 +50,4 @@ spec:
   - name: web-image
     resourceRef:
       name: imageres
-  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
@@ -19,5 +19,4 @@ spec:
     resourceRef:
       name: scaffold-git
   serviceAccountName: svc1
-  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
@@ -19,5 +19,4 @@ spec:
     resourceRef:
       name: scaffold-git
   serviceAccountName: svc1
-  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -17,5 +17,4 @@ spec:
     resourceRef:
       name: scaffold-git
   serviceAccountName: svc1
-  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified_v1beta1.golden
@@ -17,5 +17,4 @@ spec:
     resourceRef:
       name: scaffold-git
   serviceAccountName: svc1
-  timeout: 1h0m0s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -27,8 +27,7 @@
 				"value": "value1"
 			}
 		],
-		"serviceAccountName": "svc1",
-		"timeout": "1h0m0s"
+		"serviceAccountName": "svc1"
 	},
 	"status": {}
 }

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json_-f.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_output=json_-f.golden
@@ -95,8 +95,7 @@
 					"name": "imageres"
 				}
 			}
-		],
-		"timeout": "1h0m0s"
+		]
 	},
 	"status": {}
 }

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -162,7 +162,7 @@ like cat,foo,bar
 	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass the workspace.")
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the task")
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a task definition to start a taskrun")
-	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "1h", "timeout for taskrun")
+	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for taskrun")
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview taskrun without running it")
 	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of taskrun dry-run (yaml or json)")
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the taskrun name (must be lowercase alphanumeric characters)")
@@ -260,11 +260,13 @@ func startTask(opt startOptions, args []string) error {
 		}
 	}
 
-	timeoutDuration, err := time.ParseDuration(opt.TimeOut)
-	if err != nil {
-		return err
+	if opt.TimeOut != "" {
+		timeoutDuration, err := time.ParseDuration(opt.TimeOut)
+		if err != nil {
+			return err
+		}
+		tr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
 	}
-	tr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
 
 	if opt.PrefixName == "" {
 		tr.ObjectMeta.GenerateName = tname + "-run-"

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f_v1alpha1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f_v1alpha1.golden
@@ -47,6 +47,5 @@ spec:
       image: gcr.io/kaniko-project/executor:v0.14.0
       name: build-and-push
       resources: {}
-  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f_v1beta1.golden
@@ -46,6 +46,5 @@ spec:
       image: gcr.io/kaniko-project/executor:v0.14.0
       name: build-and-push
       resources: {}
-  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -18,6 +18,5 @@ spec:
   serviceAccountName: svc1
   taskRef:
     name: task-1
-  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified_v1beta1.golden
@@ -18,6 +18,5 @@ spec:
   serviceAccountName: svc1
   taskRef:
     name: task-1
-  timeout: 1h0m0s
 status:
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -11,7 +11,6 @@
 		"taskRef": {
 			"name": "task-1"
 		},
-		"timeout": "1h0m0s",
 		"inputs": {
 			"resources": [
 				{

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json_-f.golden
@@ -61,7 +61,6 @@
 				]
 			}
 		},
-		"timeout": "1h0m0s",
 		"inputs": {
 			"resources": [
 				{


### PR DESCRIPTION
Part of #865 

This pull request partially addresses #865. It removes default values for `tkn pipeline start` and `tkn task start` for the `--timeout` option. This will need to eventually also be applied to `tkn clustertask start`, but there needs to be changes made via #793 before that can take place.

Removing the default should be backwards compatible as pipelines will still apply the `1h` default in the event nothing is specified via `tkn`. This will also respect the `default-timeout-minutes` property specified in config-defaults. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Remove 1h default for --timeout for pipeline and task start to allow default-timeout-minutes to be correctly applied
```
