### PR TITLE
Fix triggerbinding and template `list` error messages

### DIFF
--- a/pkg/cmd/triggerbinding/list.go
+++ b/pkg/cmd/triggerbinding/list.go
@@ -67,12 +67,12 @@ or
 
 			tbs, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf(`failed to list triggerbindings from %s namespace \n`, p.Namespace())
+				return fmt.Errorf("failed to list triggerbindings from %s namespace", p.Namespace())
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				return errors.New(`output option not set properly \n`)
+				return errors.New("output option not set properly")
 			}
 
 			stream := &cli.Stream{
@@ -94,7 +94,7 @@ or
 			}
 
 			if err = printFormatted(stream, tbs, p); err != nil {
-				return errors.New(`failed to print triggerbindings \n`)
+				return errors.New("failed to print triggerbindings")
 			}
 			return nil
 

--- a/pkg/cmd/triggertemplate/list.go
+++ b/pkg/cmd/triggertemplate/list.go
@@ -67,12 +67,12 @@ or
 
 			tts, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf(`failed to list triggertemplates from %s namespace \n`, p.Namespace())
+				return fmt.Errorf("failed to list triggertemplates from %s namespace", p.Namespace())
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				return errors.New(`output option not set properly \n`)
+				return errors.New("output option not set properly")
 			}
 
 			stream := &cli.Stream{
@@ -85,7 +85,7 @@ or
 			}
 
 			if err = printFormatted(stream, tts, p); err != nil {
-				return errors.New(`failed to print triggertemplates \n`)
+				return errors.New("failed to print triggertemplates")
 			}
 			return nil
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The error messages container /n in the output. Updated to not show the same in triggertemplate and triggerbinding list commands.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
