### PR TITLE
Makefile changes for new skipCheckFlag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 
+ifneq ($(SKIP_CHECK_FLAG),)
+	SKIPLDFLAG := -X github.com/tektoncd/cli/pkg/cmd/version.skipCheckFlag=$(SKIP_CHECK_FLAG)
+endif
+
 ifneq (,$(wildcard ./VERSION))
-LDFLAGS := -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=`cat VERSION`"
+	VERSIONLDFLAG := -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=`cat VERSION`
 endif
 
 ifneq ($(RELEASE_VERSION),)
-LDFLAGS := -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(RELEASE_VERSION)"
+	VERSIONLDFLAG := -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(RELEASE_VERSION)
+endif
+
+FLAGS := $(VERSIONLDFLAG)$(SKIPLDFLAG)
+ifneq ($(SKIPLDFLAG),)
+	FLAGS := $(VERSIONLDFLAG) $(SKIPLDFLAG)
+endif
+
+ifneq ($(FLAGS),)
+	LDFLAGS := -ldflags "$(FLAGS)"
 endif
 
 all: bin/tkn test


### PR DESCRIPTION
We added a new skipCheckFlag to skip tkn version -c flag
during build. This will add changes to handle that in
makefile target

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Makefile changes for new skipCheckFlag
```
