### PR TITLE
Refactoring for --all-namespace flag

### DIFF
--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -80,8 +80,10 @@ func listCommand(p cli.Params) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := validate.NamespaceExists(p); err != nil && !opts.AllNamespaces {
-				return err
+			if !opts.AllNamespaces {
+				if err := validate.NamespaceExists(p); err != nil {
+					return err
+				}
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -86,8 +86,10 @@ List all PipelineRuns in a namespace 'foo':
 				pipeline = args[0]
 			}
 
-			if err := validate.NamespaceExists(p); err != nil {
-				return err
+			if !opts.AllNamespaces {
+				if err := validate.NamespaceExists(p); err != nil {
+					return err
+				}
 			}
 
 			if opts.Limit < 0 {

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -21,12 +21,11 @@ import (
 	"text/template"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/tektoncd/cli/pkg/task"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
+	"github.com/tektoncd/cli/pkg/task"
 	"github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,8 +70,10 @@ func listCommand(p cli.Params) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := validate.NamespaceExists(p); err != nil && !opts.AllNamespaces {
-				return err
+			if !opts.AllNamespaces {
+				if err := validate.NamespaceExists(p); err != nil {
+					return err
+				}
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -83,13 +83,14 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 		Example: eg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var task string
-
 			if len(args) > 0 {
 				task = args[0]
 			}
 
-			if err := validate.NamespaceExists(p); err != nil {
-				return err
+			if !opts.AllNamespaces {
+				if err := validate.NamespaceExists(p); err != nil {
+					return err
+				}
 			}
 
 			if opts.Limit < 0 {

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -281,7 +281,7 @@ func TestListTaskRuns(t *testing.T) {
 		{
 			name:      "print taskruns in all namespaces",
 			command:   command(t, trsMultipleNs, now, ns, version, dc2),
-			args:      []string{"list", "--all-namespaces", "-n", "foo"},
+			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
 		{
@@ -293,7 +293,7 @@ func TestListTaskRuns(t *testing.T) {
 		{
 			name:      "print taskruns in all namespaces without headers",
 			command:   command(t, trsMultipleNs, now, ns, version, dc2),
-			args:      []string{"list", "--all-namespaces", "--no-headers", "-n", "foo"},
+			args:      []string{"list", "--all-namespaces", "--no-headers"},
 			wantError: false,
 		},
 	}
@@ -555,7 +555,7 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 		{
 			name:      "print taskruns in all namespaces",
 			command:   command(t, trsMultipleNs, now, ns, version, dc2),
-			args:      []string{"list", "--all-namespaces", "-n", "foo"},
+			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
 	}


### PR DESCRIPTION
This will remove the namespace checking if --all-namespace
flag is specified, as it is not required

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

