### PR TITLE
Fix --keep Description and Remove Need to use with --all Flag

### DIFF
--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -32,7 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-      --keep int                      Keep n least recent number of pipelineruns when using --all with delete
+      --keep int                      Keep n most recent number of pipelineruns
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -p, --pipeline string               The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -32,7 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-      --keep int                      Keep n least recent number of taskruns when using --all with delete
+      --keep int                      Keep n most recent number of taskruns
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
   -t, --task string                   The name of a task whose taskruns should be deleted (does not delete the task)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -37,7 +37,7 @@ Delete pipelineruns in a namespace
 
 .PP
 \fB\-\-keep\fP=0
-    Keep n least recent number of pipelineruns when using \-\-all with delete
+    Keep n most recent number of pipelineruns
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -37,7 +37,7 @@ Delete taskruns in a namespace
 
 .PP
 \fB\-\-keep\fP=0
-    Keep n least recent number of taskruns when using \-\-all with delete
+    Keep n most recent number of taskruns
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -64,6 +64,14 @@ or
 				return err
 			}
 
+			if opts.Keep < 0 {
+				return fmt.Errorf("keep option should not be lower than 0")
+			}
+
+			if opts.Keep > 0 {
+				opts.DeleteAllNs = true
+			}
+
 			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
@@ -74,7 +82,7 @@ or
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().StringVarP(&opts.ParentResourceName, "pipeline", "p", "", "The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)")
-	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n least recent number of pipelineruns when using --all with delete")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of pipelineruns")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all pipelineruns in a namespace (default: false)")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
 	return c

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -236,7 +236,7 @@ func TestPipelineRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Delete all keeping 2",
-			command:     []string{"delete", "--all", "-f", "--keep", "2", "-n", "ns"},
+			command:     []string{"delete", "-f", "--keep", "2", "-n", "ns"},
 			dynamic:     seeds[4].dynamicClient,
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
@@ -245,12 +245,21 @@ func TestPipelineRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Keep -1 is a no go",
-			command:     []string{"delete", "--all", "-f", "--keep", "-1", "-n", "ns"},
+			command:     []string{"delete", "-f", "--keep", "-1", "-n", "ns"},
 			dynamic:     seeds[4].dynamicClient,
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "keep option should not be lower than 0",
+		},
+		{
+			name:        "Delete all keeping 1 with --all flag",
+			command:     []string{"delete", "-f", "--all", "--keep", "1", "-n", "ns"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 1 PipelineRuns deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Error from using pipelinerun name with --all",

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -65,6 +65,14 @@ or
 				return err
 			}
 
+			if opts.Keep < 0 {
+				return fmt.Errorf("keep option should not be lower than 0")
+			}
+
+			if opts.Keep > 0 {
+				opts.DeleteAllNs = true
+			}
+
 			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
 				return err
 			}
@@ -76,7 +84,7 @@ or
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().StringVarP(&opts.ParentResourceName, "task", "t", "", "The name of a task whose taskruns should be deleted (does not delete the task)")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all taskruns in a namespace (default: false)")
-	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n least recent number of taskruns when using --all with delete")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of taskruns")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_taskrun")
 	return c
 }

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -206,7 +206,7 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Delete all keeping 2",
-			command:     []string{"delete", "--all", "-f", "--keep", "2", "-n", "ns"},
+			command:     []string{"delete", "-f", "--keep", "2", "-n", "ns"},
 			dynamic:     seeds[4].dynamicClient,
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
@@ -214,8 +214,17 @@ func TestTaskRunDelete(t *testing.T) {
 			want:        "All but 2 TaskRuns deleted in namespace \"ns\"\n",
 		},
 		{
+			name:        "Delete all keeping 1 with --all flag",
+			command:     []string{"delete", "-f", "--all", "--keep", "1", "-n", "ns"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 1 TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
 			name:        "Keep -1 is a no go",
-			command:     []string{"delete", "--all", "-f", "--keep", "-1", "-n", "ns"},
+			command:     []string{"delete", "-f", "--keep", "-1", "-n", "ns"},
 			dynamic:     seeds[4].dynamicClient,
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -35,10 +35,6 @@ type DeleteOptions struct {
 }
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns string) error {
-	if o.Keep > 0 && !(o.DeleteAllNs || o.DeleteAll) {
-		return fmt.Errorf("must use --all flag with --keep")
-	}
-
 	// make sure no resource names are provided when using --all flag
 	if len(resourceNames) > 0 && (o.DeleteAllNs || o.DeleteAll) || o.DeleteAllNs && o.DeleteRelated {
 		return fmt.Errorf("--all flag should not have any arguments or flags specified with it")
@@ -54,10 +50,6 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	// in non PipelineRun or TaskRun deletions
 	if len(resourceNames) == 0 && o.ParentResource == "" && o.ParentResourceName == "" && !o.DeleteAllNs && !o.DeleteAll {
 		return fmt.Errorf("must provide %s name(s) or use --all flag with delete", o.Resource)
-	}
-
-	if o.Keep < 0 {
-		return fmt.Errorf("keep option should not be lower than 0")
 	}
 
 	if o.ForceDelete {

--- a/pkg/options/delete_test.go
+++ b/pkg/options/delete_test.go
@@ -145,20 +145,6 @@ func TestDeleteOptions(t *testing.T) {
 			wantError:      true,
 			want:           "must provide Condition name(s) or use --all flag with delete",
 		},
-		{
-			name:           "Error when using --keep without --all",
-			opt:            &DeleteOptions{Keep: 7, DeleteAllNs: false, DeleteAll: false},
-			resourcesNames: []string{},
-			wantError:      true,
-			want:           "must use --all flag with --keep",
-		},
-		{
-			name:           "Error --keep < 0",
-			opt:            &DeleteOptions{Keep: -1, DeleteAllNs: true},
-			resourcesNames: []string{},
-			wantError:      true,
-			want:           "keep option should not be lower than 0",
-		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
Slight cleanup of `--keep` flag for `tkn pr delete`/`tkn tr delete`. With this change, users will no longer need to use `--all` with `--keep` but still can. This pull request will set `--all` to true when `--keep` is greater than 0. This is needed since `--keep` relies on funcs used with `--all`. 

This pull request also corrects the description to clearly communicate what PipelineRuns/TaskRuns are kept when using `--keep`. #800 is incorrect in stating that most recent PipelineRuns/TaskRuns are not kept. I believe the original issue was opened because of #802, which caused confusion cause of what was kept. 

This pull request does not solve #800 as the behavior should probably be changed later on, but it does clean up certain user experience aspects of `--keep`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Do not require use of --all with --keep flag and correct description of keep option to say that most recent pipelinerun/taskruns are kept
```
