### PR TITLE
Command Suggestion for Incorrect Subcommands

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -2,6 +2,12 @@
 
 CLI for tekton pipelines
 
+### Usage
+
+```
+tkn
+```
+
 ### Synopsis
 
 CLI for tekton pipelines

--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -4,6 +4,12 @@ Manage clustertasks
 
 ***Aliases**: ct,clustertasks*
 
+### Usage
+
+```
+tkn clustertask
+```
+
 ### Synopsis
 
 Manage clustertasks

--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -4,6 +4,12 @@ Manage clustertriggerbindings
 
 ***Aliases**: ctb,clustertriggerbindings*
 
+### Usage
+
+```
+tkn clustertriggerbinding
+```
+
 ### Synopsis
 
 Manage clustertriggerbindings

--- a/docs/cmd/tkn_condition.md
+++ b/docs/cmd/tkn_condition.md
@@ -4,6 +4,12 @@ Manage conditions
 
 ***Aliases**: cond,conditions*
 
+### Usage
+
+```
+tkn condition
+```
+
 ### Synopsis
 
 Manage conditions

--- a/docs/cmd/tkn_eventlistener.md
+++ b/docs/cmd/tkn_eventlistener.md
@@ -4,6 +4,12 @@ Manage eventlisteners
 
 ***Aliases**: el,eventlisteners*
 
+### Usage
+
+```
+tkn eventlistener
+```
+
 ### Synopsis
 
 Manage eventlisteners

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -4,6 +4,12 @@ Manage pipelines
 
 ***Aliases**: p,pipelines*
 
+### Usage
+
+```
+tkn pipeline
+```
+
 ### Synopsis
 
 Manage pipelines

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -4,6 +4,12 @@ Manage pipelineruns
 
 ***Aliases**: pr,pipelineruns*
 
+### Usage
+
+```
+tkn pipelinerun
+```
+
 ### Synopsis
 
 Manage pipelineruns

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -4,6 +4,12 @@ Manage pipeline resources
 
 ***Aliases**: res,resources*
 
+### Usage
+
+```
+tkn resource
+```
+
 ### Synopsis
 
 Manage pipeline resources

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -4,6 +4,12 @@ Manage tasks
 
 ***Aliases**: t,tasks*
 
+### Usage
+
+```
+tkn task
+```
+
 ### Synopsis
 
 Manage tasks

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -4,6 +4,12 @@ Manage taskruns
 
 ***Aliases**: tr,taskruns*
 
+### Usage
+
+```
+tkn taskrun
+```
+
 ### Synopsis
 
 Manage taskruns

--- a/docs/cmd/tkn_triggerbinding.md
+++ b/docs/cmd/tkn_triggerbinding.md
@@ -4,6 +4,12 @@ Manage triggerbindings
 
 ***Aliases**: tb,triggerbindings*
 
+### Usage
+
+```
+tkn triggerbinding
+```
+
 ### Synopsis
 
 Manage triggerbindings

--- a/docs/cmd/tkn_triggertemplate.md
+++ b/docs/cmd/tkn_triggertemplate.md
@@ -4,6 +4,12 @@ Manage triggertemplates
 
 ***Aliases**: tt,triggertemplates*
 
