### PR TITLE
Set client version in the Debian package

### DIFF
--- a/tekton/debbuild/container/buildpackage.sh
+++ b/tekton/debbuild/container/buildpackage.sh
@@ -36,6 +36,9 @@ cd cli-${version}
 # Make it easy for devs
 [[ -d /debian ]] && { rm -rf debian && cp -a /debian . ; }
 
+# Makefile will use it automatically to set the binary version
+echo ${version} > VERSION
+
 dch -M -v ${version}-${RELEASE} -D $(sed -n '/DISTRIB_CODENAME/ { s/.*=//;p;;}' /etc/lsb-release) "new update"
 
 pcscd

--- a/tekton/debbuild/container/buildpackage.sh
+++ b/tekton/debbuild/container/buildpackage.sh
@@ -19,8 +19,8 @@ RELEASE=2
 TMPD=$(mktemp -d)
 mkdir -p ${TMPD}
 clean() { rm -rf ${TMPD} ;}
-# trap clean EXIT
-TMPD=/tmp/debug;mkdir -p ${TMPD}
+trap clean EXIT
+# TMPD=/tmp/debug;mkdir -p ${TMPD}
 
 curl -o ${TMPD}/output.json -s https://api.github.com/repos/tektoncd/cli/releases/latest
 version=$(python3 -c "import sys, json;x=json.load(sys.stdin);print(x['tag_name'])" < ${TMPD}/output.json)

--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -14,8 +14,9 @@ BUILD_DATE := $(BUILD_DATE:+0000=Z)
 	dh $@
 
 override_dh_auto_build:
-	export XDG_CACHE_HOME=/tmp/cache ; \
-	test -e ./VERSION && VERSION=`cat VERSION` || VERSION=$(BUILD_DATE) ; \
+	@set -x ; export XDG_CACHE_HOME=/tmp/cache ; \
+	RELEASED_VERSION=`curl -s  https://api.github.com/repos/tektoncd/cli/releases/latest|python3 -c "import sys, json;x=json.load(sys.stdin);print(x['tag_name'])"|sed 's/^v//'` ; test -n "$$RELEASED_VERSION" || RELEASED_VERSION=$(BUILD_DATE) ; \
+	test -e ./VERSION && VERSION=`cat VERSION` || VERSION=$$RELEASED_VERSION ; \
 		go build -mod=vendor -v -o ${TKN} -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$$VERSION" ./cmd/tkn
 	$(TKN) version
 	$(TKN) completion zsh > debian/tkn.zsh-completion


### PR DESCRIPTION
# Changes

Set properly the client version on the Debian package

We were showing a Build Date previously instead of the client version.

Fixes #903

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
fix client version in Debian package
```