### PR TITLE
Fix --keep with TaskRun and PipelineRun Delete when Using --task or --pipeline Flags

### DIFF
--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -111,7 +111,7 @@ func TestPipelineRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 6; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -218,7 +218,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" (y/n): PipelineRuns deleted: \"pipeline-run-2\", \"pipeline-run-3\"\n",
+			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" (y/n): All PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -273,6 +273,24 @@ func TestPipelineRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
+		},
+		{
+			name:        "Remove pipelineruns of a pipeline using --keep",
+			command:     []string{"rm", "--pipeline", "pipeline", "-n", "ns", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" keeping 2 pipelineruns (y/n): All but 2 PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using argument with --keep",
+			command:     []string{"rm", "pipelinerun", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep flag should not have any arguments specified with it",
 		},
 	}
 
@@ -379,7 +397,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 6; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -486,7 +504,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" (y/n): PipelineRuns deleted: \"pipeline-run-2\", \"pipeline-run-3\"\n",
+			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" (y/n): All PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -532,6 +550,24 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
+		},
+		{
+			name:        "Remove pipelineruns of a pipeline using --keep",
+			command:     []string{"rm", "--pipeline", "pipeline", "-n", "ns", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: strings.NewReader("y"),
+			wantError:   false,
+			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" keeping 2 pipelineruns (y/n): All but 2 PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using argument with --keep",
+			command:     []string{"rm", "pipelinerun", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: strings.NewReader("y"),
+			wantError:   true,
+			want:        "--keep flag should not have any arguments specified with it",
 		},
 	}
 

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/actions"
@@ -69,7 +70,7 @@ or
 				return fmt.Errorf("keep option should not be lower than 0")
 			}
 
