### PR TITLE
Fix to provide an error for tkn completion without argument

### DIFF
--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -104,6 +104,7 @@ func Command() *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "utility",
 		},
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				switch args[0] {

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -1,0 +1,32 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/test"
+)
+
+func TestCompletion_Empty(t *testing.T) {
+
+	completion := Command()
+	out, err := test.ExecuteCommand(completion)
+	if err == nil {
+		t.Errorf("No errors was defined. Output: %s", out)
+	}
+	expected := "requires at least 1 arg(s), only received 0"
+	test.AssertOutput(t, expected, err.Error())
+}


### PR DESCRIPTION
# Changes

Earlier Tkn completion with no shell param doesn't do anything but now a help message is printed and non-zero code is returned.

Fixes: #701

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
