### PR TITLE
Enable yaml lint

### DIFF
--- a/tekton/get-version.yaml
+++ b/tekton/get-version.yaml
@@ -14,7 +14,8 @@ spec:
     script: |
       git status && git fetch -p --all
   - name: get-versions
-    image: goreleaser/goreleaser # because it has git
+    # because it has git
+    image: goreleaser/goreleaser
     workingDir: /workspace/source
     script: |
       echo -n $(git tag --points-at HEAD) > /tekton/results/version

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -91,9 +91,7 @@ function post_build_tests() {
     test_golden_has_been_generated
     test_documentation_has_been_generated
     check_go_lint
-    # Skipping yaml lint because of some issue in CI
-    # https://github.com/tektoncd/plumbing/issues/307
-    # check_yaml_lint
+    check_yaml_lint
 }
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
This will enable yaml lint again as it was
disabled because not working properly before

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Enable yaml lint
```
