### PR TITLE
Add support for filtering by field-selector on pipelineruns and taskruns

### DIFF
--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -30,6 +30,7 @@ List all PipelineRuns in a namespace 'foo':
 ```
   -A, --all-namespaces                list PipelineRuns from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --field-selector string         Selector (field query) to filter on. Supports '=', '==', and '!=' (e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='
       --limit int                     limit PipelineRuns listed (default: return all PipelineRuns)

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -30,6 +30,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 ```
   -A, --all-namespaces                list TaskRuns from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --field-selector string         Selector (field query) to filter on. Supports '=', '==', and '!=' (e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='
       --limit int                     limit TaskRuns listed (default: return all TaskRuns)

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -28,6 +28,10 @@ Lists PipelineRuns in a namespace
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
+\fB\-\-field\-selector\fP=""
+    Selector (field query) to filter on. Supports '=', '==', and '!=' (e.g. \-\-field\-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for list
 

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -28,6 +28,10 @@ Lists TaskRuns in a namespace
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
+\fB\-\-field\-selector\fP=""
+    Selector (field query) to filter on. Supports '=', '==', and '!=' (e.g. \-\-field\-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for list
 

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-list_pipelinerun_by_field-selector.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-list_pipelinerun_by_field-selector.golden
@@ -1,0 +1,2 @@
+NAME    STARTED   DURATION   STATUS
+pr0-1   ---       ---        ---

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-list_pipelinerun_by_field-selector_negative_case.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-list_pipelinerun_by_field-selector_negative_case.golden
@@ -1,0 +1,1 @@
+Error: failed to list PipelineRuns from namespace namespace: field label not supported: a

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-list_pipelinerun_by_field-selector.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-list_pipelinerun_by_field-selector.golden
@@ -1,0 +1,2 @@
+NAME    STARTED          DURATION   STATUS
+pr1-1   59 minutes ago   1 minute   Succeeded

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-list_pipelinerun_by_field-selector_negative_case.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-list_pipelinerun_by_field-selector_negative_case.golden
@@ -1,0 +1,1 @@
+Error: failed to list PipelineRuns from namespace namespace: field label not supported: a

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-list_taskruns_by_field-selector.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-list_taskruns_by_field-selector.golden
@@ -1,0 +1,2 @@
+NAME    STARTED   DURATION   STATUS
+tr0-1   ---       ---        Succeeded

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-list_taskruns_by_field-selector_negative_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-list_taskruns_by_field-selector_negative_case.golden
@@ -1,0 +1,1 @@
+Error: failed to list TaskRuns from namespace foo: field label not supported: a

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-list_taskruns_by_field-selector.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-list_taskruns_by_field-selector.golden
@@ -1,0 +1,2 @@
+NAME    STARTED      DURATION   STATUS
+tr1-1   1 hour ago   1 minute   Succeeded

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-list_taskruns_by_field-selector_negative_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-list_taskruns_by_field-selector_negative_case.golden
@@ -1,0 +1,1 @@
+Error: failed to list TaskRuns from namespace foo: field label not supported: a

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -192,6 +192,20 @@ Waiting for logs to be available...
 
 	time.Sleep(1 * time.Second)
 
+	t.Run("Get list of Pipelineruns using field-selector", func(t *testing.T) {
+		pipelinerunGeneratedName := e2e.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
+		fs := "metadata.name=" + pipelinerunGeneratedName
+		res := tkn.Run("pipelinerun", "list", "--field-selector", fs)
+
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Err:      icmd.None,
+		})
+		prname := e2e.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
+		prlist := res.Stdout()
+		assert.Check(t, strings.Contains(prlist, prname), "String does not contain expected PipelineRun name")
+	})
+
 	t.Run("Get list of Taskruns from namespace  "+namespace, func(t *testing.T) {
 		res := tkn.Run("taskrun", "list")
 

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -98,6 +98,41 @@ Waiting for logs to be available...
 		})
 	})
 
+	t.Run("Get a Taskrun using field-selector from namespace  "+namespace, func(t *testing.T) {
+		taskRunGeneratedName := e2e.GetTaskRunListWithName(c, "read-task").Items[0].Name
+		fs := "metadata.name=" + taskRunGeneratedName
+		res := tkn.Run("taskrun", "list", "--field-selector", fs)
+
+		expected := e2e.ListAllTaskRunsOutput(t, c, false, map[int]interface{}{
+			0: &e2e.TaskRunData{
+				Name:   taskRunGeneratedName,
+				Status: "Succeeded",
+			},
+		})
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Err:      icmd.None,
+			Out:      expected,
+		})
+	})
+
+	t.Run("Get list of Taskruns using field-selector from namespace  "+namespace, func(t *testing.T) {
+		fs := "metadata.namespace=" + namespace
+		res := tkn.Run("taskrun", "list", "--field-selector", fs)
+
+		expected := e2e.ListAllTaskRunsOutput(t, c, false, map[int]interface{}{
+			0: &e2e.TaskRunData{
+				Name:   "read-task-run-",
+				Status: "Succeeded",
+			},
+		})
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Err:      icmd.None,
+			Out:      expected,
+		})
+	})
+
 	t.Run("Validate interactive task logs, with  follow mode (-f) ", func(t *testing.T) {
 		tkn.RunInteractiveTests(t, &e2e.Prompt{
 			CmdArgs: []string{"task", "logs", "-f"},


### PR DESCRIPTION
# Changes

This adds --field-selector option to allow filtering basis of key value pair for pipelineruns and taskruns
Part of #684 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

