### PR TITLE
American spelling of `color`

### DIFF
--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -14,7 +14,7 @@ Manage clustertasks
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertask
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -14,7 +14,7 @@ Manage clustertasks
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertask
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -41,7 +41,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -41,7 +41,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_describe.md
+++ b/docs/cmd/tkn_clustertask_describe.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_describe.md
+++ b/docs/cmd/tkn_clustertask_describe.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -28,7 +28,7 @@ Lists clustertasks in a namespace
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -28,7 +28,7 @@ Lists clustertasks in a namespace
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -47,7 +47,7 @@ like cat,foo,bar
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -47,7 +47,7 @@ like cat,foo,bar
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -14,7 +14,7 @@ Manage clustertriggerbindings
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertriggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -14,7 +14,7 @@ Manage clustertriggerbindings
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertriggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_delete.md
+++ b/docs/cmd/tkn_clustertriggerbinding_delete.md
@@ -41,7 +41,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_delete.md
+++ b/docs/cmd/tkn_clustertriggerbinding_delete.md
@@ -41,7 +41,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_describe.md
+++ b/docs/cmd/tkn_clustertriggerbinding_describe.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_describe.md
+++ b/docs/cmd/tkn_clustertriggerbinding_describe.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_list.md
+++ b/docs/cmd/tkn_clustertriggerbinding_list.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_list.md
+++ b/docs/cmd/tkn_clustertriggerbinding_list.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition.md
+++ b/docs/cmd/tkn_condition.md
@@ -15,7 +15,7 @@ Manage conditions
   -h, --help                help for condition
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition.md
+++ b/docs/cmd/tkn_condition.md
@@ -15,7 +15,7 @@ Manage conditions
   -h, --help                help for condition
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_describe.md
+++ b/docs/cmd/tkn_condition_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_describe.md
+++ b/docs/cmd/tkn_condition_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_list.md
+++ b/docs/cmd/tkn_condition_list.md
@@ -29,7 +29,7 @@ Lists conditions in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_list.md
+++ b/docs/cmd/tkn_condition_list.md
@@ -29,7 +29,7 @@ Lists conditions in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener.md
+++ b/docs/cmd/tkn_eventlistener.md
@@ -15,7 +15,7 @@ Manage eventlisteners
   -h, --help                help for eventlistener
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener.md
+++ b/docs/cmd/tkn_eventlistener.md
@@ -15,7 +15,7 @@ Manage eventlisteners
   -h, --help                help for eventlistener
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_describe.md
+++ b/docs/cmd/tkn_eventlistener_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_describe.md
+++ b/docs/cmd/tkn_eventlistener_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_list.md
+++ b/docs/cmd/tkn_eventlistener_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_list.md
+++ b/docs/cmd/tkn_eventlistener_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -15,7 +15,7 @@ Manage pipelines
   -h, --help                help for pipeline
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -15,7 +15,7 @@ Manage pipelines
   -h, --help                help for pipeline
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_create.md
+++ b/docs/cmd/tkn_pipeline_create.md
@@ -35,7 +35,7 @@ Create a Pipeline defined by foo.yaml in namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -29,7 +29,7 @@ Describes a pipeline in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -29,7 +29,7 @@ Describes a pipeline in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -31,7 +31,7 @@ Lists pipelines in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -31,7 +31,7 @@ Lists pipelines in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -48,7 +48,7 @@ Show logs for given pipeline and pipelinerun:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -48,7 +48,7 @@ Show logs for given pipeline and pipelinerun:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -63,7 +63,7 @@ my-secret and my-empty-dir)
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -63,7 +63,7 @@ my-secret and my-empty-dir)
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -15,7 +15,7 @@ Manage pipelineruns
   -h, --help                help for pipelinerun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -15,7 +15,7 @@ Manage pipelineruns
   -h, --help                help for pipelinerun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -31,7 +31,7 @@ Cancel the PipelineRun named 'foo' from namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -31,7 +31,7 @@ Cancel the PipelineRun named 'foo' from namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -44,7 +44,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -44,7 +44,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -45,7 +45,7 @@ List all PipelineRuns in a namespace 'foo':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -45,7 +45,7 @@ List all PipelineRuns in a namespace 'foo':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -45,7 +45,7 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -45,7 +45,7 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -15,7 +15,7 @@ Manage pipeline resources
   -h, --help                help for resource
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -15,7 +15,7 @@ Manage pipeline resources
   -h, --help                help for resource
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -33,7 +33,7 @@ Creates new PipelineResource as per the given input:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -33,7 +33,7 @@ Creates new PipelineResource as per the given input:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_describe.md
+++ b/docs/cmd/tkn_resource_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_describe.md
+++ b/docs/cmd/tkn_resource_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -39,7 +39,7 @@ List all PipelineResources in a namespace 'foo':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -39,7 +39,7 @@ List all PipelineResources in a namespace 'foo':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -15,7 +15,7 @@ Manage tasks
   -h, --help                help for task
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -15,7 +15,7 @@ Manage tasks
   -h, --help                help for task
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_create.md
+++ b/docs/cmd/tkn_task_create.md
@@ -35,7 +35,7 @@ Create a Task defined by foo.yaml in namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_describe.md
+++ b/docs/cmd/tkn_task_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_describe.md
+++ b/docs/cmd/tkn_task_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -31,7 +31,7 @@ Lists tasks in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -31,7 +31,7 @@ Lists tasks in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_logs.md
+++ b/docs/cmd/tkn_task_logs.md
@@ -47,7 +47,7 @@ Show logs for given task and taskrun:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_logs.md
+++ b/docs/cmd/tkn_task_logs.md
@@ -47,7 +47,7 @@ Show logs for given task and taskrun:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -51,7 +51,7 @@ like cat,foo,bar
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -51,7 +51,7 @@ like cat,foo,bar
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -15,7 +15,7 @@ Manage taskruns
   -h, --help                help for taskrun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -15,7 +15,7 @@ Manage taskruns
   -h, --help                help for taskrun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -31,7 +31,7 @@ Cancel the TaskRun named 'foo' from namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -31,7 +31,7 @@ Cancel the TaskRun named 'foo' from namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -44,7 +44,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -44,7 +44,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -45,7 +45,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -45,7 +45,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -45,7 +45,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -45,7 +45,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding.md
