### PR TITLE
Fix tkn task delete <name> --trs deletes ClusterTaskrun also

### DIFF
--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -125,6 +125,8 @@ func taskRunLister(cs *cli.Clients, ns string) func(string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		// this is required as the same label is getting added for both Task and ClusterTask
+		taskRuns.Items = task.FilterByRef(taskRuns.Items, "Task")
 		var names []string
 		for _, tr := range taskRuns.Items {
 			names = append(names, tr.Name)

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -51,7 +51,7 @@ func TestTaskDelete(t *testing.T) {
 	trdata := []*v1alpha1.TaskRun{
 		tb.TaskRun("task-run-1", "ns",
 			tb.TaskRunLabel("tekton.dev/task", "task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
@@ -61,7 +61,20 @@ func TestTaskDelete(t *testing.T) {
 		),
 		tb.TaskRun("task-run-2", "ns",
 			tb.TaskRunLabel("tekton.dev/task", "task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		// ClusterTask is provided in the TaskRef of TaskRun, so as to verify
+		// TaskRun created by ClusterTask is not getting deleted while deleting
+		// Task with `--trs` flag and name of Task and ClusterTask is same.
+		tb.TaskRun("task-run-3", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "task"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind(v1alpha1.ClusterTaskKind))),
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
@@ -93,6 +106,7 @@ func TestTaskDelete(t *testing.T) {
 			cb.UnstructuredT(tdata[1], version),
 			cb.UnstructuredTR(trdata[0], version),
 			cb.UnstructuredTR(trdata[1], version),
+			cb.UnstructuredTR(trdata[2], version),
 		)
 		if err != nil {
 			t.Errorf("unable to create dynamic client: %v", err)
@@ -290,7 +304,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 	trdata := []*v1alpha1.TaskRun{
 		tb.TaskRun("task-run-1", "ns",
 			tb.TaskRunLabel("tekton.dev/task", "task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
@@ -300,7 +314,20 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 		),
 		tb.TaskRun("task-run-2", "ns",
 			tb.TaskRunLabel("tekton.dev/task", "task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
+			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Status: corev1.ConditionTrue,
+					Reason: resources.ReasonSucceeded,
+				}),
+			),
+		),
+		// ClusterTask is provided in the TaskRef of TaskRun, so as to verify
+		// TaskRun created by ClusterTask is not getting deleted while deleting
+		// Task with `--trs` flag and name of Task and ClusterTask is same.
+		tb.TaskRun("task-run-3", "ns",
+			tb.TaskRunLabel("tekton.dev/task", "task"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("task", tb.TaskRefKind(v1alpha1.ClusterTaskKind))),
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
@@ -332,6 +359,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			cb.UnstructuredT(tdata[1], version),
 			cb.UnstructuredTR(trdata[0], version),
 			cb.UnstructuredTR(trdata[1], version),
+			cb.UnstructuredTR(trdata[2], version),
 		)
 		if err != nil {
 			t.Errorf("unable to create dynamic client: %v", err)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Earlier `tkn task delete <name> --trs` deletes the taskrun created by `clustertask` if the name of task and clustertask is same, This PR fixes this issue.

Fixes: #972

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

