### PR TITLE
Change Taskrun and PipelineRun Delete Test Names

### DIFF
--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -196,7 +196,7 @@ func TestPipelineDelete(t *testing.T) {
 			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
-			name:        "With delete all flag, reply yes",
+			name:        "With --prs flag, reply yes",
 			command:     []string{"rm", "pipeline", "-n", "ns", "--prs"},
 			dynamic:     seeds[3].dynamicClient,
 			input:       seeds[3].pipelineClient,
@@ -205,7 +205,7 @@ func TestPipelineDelete(t *testing.T) {
 			want:        "Are you sure you want to delete pipeline and related resources \"pipeline\" (y/n): PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
 		},
 		{
-			name:        "With delete all and force delete flag",
+			name:        "With --prs and force delete flag",
 			command:     []string{"rm", "pipeline", "-n", "ns", "-f", "--prs"},
 			dynamic:     seeds[4].dynamicClient,
 			input:       seeds[4].pipelineClient,

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -183,7 +183,7 @@ func TestTaskDelete(t *testing.T) {
 			want:        "Are you sure you want to delete task and related resources \"task\" (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
 		},
 		{
-			name:        "With delete all and force delete flag",
+			name:        "With --trs and force delete flag",
 			command:     []string{"rm", "task", "-n", "ns", "-f", "--trs"},
 			dynamic:     seeds[4].dynamicClient,
 			input:       seeds[4].pipelineClient,


### PR DESCRIPTION
Minor clean up of test names using `--trs` and `--prs` flag. Test names still reference `--all` in names, which used to be the flag for `--prs`/`--trs`.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
N/A
```