+++ b/docs/cmd/tkn_triggerbinding.md
@@ -15,7 +15,7 @@ Manage triggerbindings
   -h, --help                help for triggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding.md
+++ b/docs/cmd/tkn_triggerbinding.md
@@ -15,7 +15,7 @@ Manage triggerbindings
   -h, --help                help for triggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_describe.md
+++ b/docs/cmd/tkn_triggerbinding_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_describe.md
+++ b/docs/cmd/tkn_triggerbinding_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_list.md
+++ b/docs/cmd/tkn_triggerbinding_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_list.md
+++ b/docs/cmd/tkn_triggerbinding_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate.md
+++ b/docs/cmd/tkn_triggertemplate.md
@@ -15,7 +15,7 @@ Manage triggertemplates
   -h, --help                help for triggertemplate
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate.md
+++ b/docs/cmd/tkn_triggertemplate.md
@@ -15,7 +15,7 @@ Manage triggertemplates
   -h, --help                help for triggertemplate
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_describe.md
+++ b/docs/cmd/tkn_triggertemplate_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_describe.md
+++ b/docs/cmd/tkn_triggertemplate_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_list.md
+++ b/docs/cmd/tkn_triggertemplate_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolor            disable coloring (default: false)
+  -C, --nocolor             disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_list.md
+++ b/docs/cmd/tkn_triggertemplate_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --nocolor            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -55,8 +55,8 @@ Delete clustertask resources in a cluster
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertask-describe.1
+++ b/docs/man/man1/tkn-clustertask-describe.1
@@ -47,8 +47,8 @@ Describes a clustertask
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -47,8 +47,8 @@ Lists clustertasks in a namespace
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -74,8 +74,8 @@ Start clustertasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertask.1
+++ b/docs/man/man1/tkn-clustertask.1
@@ -32,8 +32,8 @@ Manage clustertasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-clustertriggerbinding-delete.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-delete.1
@@ -55,8 +55,8 @@ Delete clustertriggerbindings
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertriggerbinding-describe.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-describe.1
@@ -47,8 +47,8 @@ Describes a clustertriggerbinding
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertriggerbinding-list.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-list.1
@@ -47,8 +47,8 @@ Lists clustertriggerbindings in a namespace
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertriggerbinding.1
+++ b/docs/man/man1/tkn-clustertriggerbinding.1
@@ -32,8 +32,8 @@ Manage clustertriggerbindings
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -59,8 +59,8 @@ Delete a condition in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-condition-describe.1
+++ b/docs/man/man1/tkn-condition-describe.1
@@ -51,8 +51,8 @@ Describe Conditions in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-condition-list.1
+++ b/docs/man/man1/tkn-condition-list.1
@@ -51,8 +51,8 @@ Lists conditions in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-condition.1
+++ b/docs/man/man1/tkn-condition.1
@@ -36,8 +36,8 @@ Manage conditions
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-eventlistener-delete.1
+++ b/docs/man/man1/tkn-eventlistener-delete.1
@@ -59,8 +59,8 @@ Delete EventListeners in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener-describe.1
+++ b/docs/man/man1/tkn-eventlistener-describe.1
@@ -51,8 +51,8 @@ Describe EventListener in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener-list.1
+++ b/docs/man/man1/tkn-eventlistener-list.1
@@ -51,8 +51,8 @@ Lists eventlisteners in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener.1
+++ b/docs/man/man1/tkn-eventlistener.1
@@ -36,8 +36,8 @@ Manage eventlisteners
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-create.1
+++ b/docs/man/man1/tkn-pipeline-create.1
@@ -55,8 +55,8 @@ Create a pipeline in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -63,8 +63,8 @@ Delete pipelines in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline-describe.1
+++ b/docs/man/man1/tkn-pipeline-describe.1
@@ -51,8 +51,8 @@ Describes a pipeline in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-list.1
+++ b/docs/man/man1/tkn-pipeline-list.1
@@ -59,8 +59,8 @@ Lists pipelines in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -54,8 +54,8 @@ Show pipeline logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -106,8 +106,8 @@ Parameters, at least those that have no default value
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline.1
+++ b/docs/man/man1/tkn-pipeline.1
@@ -36,8 +36,8 @@ Manage pipelines
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -38,8 +38,8 @@ Cancel a PipelineRun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -67,8 +67,8 @@ Delete pipelineruns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -63,8 +63,8 @@ Describe a pipelinerun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -71,8 +71,8 @@ Lists pipelineruns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -62,8 +62,8 @@ Show the logs of PipelineRun
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun.1
+++ b/docs/man/man1/tkn-pipelinerun.1
@@ -36,8 +36,8 @@ Manage pipelineruns
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-resource-create.1
+++ b/docs/man/man1/tkn-resource-create.1
@@ -51,8 +51,8 @@ Create a pipeline resource in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -59,8 +59,8 @@ Delete pipeline resources in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource-describe.1
+++ b/docs/man/man1/tkn-resource-describe.1
@@ -51,8 +51,8 @@ Describes a pipeline resource in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource-list.1
+++ b/docs/man/man1/tkn-resource-list.1
@@ -63,8 +63,8 @@ Lists pipeline resources in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource.1
+++ b/docs/man/man1/tkn-resource.1
@@ -36,8 +36,8 @@ Manage pipeline resources
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-create.1
+++ b/docs/man/man1/tkn-task-create.1
@@ -55,8 +55,8 @@ Create a task in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -63,8 +63,8 @@ Delete task resources in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-describe.1
+++ b/docs/man/man1/tkn-task-describe.1
@@ -51,8 +51,8 @@ Describes a task in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-list.1
+++ b/docs/man/man1/tkn-task-list.1
@@ -59,8 +59,8 @@ Lists tasks in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-logs.1
+++ b/docs/man/man1/tkn-task-logs.1
@@ -54,8 +54,8 @@ Show task logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -94,8 +94,8 @@ Start tasks
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task.1
+++ b/docs/man/man1/tkn-task.1
@@ -36,8 +36,8 @@ Manage tasks
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-taskrun-cancel.1
+++ b/docs/man/man1/tkn-taskrun-cancel.1
@@ -38,8 +38,8 @@ Cancel a TaskRun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -67,8 +67,8 @@ Delete taskruns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -63,8 +63,8 @@ Describe a taskrun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -71,8 +71,8 @@ Lists TaskRuns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -62,8 +62,8 @@ Show taskruns logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun.1
+++ b/docs/man/man1/tkn-taskrun.1
@@ -36,8 +36,8 @@ Manage taskruns
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-triggerbinding-delete.1
+++ b/docs/man/man1/tkn-triggerbinding-delete.1
@@ -59,8 +59,8 @@ Delete triggerbindings in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggerbinding-describe.1
+++ b/docs/man/man1/tkn-triggerbinding-describe.1
@@ -51,8 +51,8 @@ Describes a triggerbinding in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggerbinding-list.1
+++ b/docs/man/man1/tkn-triggerbinding-list.1
@@ -51,8 +51,8 @@ Lists triggerbindings in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggerbinding.1
+++ b/docs/man/man1/tkn-triggerbinding.1
@@ -36,8 +36,8 @@ Manage triggerbindings
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-triggertemplate-delete.1
+++ b/docs/man/man1/tkn-triggertemplate-delete.1
@@ -59,8 +59,8 @@ Delete triggertemplates in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggertemplate-describe.1
+++ b/docs/man/man1/tkn-triggertemplate-describe.1
@@ -51,8 +51,8 @@ Describes a triggertemplate in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggertemplate-list.1
+++ b/docs/man/man1/tkn-triggertemplate-list.1
@@ -51,8 +51,8 @@ Lists triggertemplates in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggertemplate.1
+++ b/docs/man/man1/tkn-triggertemplate.1
@@ -36,8 +36,8 @@ Manage triggertemplates
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-nocolor\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -57,8 +57,8 @@ type Params interface {
 	SetNamespace(string)
 	Namespace() string
 
-	// SetNoColour set colouring or not
-	SetNoColour(bool)
+	// SetNoColor set coloring or not
+	SetNoColor(bool)
 
 	Time() clockwork.Clock
 }

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -178,7 +178,7 @@ func (p *TektonParams) config() (*rest.Config, error) {
 	return config, nil
 }
 
