### PR TITLE
Add `--trs` flag in `tkn ct delete` command

### DIFF
--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -34,6 +34,7 @@ or
   -h, --help                          help for delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+      --trs                           Whether to delete ClusterTask(s) and related resources (TaskRuns) (default: false)
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -44,6 +44,10 @@ Delete clustertask resources in a cluster
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].
 
+.PP
+\fB\-\-trs\fP[=false]
+    Whether to delete ClusterTask(s) and related resources (TaskRuns) (default: false)
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`tkn ct delete <cluster-task-name>` does not have support for
deleting related TaskRuns with ClusterTask.
Added `--trs` flag to add support to delete related `TaskRuns`.

Fixes: #994

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Added support for `--trs` in ClusterTask delete command, which will now delete ClusterTask along with the specified ClusterTask
```
