### PR TITLE
Check Status of TaskRun for tkn pipelinerun describe

### DIFF
--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_taskrun_with_no_status.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_taskrun_with_no_status.golden
@@ -1,0 +1,25 @@
+Name:           pipeline-run
+Namespace:      ns
+Pipeline Ref:   pipeline
+
+Status
+
+STARTED         DURATION     STATUS
+0 seconds ago   20 minutes   Succeeded
+
+Resources
+
+ NAME    RESOURCE REF
+ res-1   test-res
+ res-2   test-res2
+
+Params
+
+ NAME   VALUE
+ p-1    somethingdifferent
+ p-2    [booms booms booms]
+
+Taskruns
+
+ NAME   TASK NAME   STARTED         DURATION    STATUS
+ tr-1   t-1         0 seconds ago   5 minutes   Failed


### PR DESCRIPTION
Closes #882 

This pull request adds nil checks for the status of a TaskRun. In the event a Pod for a TaskRun is stuck in an InitializingPod state (e.g. an example would be if the TaskRun has a condition check that fails), the TaskRun object will be returned client side with no status. The properties under status are how we populate the describe template for TaskRuns associated with a PipelineRun.

The approach here will be to skip adding the TaskRun to the template if it does not have a status. Open to alternative suggestions on if this information should be displayed somehow, but I take it to mean that this TaskRun never executed and thus shouldn't be reported. What could be interesting is reporting TaskRuns that are created by Conditions as part of a PipelineRun describe to provide more detail on why a PipelineRun failed/TaskRuns did not execute.

I believe this is isolated to PipelineRuns as a `tkn tr ls` command does not return the TaskRun without a status like the `tkn pr desc` does. This brings into question whether the approach used to gather TaskRuns associated with a PipelineRun by `tkn pr desc` should be switched to another approach. It also brings into question how pipelines itself treats TaskRuns associated with a PipelineRun/Conditions that I have documented [here](https://github.com/tektoncd/pipeline/issues/2419#issuecomment-614961834). My opinion is that this is an issue that should be fixed in pipelines as opposed to the CLI, but I think that will take time so we should put in place a protection against this case for now.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Add nil check for TaskRun status in event of condition check failure for tkn pipelinerun describe
```