-func (p *TektonParams) SetNoColour(b bool) {
+func (p *TektonParams) SetNoColor(b bool) {
 	color.NoColor = b
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -29,7 +29,7 @@ const (
 	kubeConfig = "kubeconfig"
 	context    = "context"
 	namespace  = "namespace"
-	nocolor   = "nocolor"
+	nocolor    = "nocolor"
 )
 
 // AddTektonOptions amends command to add flags required to initialise a cli.Param

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -29,7 +29,7 @@ const (
 	kubeConfig = "kubeconfig"
 	context    = "context"
 	namespace  = "namespace"
-	nocolour   = "nocolour"
+	nocolor   = "nocolor"
 )
 
 // AddTektonOptions amends command to add flags required to initialise a cli.Param
@@ -47,8 +47,8 @@ func AddTektonOptions(cmd *cobra.Command) {
 		"namespace to use (default: from $KUBECONFIG)")
 
 	cmd.PersistentFlags().BoolP(
-		nocolour, "C", false,
-		"disable colouring (default: false)")
+		nocolor, "C", false,
+		"disable coloring (default: false)")
 
 	// Add custom completion for that command as specified in
 	// bashCompletionFlags map
@@ -89,19 +89,19 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 		p.SetNamespace(ns)
 	}
 
-	nocolourFlag, err := cmd.Flags().GetBool(nocolour)
+	nocolorFlag, err := cmd.Flags().GetBool(nocolor)
 	if err != nil {
 		return err
 	}
