### PR TITLE
Remove namespace flag from clusterwide cmd's

### DIFF
--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -14,7 +14,6 @@ Manage clustertasks
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertask
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -41,7 +41,6 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertask_describe.md
+++ b/docs/cmd/tkn_clustertask_describe.md
@@ -39,7 +39,6 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -28,7 +28,6 @@ Lists clustertasks in a namespace
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -47,7 +47,6 @@ like cat,foo,bar
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -14,7 +14,6 @@ Manage clustertriggerbindings
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertriggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertriggerbinding_delete.md
+++ b/docs/cmd/tkn_clustertriggerbinding_delete.md
@@ -41,7 +41,6 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertriggerbinding_describe.md
+++ b/docs/cmd/tkn_clustertriggerbinding_describe.md
@@ -39,7 +39,6 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/cmd/tkn_clustertriggerbinding_list.md
+++ b/docs/cmd/tkn_clustertriggerbinding_list.md
@@ -39,7 +39,6 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -n, --namespace string    namespace to use (default: from $KUBECONFIG)
   -C, --nocolour            disable colouring (default: false)
 ```
 

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -55,10 +55,6 @@ Delete clustertask resources in a cluster
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertask-describe.1
+++ b/docs/man/man1/tkn-clustertask-describe.1
@@ -47,10 +47,6 @@ Describes a clustertask
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -47,10 +47,6 @@ Lists clustertasks in a namespace
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -74,10 +74,6 @@ Start clustertasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertask.1
+++ b/docs/man/man1/tkn-clustertask.1
@@ -32,10 +32,6 @@ Manage clustertasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertriggerbinding-delete.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-delete.1
@@ -55,10 +55,6 @@ Delete clustertriggerbindings
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertriggerbinding-describe.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-describe.1
@@ -47,10 +47,6 @@ Describes a clustertriggerbinding
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertriggerbinding-list.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-list.1
@@ -47,10 +47,6 @@ Lists clustertriggerbindings in a namespace
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/docs/man/man1/tkn-clustertriggerbinding.1
+++ b/docs/man/man1/tkn-clustertriggerbinding.1
@@ -32,10 +32,6 @@ Manage clustertriggerbindings
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-n\fP, \fB\-\-namespace\fP=""
-    namespace to use (default: from $KUBECONFIG)
-
-.PP
 \fB\-C\fP, \fB\-\-nocolour\fP[=false]
     disable colouring (default: false)
 

--- a/pkg/cmd/clustertask/clustertask.go
+++ b/pkg/cmd/clustertask/clustertask.go
@@ -34,6 +34,7 @@ func Command(p cli.Params) *cobra.Command {
 	}
 
 	flags.AddTektonOptions(cmd)
+	_ = cmd.PersistentFlags().MarkHidden("namespace")
 	cmd.AddCommand(
 		deleteCommand(p),
 		describeCommand(p),

--- a/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
+++ b/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
@@ -34,6 +34,7 @@ func Command(p cli.Params) *cobra.Command {
 	}
 
 	flags.AddTektonOptions(cmd)
+	_ = cmd.PersistentFlags().MarkHidden("namespace")
 	cmd.AddCommand(
 		deleteCommand(p),
 		describeCommand(p),


### PR DESCRIPTION
This will remove namesapce flag from commands
like clustertask and clustertriggerbinding

Update docs

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Remove namespace flag from clusterwide cmd's
```
