### PR TITLE
Fix Alignment of Output Resource TYPE Column for task desc

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -65,7 +65,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
 {{- if eq (len .Task.Spec.Resources.Outputs) 0 }}
  No output resources
 {{- else }}
- NAME	  TYPE
+ NAME	TYPE
  
 {{- range $or := .Task.Spec.Resources.Outputs }}
  {{decorate "bullet" $or.Name }}	{{ $or.Type }}

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
@@ -11,7 +11,7 @@ Input Resources
 
 Output Resources
 
- NAME               TYPE
+ NAME             TYPE
  artifact-image   image
  code-image       image
 

--- a/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
@@ -11,7 +11,7 @@ Input Resources
 
 Output Resources
 
- NAME               TYPE
+ NAME             TYPE
  artifact-image   image
  code-image       image
 


### PR DESCRIPTION
Minor column alignment issue for `tkn task desc` output resources. Was originally picked up by tests, but made it through reviews unfortunately. This pull request corrects the alignment of the `TYPE` column for the type of output resource for a Task.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Fix column alignment for tkn task desc for TYPE column of output resources
```
