### PR TITLE
Add flag to skip check flag in version cmd

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -33,6 +33,9 @@ import (
 // NOTE: use go build -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(git describe)"
 var clientVersion = devVersion
 
+// flag to skip check flag in version cmd
+var skipCheckFlag = "false"
+
 const (
 	devVersion       = "dev"
 	latestReleaseURL = "https://api.github.com/repos/tektoncd/cli/releases/latest"
@@ -71,7 +74,9 @@ func Command(p cli.Params) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&check, "check", "c", false, "check if a newer version is available")
+	if skipCheckFlag != "true" {
+		cmd.Flags().BoolVarP(&check, "check", "c", false, "check if a newer version is available")
+	}
 	return cmd
 }
 


### PR DESCRIPTION
This will add a ldflag to skip the check
flag in version cmd. By default it will
work as the current behaviour. It will
skip adding the flag if build as passing
the flsg skipCheckFlag var as true

The flag to skip check flag can be passed as
go build -ldflags '-X github.com/tektoncd/cli/pkg/cmd/version.skipCheckFlag=true' ./cmd/tkn

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

