### PR TITLE
Disable colouring and emojis on windows

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -16,6 +16,7 @@ package flags
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -96,6 +97,10 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 
 	// Make sure we set as Nocolour if we don't have a terminal (ie redirection)
 	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		p.SetNoColour(true)
+	}
+
+	if runtime.GOOS == "windows" {
 		p.SetNoColour(true)
 	}
 


### PR DESCRIPTION
Fixes #914 and #915


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This will disable colouring and emojis on windows platform. Since windows
terminal doesn't fully supports it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Colours and emojis are disabled on windows platforms.
```