-			if opts.Keep > 0 {
+			if opts.Keep > 0 && opts.ParentResourceName == "" {
 				opts.DeleteAllNs = true
 			}
 
@@ -115,13 +116,22 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 		d = deleter.New("Task", func(_ string) error {
 			return errors.New("the task should not be deleted")
 		})
-		d.WithRelated("TaskRun", taskRunLister(p, cs), func(taskRunName string) error {
+		d.WithRelated("TaskRun", taskRunLister(p, opts.Keep, cs), func(taskRunName string) error {
 			return actions.Delete(trGroupResource, cs, taskRunName, p.Namespace(), &metav1.DeleteOptions{})
 		})
 		d.DeleteRelated(s, []string{opts.ParentResourceName})
 	}
+
 	if !opts.DeleteAllNs {
-		d.PrintSuccesses(s)
+		switch {
+		case opts.Keep > 0:
+			// Should only occur in case of --task flag and --keep being used together
+			fmt.Fprintf(s.Out, "All but %d TaskRuns associated with Task %q deleted in namespace %q\n", opts.Keep, opts.ParentResourceName, p.Namespace())
+		case opts.ParentResourceName != "":
+			fmt.Fprintf(s.Out, "All TaskRuns associated with Task %q deleted in namespace %q\n", opts.ParentResourceName, p.Namespace())
+		default:
+			d.PrintSuccesses(s)
+		}
 	} else if opts.DeleteAllNs {
 		if d.Errors() == nil {
 			if opts.Keep > 0 {
@@ -134,7 +144,7 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 	return d.Errors()
 }
 
-func taskRunLister(p cli.Params, cs *cli.Clients) func(string) ([]string, error) {
+func taskRunLister(p cli.Params, keep int, cs *cli.Clients) func(string) ([]string, error) {
 	return func(taskName string) ([]string, error) {
 		lOpts := metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("tekton.dev/task=%s", taskName),
@@ -143,23 +153,22 @@ func taskRunLister(p cli.Params, cs *cli.Clients) func(string) ([]string, error)
 		if err != nil {
 			return nil, err
 		}
-		var names []string
-		for _, tr := range taskRuns.Items {
-			names = append(names, tr.Name)
-		}
-		return names, nil
+		return keepTaskRuns(taskRuns, keep), nil
 	}
 }
 
 func allTaskRunNames(cs *cli.Clients, keep int, ns string) ([]string, error) {
-
 	taskRuns, err := trlist.TaskRuns(cs, metav1.ListOptions{}, ns)
 	if err != nil {
 		return nil, err
 	}
-	trsort.SortByStartTime(taskRuns.Items)
+	return keepTaskRuns(taskRuns, keep), nil
+}
+
+func keepTaskRuns(taskRuns *v1beta1.TaskRunList, keep int) []string {
 	var names []string
 	var counter = 0
+	trsort.SortByStartTime(taskRuns.Items)
 	for _, tr := range taskRuns.Items {
 		if keep > 0 && counter != keep {
 			counter++
@@ -167,5 +176,5 @@ func allTaskRunNames(cs *cli.Clients, keep int, ns string) ([]string, error) {
 		}
 		names = append(names, tr.Name)
 	}
-	return names, nil
+	return names
 }

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -42,7 +42,13 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 	}
 
-	trdata := []*v1alpha1.TaskRun{
+	tasks := []*v1alpha1.Task{
+		tb.Task("random",
+			tb.TaskNamespace("ns"),
+		),
+	}
+
+	trs := []*v1alpha1.TaskRun{
 		tb.TaskRun("tr0-1",
 			tb.TaskRunNamespace("ns"),
 			tb.TaskRunLabel("tekton.dev/task", "random"),
@@ -83,15 +89,15 @@ func TestTaskRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 5; i++ {
-		trs := trdata
-		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
+	for i := 0; i < 6; i++ {
+		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Tasks: tasks, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 		tdc := testDynamic.Options{}
 		dc, err := tdc.Client(
-			cb.UnstructuredTR(trdata[0], version),
-			cb.UnstructuredTR(trdata[1], version),
-			cb.UnstructuredTR(trdata[2], version),
+			cb.UnstructuredT(tasks[0], version),
+			cb.UnstructuredTR(trs[0], version),
+			cb.UnstructuredTR(trs[1], version),
+			cb.UnstructuredTR(trs[2], version),
 		)
 		if err != nil {
 			t.Errorf("unable to create dynamic client: %v", err)
@@ -182,12 +188,12 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Remove taskruns of a task",
-			command:     []string{"rm", "--task", "task", "-n", "ns"},
+			command:     []string{"rm", "--task", "random", "-n", "ns"},
 			dynamic:     seeds[0].dynamicClient,
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        `Are you sure you want to delete all taskruns related to task "task" (y/n): `,
+			want:        "Are you sure you want to delete all taskruns related to task \"random\" (y/n): All TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -243,6 +249,24 @@ func TestTaskRunDelete(t *testing.T) {
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
+		{
+			name:        "Remove taskruns of a task with --keep",
+			command:     []string{"rm", "--task", "random", "-n", "ns", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Are you sure you want to delete all taskruns related to task \"random\" keeping 2 taskruns (y/n): All but 2 TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using argument with --keep",
+			command:     []string{"rm", "taskrun", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep flag should not have any arguments specified with it",
+		},
 	}
 
 	for _, tp := range testParams {
@@ -281,7 +305,13 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 		},
 	}
 
-	trdata := []*v1alpha1.TaskRun{
+	tasks := []*v1alpha1.Task{
+		tb.Task("random",
+			tb.TaskNamespace("ns"),
+		),
+	}
+
+	trs := []*v1alpha1.TaskRun{
 		tb.TaskRun("tr0-1",
 			tb.TaskRunNamespace("ns"),
 			tb.TaskRunLabel("tekton.dev/task", "random"),
@@ -322,15 +352,15 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 5; i++ {
-		trs := trdata
-		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
+	for i := 0; i < 6; i++ {
+		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Tasks: tasks, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 		tdc := testDynamic.Options{}
 		dc, err := tdc.Client(
-			cb.UnstructuredTR(trdata[0], version),
-			cb.UnstructuredTR(trdata[1], version),
-			cb.UnstructuredTR(trdata[2], version),
+			cb.UnstructuredT(tasks[0], version),
+			cb.UnstructuredTR(trs[0], version),
+			cb.UnstructuredTR(trs[1], version),
+			cb.UnstructuredTR(trs[2], version),
 		)
 		if err != nil {
 			t.Errorf("unable to create dynamic client: %v", err)
@@ -421,12 +451,12 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Remove taskruns of a task",
-			command:     []string{"rm", "--task", "task", "-n", "ns"},
+			command:     []string{"rm", "--task", "random", "-n", "ns"},
 			dynamic:     seeds[0].dynamicClient,
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        `Are you sure you want to delete all taskruns related to task "task" (y/n): `,
+			want:        "Are you sure you want to delete all taskruns related to task \"random\" (y/n): All TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -472,6 +502,24 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
+		},
+		{
+			name:        "Remove taskruns of a task with --keep",
+			command:     []string{"rm", "--task", "random", "-n", "ns", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Are you sure you want to delete all taskruns related to task \"random\" keeping 2 taskruns (y/n): All but 2 TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error from using argument with --keep",
+			command:     []string{"rm", "taskrun", "--keep", "2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep flag should not have any arguments specified with it",
 		},
 	}
 

--- a/pkg/options/delete_test.go
+++ b/pkg/options/delete_test.go
@@ -125,6 +125,13 @@ func TestDeleteOptions(t *testing.T) {
 			want:           "--all flag should not have any arguments or flags specified with it",
 		},
 		{
+			name:           "Error when resource name used with keep",
+			opt:            &DeleteOptions{Keep: 1},
+			resourcesNames: []string{"test1"},
+			wantError:      true,
+			want:           "--keep flag should not have any arguments specified with it",
+		},
+		{
 			name:           "Specify DeleteAll option",
 			opt:            &DeleteOptions{DeleteAll: true},
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},


### PR DESCRIPTION
Closes #965 

This pull request makes `--keep` compatible with `tkn tr delete --task` and `tkn pr delete --pipeline`. With these changes, `tkn tr delete --task taskName --keep 2` would filter TaskRuns by a Task name and keep the most recent 2 TaskRuns associated with the Task `taskName`.

Deletion confirmation messages have been updated for this case as follows:

```
$ tkn pr delete --pipeline pipelineName --keep 2

Are you sure you want to delete all pipelineruns related to pipeline "pipelineName" keeping 2 pipelineruns (y/n): 
All but 2 PipelineRuns associated with Pipeline "pipelineName" deleted in namespace "ns"

$ tkn pr delete --pipeline pipelineName 

Are you sure you want to delete all pipelineruns related to pipeline "pipelineName" (y/n): 
All PipelineRuns associated with Pipeline "pipelineName" deleted in namespace "ns"
```

This pull request also fixes tests associated with `--keep` with TaskRun, which had no Task test data set up for the test. This resulted in the tests not adequately testing if the correct output was received.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Make --keep compatible with --task and --pipeline flag for taskrun and pipelinerun delete
```
