### PR TITLE
Modified param flag  description

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -36,7 +36,7 @@ like cat,foo,bar
   -L, --last                     re-run the clustertask using last taskrun values
       --output string            format of taskrun dry-run (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
-  -p, --param stringArray        pass the param as key=value or key=value1,value2
+  -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the clustertask
   -t, --timeout int              timeout for taskrun in seconds (default 3600)

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -45,7 +45,7 @@ my-secret and my-empty-dir)
   -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the pipeline using last pipelinerun values
       --output string                 format of pipelinerun dry-run (yaml or json)
-  -p, --param stringArray             pass the param as key=value or key=value1,value2
+  -p, --param stringArray             pass the param as key=value for string type, or key=value1,value2,... for array type
       --prefix-name string            specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -36,7 +36,7 @@ like cat,foo,bar
   -L, --last                     re-run the task using last taskrun values
       --output string            format of taskrun dry-run (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
-  -p, --param stringArray        pass the param as key=value or key=value1,value2
+  -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
       --prefix-name string       specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the task

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -49,7 +49,7 @@ Start clustertasks
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param as key=value or key=value1,value2
+    pass the param as key=value for string type, or key=value1,value2,... for array type
 
 .PP
 \fB\-s\fP, \fB\-\-serviceaccount\fP=""

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -53,7 +53,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param as key=value or key=value1,value2
+    pass the param as key=value for string type, or key=value1,value2,... for array type
 
 .PP
 \fB\-\-prefix\-name\fP=""

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -53,7 +53,7 @@ Start tasks
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param as key=value or key=value1,value2
+    pass the param as key=value for string type, or key=value1,value2,... for array type
 
 .PP
 \fB\-\-prefix\-name\fP=""

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -136,7 +136,7 @@ like cat,foo,bar
 
 	c.Flags().StringSliceVarP(&opt.InputResources, "inputresource", "i", []string{}, "pass the input resource name and ref as name=ref")
 	c.Flags().StringSliceVarP(&opt.OutputResources, "outputresource", "o", []string{}, "pass the output resource name and ref as name=ref")
-	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value or key=value1,value2")
+	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the clustertask using last taskrun values")

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -148,7 +148,7 @@ like cat,foo,bar
 
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the pipeline")
 	c.Flags().StringSliceVarP(&opt.Resources, "resource", "r", []string{}, "pass the resource name and ref as name=ref")
-	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value or key=value1,value2")
+	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().StringSliceVar(&opt.ServiceAccounts, "task-serviceaccount", []string{}, "pass the service account corresponding to the task")

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -152,7 +152,7 @@ like cat,foo,bar
 
 	c.Flags().StringSliceVarP(&opt.InputResources, "inputresource", "i", []string{}, "pass the input resource name and ref as name=ref")
 	c.Flags().StringSliceVarP(&opt.OutputResources, "outputresource", "o", []string{}, "pass the output resource name and ref as name=ref")
-	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value or key=value1,value2")
+	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the task using last taskrun values")


### PR DESCRIPTION
Updated the param flag description for cmds - clustertask start, task start, and pipeline start, with text : pass the param as key=value for string type, or key=value1,value2,... for array type

Fix #733

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
 Modified param flag description for clarity.
```