### PR TITLE
fix aliases for clustertriggerbindings

### DIFF
--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -2,7 +2,7 @@
 
 Manage clustertriggerbindings
 
-***Aliases**: ctb,clustertriggerbinding*
+***Aliases**: ctb,clustertriggerbindings*
 
 ### Synopsis
 

--- a/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
+++ b/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
@@ -23,7 +23,7 @@ import (
 func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "clustertriggerbinding",
-		Aliases: []string{"ctb", "clustertriggerbinding"},
+		Aliases: []string{"ctb", "clustertriggerbindings"},
 		Short:   "Manage clustertriggerbindings",
 		Annotations: map[string]string{
 			"commandType": "main",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
**Issue:**
```
tkn clustertriggerbindings
Error: unknown command "clustertriggerbindings" for "tkn"

Did you mean this?
	clustertriggerbinding

Run 'tkn --help' for usage.
```

# Changes
Modified aliases of the ctb to include **clustertriggerbindings**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