+### Usage
+
+```
+tkn triggertemplate
+```
+
 ### Synopsis
 
 Manage triggertemplates

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -30,8 +30,8 @@ func TestCommand_no_global_flags(t *testing.T) {
 	p := &test.Params{}
 	pipelinerun := Root(p)
 	out, err := test.ExecuteCommand(pipelinerun)
-	if err == nil {
-		t.Errorf("test should have command with an error: `subcommand is required` Output: `%s`", out)
+	if err != nil {
+		t.Errorf("TestCommand_no_global_flags should not result in an error but did: %v", err)
 	}
 
 	if strings.Contains(out, unwantedflag) {
@@ -47,5 +47,16 @@ func TestCommand_suggest(t *testing.T) {
 		t.Errorf("No errors was defined. Output: %s", out)
 	}
 	expected := "unknown command \"pi\" for \"tkn\"\n\nDid you mean this?\n\tpipeline\n\tpipelinerun\n"
+	tu.AssertOutput(t, expected, err.Error())
+}
+
+func TestSubCommand_suggest(t *testing.T) {
+	p := &test.Params{}
+	pipelinedescriberun := Root(p)
+	out, err := test.ExecuteCommand(pipelinedescriberun, "pipeline", "des")
+	if err == nil {
+		t.Errorf("No errors was defined. Output: %s", out)
+	}
+	expected := "unknown command \"des\" for \"tkn pipeline\"\n\nDid you mean this?\n\tdescribe\n"
 	tu.AssertOutput(t, expected, err.Error())
 }

--- a/pkg/suggestion/suggest.go
+++ b/pkg/suggestion/suggest.go
@@ -1,0 +1,137 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package suggestion
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// SubcommandsRequiredWithSuggestions will ensure we have a subcommand provided by the user and augments it with
+// suggestion for commands, alias and help on root command.
+func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error {
+	requireMsg := "unknown command \"%s\" for \"%s\""
+	typedName := ""
+	// This will be triggered if cobra didn't find any subcommands.
+	// Find some suggestions.
+	var suggestions []string
+
+	if len(args) != 0 && !cmd.DisableSuggestions {
+		typedName += args[0]
+		if cmd.SuggestionsMinimumDistance <= 0 {
+			cmd.SuggestionsMinimumDistance = 2
+		}
+		// subcommand suggestions
+		suggestions = cmd.SuggestionsFor(args[0])
+
+		// subcommand alias suggestions (with distance, not exact)
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() {
+				candidate := suggestsByPrefixOrLd(typedName, c.Name(), cmd.SuggestionsMinimumDistance)
+				if candidate == "" {
+					continue
+				}
+				_, found := Find(suggestions, candidate)
+				if !found {
+					suggestions = append(suggestions, candidate)
+				}
+			}
+		}
+
+		// help for root command
+		if !cmd.HasParent() {
+			candidate := suggestsByPrefixOrLd(typedName, "help", cmd.SuggestionsMinimumDistance)
+			if candidate != "" {
+				suggestions = append(suggestions, candidate)
+			}
+		}
+	}
+
+	var suggestionsMsg string
+	if len(suggestions) > 0 {
+		suggestionsMsg += "\nDid you mean this?\n"
+		for _, s := range suggestions {
+			suggestionsMsg += fmt.Sprintf("\t%v\n", s)
+		}
+	}
+
+	if suggestionsMsg != "" {
+		requireMsg = fmt.Sprintf("%s\n%s", requireMsg, suggestionsMsg)
+		return fmt.Errorf(requireMsg, typedName, cmd.CommandPath())
+	}
+
+	return cmd.Help()
+}
+
+// suggestsByPrefixOrLd suggests a command by levenshtein distance or by prefix.
+// It returns an empty string if nothing was found
+func suggestsByPrefixOrLd(typedName, candidate string, minDistance int) string {
+	levenshteinVariable := levenshteinDistance(typedName, candidate, true)
+	suggestByLevenshtein := levenshteinVariable <= minDistance
+	suggestByPrefix := strings.HasPrefix(strings.ToLower(candidate), strings.ToLower(typedName))
+	if !suggestByLevenshtein && !suggestByPrefix {
+		return ""
+	}
+	return candidate
+}
+
+// ld compares two strings and returns the levenshtein distance between them.
+func levenshteinDistance(s, t string, ignoreCase bool) int {
+	if ignoreCase {
+		s = strings.ToLower(s)
+		t = strings.ToLower(t)
+	}
+	d := make([][]int, len(s)+1)
+	for i := range d {
+		d[i] = make([]int, len(t)+1)
+	}
+	for i := range d {
+		d[i][0] = i
+	}
+	for j := range d[0] {
+		d[0][j] = j
+	}
+	for j := 1; j <= len(t); j++ {
+		for i := 1; i <= len(s); i++ {
+			if s[i-1] == t[j-1] {
+				d[i][j] = d[i-1][j-1]
+			} else {
+				min := d[i-1][j]
+				if d[i][j-1] < min {
+					min = d[i][j-1]
+				}
+				if d[i-1][j-1] < min {
+					min = d[i-1][j-1]
+				}
+				d[i][j] = min + 1
+			}
+		}
+
+	}
+	return d[len(s)][len(t)]
+}
+
+// Find takes a slice and looks for an element in it. If found it will
+// return it's key, otherwise it will return -1 and a bool of false.
+func Find(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/pkg/suggestion/suggest_test.go
+++ b/pkg/suggestion/suggest_test.go
@@ -1,0 +1,50 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package suggestion
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/cmd/task"
+	"github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
+	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
+	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSuggestion(t *testing.T) {
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"task"})
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client()
+	if err != nil {
+		fmt.Println(err)
+	}
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	task := task.Command(p)
+	args := []string{"l"}
+	err = SubcommandsRequiredWithSuggestions(task, args)
+	test.AssertOutput(t, "unknown command \"l\" for \"task\"\n\nDid you mean this?\n\tlist\n\tlogs\n", err.Error())
+}


### PR DESCRIPTION
# Changes

Earlier there were no suggestions for tkn subcommands but with this patch entering wrong subcommands will give suggestions.
example:- tkn p des

Error: unknown command "des" for "pipeline"

Did you mean this?
	describe

Signed-off-by: vinamra28 <vinjain@redhat.com>

Fixes #291 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