-	p.SetNoColour(nocolourFlag)
+	p.SetNoColor(nocolorFlag)
 
-	// Make sure we set as Nocolour if we don't have a terminal (ie redirection)
+	// Make sure we set as Nocolor if we don't have a terminal (ie redirection)
 	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
-		p.SetNoColour(true)
+		p.SetNoColor(true)
 	}
 
 	if runtime.GOOS == "windows" {
-		p.SetNoColour(true)
+		p.SetNoColor(true)
 	}
 
 	return nil

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -41,11 +41,11 @@ func TestFlags_add_shell_completion(t *testing.T) {
 	}
 }
 
-func TestFlags_colouring(t *testing.T) {
+func TestFlags_coloring(t *testing.T) {
 	// When running it on CI, our test don't have a tty so this gets disabled
 	// automatically, not really sure how can we workaround that :(
 	// cmd := &cobra.Command{}
-	// cmd.SetArgs([]string{"--nocolour"})
+	// cmd.SetArgs([]string{"--nocolor"})
 	// _ = InitParams(&cli.TektonParams{}, cmd)
 	// assert.False(t, color.NoColor)
 

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -35,7 +35,7 @@ var (
 )
 
 // DecorateAttr decorate strings with a color or an emoji, respecting the user
-// preference if no colour needed.
+// preference if no color needed.
 func DecorateAttr(attrString, message string) string {
 	if color.NoColor {
 		return message
@@ -134,7 +134,7 @@ func (r *rainbow) get(x string) color.Attribute {
 }
 
 // Fprintf formats according to a format specifier and writes to w.
-// the first argument is a label to keep the same colour on.
+// the first argument is a label to keep the same color on.
 func (r *rainbow) Fprintf(label string, w io.Writer, format string, args ...interface{}) {
 	attribute := r.get(label)
 	crainbow := color.Set(attribute).Add(color.Bold)

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -24,7 +24,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestRainbowsColours(t *testing.T) {
+func TestRainbowsColors(t *testing.T) {
 	rb := newRainbow()
 	assert.Equal(t, rb.counter.value, uint32(0)) // nothing
 
@@ -55,7 +55,7 @@ func TestNoDecoration(t *testing.T) {
 		want string
 	}{
 		{
-			name: "test that no colour get passed when running in tests",
+			name: "test that no color get passed when running in tests",
 			args: args{"foo", "message"},
 			want: "message",
 		},
@@ -70,7 +70,7 @@ func TestNoDecoration(t *testing.T) {
 }
 
 func TestDecoration(t *testing.T) {
-	// We disable emoji and other colourful stuff while testing,
+	// We disable emoji and other colorful stuff while testing,
 	// but here we want to explicitly enable it.
 	color.NoColor = false
 	defer func() {

--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -34,7 +34,7 @@ var ConditionColor = map[string]color.Attribute{
 
 var stepCounter uint64
 
-// ColorStatus Get a status coloured
+// ColorStatus Get a status colored
 func ColorStatus(status string) string {
 	return color.New(ConditionColor[status]).Sprint(status)
 }

--- a/pkg/options/describe.go
+++ b/pkg/options/describe.go
@@ -100,9 +100,9 @@ func (opts *DescribeOptions) Ask(resource string, options []string) error {
 }
 
 func (opts *DescribeOptions) FuzzyAsk(resource string, options []string) error {
-	chosencolouring := color.NoColor
+	chosencoloring := color.NoColor
 	defer func() {
-		color.NoColor = chosencolouring
+		color.NoColor = chosencoloring
 	}()
 	// Remove colors as fuzzyfinder doesn't support it
 	color.NoColor = true

--- a/pkg/options/logs.go
+++ b/pkg/options/logs.go
@@ -99,9 +99,9 @@ func (opts *LogOptions) Ask(resource string, options []string) error {
 }
 
 func (opts *LogOptions) FuzzyAsk(resource string, options []string) error {
-	chosencolouring := color.NoColor
+	chosencoloring := color.NoColor
 	defer func() {
-		color.NoColor = chosencolouring
+		color.NoColor = chosencoloring
 	}()
 	// Remove colors as fuzzyfinder doesn't support it!
 	color.NoColor = true

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -44,7 +44,7 @@ func (p *Params) Namespace() string {
 	return p.ns
 }
 
-func (p *Params) SetNoColour(b bool) {
+func (p *Params) SetNoColor(b bool) {
 }
 
 func (p *Params) SetKubeConfigPath(path string) {


### PR DESCRIPTION
# Changes

- The Kubernetes ecosystem and community have standardized on the
American spelling of words. This commit converts to `colour` to `color`
to be consistent with the community at large.

Signed-off-by: JJ Asghar <jjasghar@gmail.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Changed the spelling of colour to color.
```
