### PR TITLE
Fix to provide error in case of no pr logs

### DIFF
--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -876,10 +876,10 @@ func TestLogs_nologs(t *testing.T) {
 	}
 	prlo := logOpts(prName, ns, cs, dc, fake.Streamer([]fake.Log{}), false, false)
 	output, err := fetchLogs(prlo)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+	if err == nil {
+		t.Errorf("Unexpected output: %v", output)
 	}
-	test.AssertOutput(t, "No logs found\n", output)
+	test.AssertOutput(t, "pipelinerun has not started yet", err.Error())
 }
 
 func TestLog_run_failed_with_and_without_follow(t *testing.T) {
@@ -1727,10 +1727,10 @@ func TestLogs_nologs_v1beta1(t *testing.T) {
 	}
 	prlo := logOpts(prName, ns, cs, dc, fake.Streamer([]fake.Log{}), false, false)
 	output, err := fetchLogs(prlo)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+	if err == nil {
+		t.Errorf("Unexpected output: %v", output)
 	}
-	test.AssertOutput(t, "No logs found\n", output)
+	test.AssertOutput(t, "pipelinerun has not started yet", err.Error())
 }
 
 func TestLog_run_failed_with_and_without_follow_v1beta1(t *testing.T) {


### PR DESCRIPTION
# Changes

Earlier when we do `tkn pr logs <pr-name>` we get `no logs found` even if logs are available which is fixed in this PR

Fixes: #969 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
