### PR TITLE
Remove Namespace Validation from List Pipeline

### DIFF
--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/pipeline"
-	"github.com/tektoncd/cli/pkg/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -79,13 +78,6 @@ func listCommand(p cli.Params) *cobra.Command {
 		},
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if !opts.AllNamespaces {
-				if err := validate.NamespaceExists(p); err != nil {
-					return err
-				}
-			}
-
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
 				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")

--- a/pkg/cmd/pipeline/list_test.go
+++ b/pkg/cmd/pipeline/list_test.go
@@ -33,29 +33,6 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func TestPipelinesList_invalid_namespace(t *testing.T) {
-
-	nsList := []*corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
-			},
-		},
-	}
-
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: nsList})
-	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube}
-
-	pipeline := Command(p)
-	output, err := test.ExecuteCommand(pipeline, "list", "-n", "invalid")
-
-	if err == nil {
-		t.Errorf("Error expected for invalid namespace")
-	}
-
-	test.AssertOutput(t, "Error: namespaces \"invalid\" not found\n", output)
-}
-
 func TestPipelinesList_empty(t *testing.T) {
 
 	nsList := []*corev1.Namespace{


### PR DESCRIPTION
Removing namespace validation from listing pipeline because it
conflicts with common scenario of having sample pipelines in a
namespace in which user doesn't have access except list pipelines.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
