### PR TITLE
Fix pipeline version not working

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,17 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package version
 
 import (
@@ -5,25 +19,45 @@ import (
 	"strings"
 
 	"github.com/tektoncd/cli/pkg/cli"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const pipelineNamespace = "tekton-pipelines"
 
 // GetPipelineVersion Get pipeline version, functions imported from Dashboard
 func GetPipelineVersion(c *cli.Clients) (string, error) {
 	version := ""
+	namespaces := []string{"tekton-pipelines", "openshift-pipelines"}
 
 	listOptions := metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/component=controller,app.kubernetes.io/name=tekton-pipelines",
 	}
 
-	deployments, err := c.Kube.AppsV1().Deployments(pipelineNamespace).List(listOptions)
-	if err != nil {
-		return "", err
+	var deployments []v1.Deployment
+	for _, namespace := range namespaces {
+		d, _ := c.Kube.AppsV1().Deployments(namespace).List(listOptions)
+		deployments = append(deployments, d.Items...)
 	}
 
-	for _, deployment := range deployments.Items {
+	if len(deployments) > 0 {
+		version = findVersion(deployments)
+	}
+
+	if version == "" {
+		d, _ := c.Kube.AppsV1().Deployments("").List(listOptions)
+		deployments = append(deployments, d.Items...)
+		version = findVersion(deployments)
+	}
+
+	if version == "" {
+		return "", fmt.Errorf("Error getting the tekton pipelines deployment version. Version is unknown")
+	}
+
+	return version, nil
+}
+
+func findVersion(deployments []v1.Deployment) string {
+	version := ""
+	for _, deployment := range deployments {
 		deploymentLabels := deployment.Spec.Template.GetLabels()
 		deploymentAnnotations := deployment.Spec.Template.GetAnnotations()
 
@@ -47,10 +81,5 @@ func GetPipelineVersion(c *cli.Clients) (string, error) {
 			}
 		}
 	}
-
-	if version == "" {
-		return "", fmt.Errorf("Error getting the tekton pipelines deployment version. Version is unknown")
-	}
-
-	return version, nil
+	return version
 }


### PR DESCRIPTION
This will fix the issue of pipeline version showing
unknown when installed in other namespace
Now it will check tekton-pipelines and openshift-pipelines
namespace and if not found then will check all
namespaces for deployment

Fix #925

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix pipeline version not showing when installed in other namespace
```
