### PR TITLE
Refactor v1beta1 unit tests

### DIFF
--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -25,13 +25,16 @@ import (
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func TestPipelineDelete(t *testing.T) {
@@ -293,60 +296,94 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 	version := "v1beta1"
 	clock := clockwork.NewFakeClock()
 
-	pdata := []*v1alpha1.Pipeline{
-		tb.Pipeline("pipeline",
-			tb.PipelineNamespace("ns"),
-			// created  5 minutes back
-			cb.PipelineCreationTimestamp(clock.Now().Add(-5*time.Minute)),
-		),
-		tb.Pipeline("pipeline2",
-			tb.PipelineNamespace("ns"),
-			// created  5 minutes back
-			cb.PipelineCreationTimestamp(clock.Now().Add(-5*time.Minute)),
-		),
+	pdata := []*v1beta1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+				// created  5 minutes back
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline2",
+				Namespace: "ns",
+				// created  5 minutes back
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
 	}
-	prdata := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("pipeline-run-1",
-			tb.PipelineRunNamespace("ns"),
-			cb.PipelineRunCreationTimestamp(clock.Now()),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-			tb.PipelineRunSpec("pipeline"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				// pipeline run starts now
-				tb.PipelineRunStartTime(clock.Now()),
-				// takes 10 minutes to complete
-				cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
-			),
-		),
-		tb.PipelineRun("pipeline-run-2",
-			tb.PipelineRunNamespace("ns"),
-			cb.PipelineRunCreationTimestamp(clock.Now()),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-			tb.PipelineRunSpec("pipeline"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				// pipeline run starts now
-				tb.PipelineRunStartTime(clock.Now()),
-				// takes 10 minutes to complete
-				cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
-			),
-		),
+
+	prdata := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-1",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-2",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
 	}
+
 	type clients struct {
-		pipelineClient pipelinetest.Clients
+		pipelineClient pipelinev1beta1test.Clients
 		dynamicClient  dynamic.Interface
 	}
 	seeds := make([]clients, 0)
 
 	for i := 0; i < 8; i++ {
-		cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
 			Namespaces: []*corev1.Namespace{
@@ -361,10 +398,10 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
 		tdc := testDynamic.Options{}
 		dc, err := tdc.Client(
-			cb.UnstructuredP(pdata[0], version),
-			cb.UnstructuredP(pdata[1], version),
-			cb.UnstructuredPR(prdata[0], version),
-			cb.UnstructuredPR(prdata[1], version),
+			cb.UnstructuredV1beta1P(pdata[0], version),
+			cb.UnstructuredV1beta1P(pdata[1], version),
+			cb.UnstructuredV1beta1PR(prdata[0], version),
+			cb.UnstructuredV1beta1PR(prdata[1], version),
 		)
 		if err != nil {
 			t.Errorf("unable to create dynamic client: %v", err)
@@ -377,7 +414,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 		name        string
 		command     []string
 		dynamic     dynamic.Interface
-		input       pipelinetest.Clients
+		input       pipelinev1beta1test.Clients
 		inputStream io.Reader
 		wantError   bool
 		want        string

--- a/pkg/cmd/pipelinerun/cancel_test.go
+++ b/pkg/cmd/pipelinerun/cancel_test.go
@@ -23,6 +23,8 @@ import (
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stest "k8s.io/client-go/testing"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 var (
@@ -323,25 +326,57 @@ func Test_cancel_pipelinerun_v1beta1(t *testing.T) {
 
 	prName := "test-pipeline-run-123"
 
-	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun(prName,
-			tb.PipelineRunNamespace("ns"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipelineName"),
-			tb.PipelineRunSpec("pipelineName",
-				tb.PipelineRunServiceAccountName("test-sa"),
-				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
-				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
-				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
-				tb.PipelineRunParam("rev-param", "revision1"),
-			),
-		),
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "somethingmorefun",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+		},
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"pipeline", "pipelinerun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client(
-		cb.UnstructuredPR(prs[0], versionB1),
+		cb.UnstructuredV1beta1PR(prs[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -367,21 +402,53 @@ func Test_cancel_pipelinerun_client_err_v1beta1(t *testing.T) {
 	prName := "test-pipeline-run-123"
 	errStr := "test generated error"
 
-	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun(prName,
-			tb.PipelineRunNamespace("ns"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipelineName"),
-			tb.PipelineRunSpec("pipelineName",
-				tb.PipelineRunServiceAccountName("test-sa"),
-				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
-				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
-				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
-				tb.PipelineRunParam("rev-param", "revision1"),
-			),
-		),
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "rev-param",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+		},
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"pipeline", "pipelinerun"})
 	tdc := testDynamic.Options{
 		PrependReactors: []testDynamic.PrependOpt{
@@ -392,7 +459,7 @@ func Test_cancel_pipelinerun_client_err_v1beta1(t *testing.T) {
 					return true, nil, errors.New(errStr)
 				}}}}
 	dc, err := tdc.Client(
-		cb.UnstructuredPR(prs[0], versionB1),
+		cb.UnstructuredV1beta1PR(prs[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -417,28 +484,67 @@ func Test_finished_pipelinerun_success_v1beta1(t *testing.T) {
 
 	prName := "test-pipeline-run-123"
 
-	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun(prName,
-			tb.PipelineRunNamespace("ns"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipelineName"),
-			tb.PipelineRunSpec("pipelineName",
-				tb.PipelineRunServiceAccountName("test-sa"),
-				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
-				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
-				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
-				tb.PipelineRunParam("rev-param", "revision1"),
-			),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(success),
-			),
-		),
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "rev-param",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			},
+		},
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"pipeline", "pipelinerun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client(
-		cb.UnstructuredPR(prs[0], versionB1),
+		cb.UnstructuredV1beta1PR(prs[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -463,28 +569,67 @@ func Test_finished_pipelinerun_failure_v1beta1(t *testing.T) {
 
 	prName := "test-pipeline-run-123"
 
-	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun(prName,
-			tb.PipelineRunNamespace("ns"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipelineName"),
-			tb.PipelineRunSpec("pipelineName",
-				tb.PipelineRunServiceAccountName("test-sa"),
-				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
-				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
-				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
-				tb.PipelineRunParam("rev-param", "revision1"),
-			),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(failure),
-			),
-		),
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "rev-param",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			},
+		},
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"pipeline", "pipelinerun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client(
-		cb.UnstructuredPR(prs[0], versionB1),
+		cb.UnstructuredV1beta1PR(prs[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -509,28 +654,67 @@ func Test_finished_pipelinerun_cancel_v1beta1(t *testing.T) {
 
 	prName := "test-pipeline-run-123"
 
-	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun(prName,
-			tb.PipelineRunNamespace("ns"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipelineName"),
-			tb.PipelineRunSpec("pipelineName",
-				tb.PipelineRunServiceAccountName("test-sa"),
-				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
-				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
-				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
-				tb.PipelineRunParam("rev-param", "revision1"),
-			),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(cancel),
-			),
-		),
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "rev-param",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: "PipelineRunCancelled",
+						},
+					},
+				},
+			},
+		},
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"pipeline", "pipelinerun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client(
-		cb.UnstructuredPR(prs[0], versionB1),
+		cb.UnstructuredV1beta1PR(prs[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -25,13 +25,16 @@ import (
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func TestPipelineRunDelete(t *testing.T) {
@@ -332,73 +335,114 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 		},
 	}
 
-	pdata := []*v1alpha1.Pipeline{
-		tb.Pipeline("pipeline",
-			tb.PipelineNamespace("ns"),
-			// created  5 minutes back
-			cb.PipelineCreationTimestamp(clock.Now().Add(-5*time.Minute)),
-		),
+	pdata := []*v1beta1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
 	}
 
-	prdata := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("pipeline-run-1",
-			tb.PipelineRunNamespace("ns"),
-			cb.PipelineRunCreationTimestamp(clock.Now()),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-			tb.PipelineRunSpec("pipeline"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				// pipeline run starts now
-				tb.PipelineRunStartTime(clock.Now()),
-				// takes 10 minutes to complete
-				cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
-			),
-		),
-		tb.PipelineRun("pipeline-run-2",
-			tb.PipelineRunNamespace("ns"),
-			cb.PipelineRunCreationTimestamp(clock.Now()),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-			tb.PipelineRunSpec("pipeline"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				// pipeline run starts now
-				tb.PipelineRunStartTime(clock.Now()),
-				// takes 10 minutes to complete
-				cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
-			),
-		),
-		tb.PipelineRun("pipeline-run-3",
-			tb.PipelineRunNamespace("ns"),
-			cb.PipelineRunCreationTimestamp(clock.Now()),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-			tb.PipelineRunSpec("pipeline"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				// pipeline run starts now
-				tb.PipelineRunStartTime(clock.Now()),
-				// takes 10 minutes to complete
-				cb.PipelineRunCompletionTime(clock.Now().Add(10*time.Minute)),
-			),
-		),
+	prdata := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "ns",
+				Name:              "pipeline-run-1",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "ns",
+				Name:              "pipeline-run-2",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "ns",
+				Name:              "pipeline-run-3",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
 	}
 
 	type clients struct {
-		pipelineClient pipelinetest.Clients
+		pipelineClient pipelinev1beta1test.Clients
 		dynamicClient  dynamic.Interface
 	}
 
 	seeds := make([]clients, 0)
 	for i := 0; i < 6; i++ {
-		cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
 			Namespaces:   ns,
@@ -406,9 +450,9 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
 		tdc := testDynamic.Options{}
 		dc, err := tdc.Client(
-			cb.UnstructuredPR(prdata[0], version),
-			cb.UnstructuredPR(prdata[1], version),
-			cb.UnstructuredPR(prdata[2], version),
+			cb.UnstructuredV1beta1PR(prdata[0], version),
+			cb.UnstructuredV1beta1PR(prdata[1], version),
+			cb.UnstructuredV1beta1PR(prdata[2], version),
 		)
 		if err != nil {
 			t.Errorf("unable to create dynamic client: %v", err)
@@ -420,7 +464,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 		name        string
 		command     []string
 		dynamic     dynamic.Interface
-		input       pipelinetest.Clients
+		input       pipelinev1beta1test.Clients
 		inputStream io.Reader
 		wantError   bool
 		want        string

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -26,7 +26,9 @@ import (
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	"gotest.tools/v3/golden"
@@ -34,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func TestListPipelineRuns(t *testing.T) {
@@ -144,92 +147,92 @@ func TestListPipelineRuns(t *testing.T) {
 	}{
 		{
 			name:      "Invalid namespace",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "invalid"},
 			wantError: true,
 		},
 		{
 			name:      "by pipeline name",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "pipeline", "-n", "namespace"},
 			wantError: false,
 		},
 		{
 			name:      "by output as name",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "-o", "name"},
 			wantError: false,
 		},
 		{
 			name:      "all in namespace",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace"},
 			wantError: false,
 		},
 		{
 			name:      "by template",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:      "limit pipelineruns returned to 1",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", 1)},
 			wantError: false,
 		},
 		{
 			name:      "limit pipelineruns negative case",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", -1)},
 			wantError: false,
 		},
 		{
 			name:      "filter pipelineruns by label with in query",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--label", "viva in (wakanda,galapagos)"},
 			wantError: false,
 		},
 		{
 			name:      "filter pipelineruns by label",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--label", "viva=wakanda"},
 			wantError: false,
 		},
 		{
 			name:      "no mixing pipelinename and label",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--label", "viva=wakanda", "pr3-1"},
 			wantError: true,
 		},
 
 		{
 			name:      "limit pipelineruns greater than maximum case",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", 7)},
 			wantError: false,
 		},
 		{
 			name:      "limit pipelineruns with output flag set",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "--limit", fmt.Sprintf("%d", 2)},
 			wantError: false,
 		},
 		{
 			name:      "print in reverse",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "namespace"},
 			wantError: false,
 		},
 		{
 			name:      "print in reverse with output flag",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:      "print pipelineruns in all namespaces",
-			command:   command(t, prsMultipleNs, clock.Now(), ns, version, dc2),
+			command:   commandV1alpha1(t, prsMultipleNs, clock.Now(), ns, version, dc2),
 			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
@@ -256,67 +259,100 @@ func TestListPipelineRuns_v1beta1(t *testing.T) {
 	pr2Started := clock.Now().Add(-2 * time.Hour)
 	pr3Started := clock.Now().Add(-1 * time.Hour)
 
-	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("pr0-1",
-			tb.PipelineRunNamespace("namespace"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
-			tb.PipelineRunStatus(),
-		),
-		tb.PipelineRun("pr1-1",
-			tb.PipelineRunNamespace("namespace"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipeline"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				tb.PipelineRunStartTime(pr1Started),
-				cb.PipelineRunCompletionTime(pr1Started.Add(runDuration)),
-			),
-		),
-		tb.PipelineRun("pr2-1",
-			tb.PipelineRunNamespace("namespace"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonRunning,
-				}),
-				tb.PipelineRunStartTime(pr2Started),
-			),
-		),
-		tb.PipelineRun("pr2-2",
-			tb.PipelineRunNamespace("namespace"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
-			tb.PipelineRunLabel("viva", "galapagos"),
-			tb.PipelineRunStatus(
-				tb.PipelineRunStatusCondition(apis.Condition{
-					Status: corev1.ConditionFalse,
-					Reason: resources.ReasonFailed,
-				}),
-				tb.PipelineRunStartTime(pr3Started),
-				cb.PipelineRunCompletionTime(pr3Started.Add(runDuration)),
-			),
-		),
-		tb.PipelineRun("pr3-1",
-			tb.PipelineRunNamespace("namespace"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
-			tb.PipelineRunLabel("viva", "wakanda"),
-			tb.PipelineRunStatus(),
-		),
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace",
+				Name:      "pr0-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "random"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace",
+				Name:      "pr1-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: pr1Started},
+					CompletionTime: &metav1.Time{Time: pr1Started.Add(runDuration)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace",
+				Name:      "pr2-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "random"},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonRunning,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: pr2Started},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace",
+				Name:      "pr2-2",
+				Labels:    map[string]string{"tekton.dev/pipeline": "random", "viva": "galapagos"},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: resources.ReasonFailed,
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: pr3Started},
+					CompletionTime: &metav1.Time{Time: pr3Started.Add(runDuration)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace",
+				Name:      "pr3-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "random", "viva": "wakanda"},
+			},
+		},
 	}
 
-	prsMultipleNs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("pr4-1",
-			tb.PipelineRunNamespace("namespace-tout"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
-			tb.PipelineRunStatus(),
-		),
-		tb.PipelineRun("pr4-2",
-			tb.PipelineRunNamespace("namespace-lacher"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "random"),
-			tb.PipelineRunStatus(),
-		),
+	prsMultipleNs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace-tout",
+				Name:      "pr4-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "random"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace-lacher",
+				Name:      "pr4-2",
+				Labels:    map[string]string{"tekton.dev/pipeline": "random"},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -329,11 +365,11 @@ func TestListPipelineRuns_v1beta1(t *testing.T) {
 
 	tdc1 := testDynamic.Options{}
 	dc1, err := tdc1.Client(
-		cb.UnstructuredPR(prs[0], version),
-		cb.UnstructuredPR(prs[1], version),
-		cb.UnstructuredPR(prs[2], version),
-		cb.UnstructuredPR(prs[3], version),
-		cb.UnstructuredPR(prs[4], version),
+		cb.UnstructuredV1beta1PR(prs[0], version),
+		cb.UnstructuredV1beta1PR(prs[1], version),
+		cb.UnstructuredV1beta1PR(prs[2], version),
+		cb.UnstructuredV1beta1PR(prs[3], version),
+		cb.UnstructuredV1beta1PR(prs[4], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -347,104 +383,104 @@ func TestListPipelineRuns_v1beta1(t *testing.T) {
 	}{
 		{
 			name:      "Invalid namespace",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "invalid"},
 			wantError: true,
 		},
 		{
 			name:      "by pipeline name",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "pipeline", "-n", "namespace"},
 			wantError: false,
 		},
 		{
 			name:      "by output as name",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "-o", "name"},
 			wantError: false,
 		},
 		{
 			name:      "all in namespace",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace"},
 			wantError: false,
 		},
 		{
 			name:      "by template",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:      "limit pipelineruns returned to 1",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", 1)},
 			wantError: false,
 		},
 		{
 			name:      "limit pipelineruns negative case",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", -1)},
 			wantError: false,
 		},
 		{
 			name:      "filter pipelineruns by label with in query",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--label", "viva in (wakanda,galapagos)"},
 			wantError: false,
 		},
 		{
 			name:      "filter pipelineruns by label",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--label", "viva=wakanda"},
 			wantError: false,
 		},
 		{
 			name:      "no mixing pipelinename and label",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--label", "viva=wakanda", "pr3-1"},
 			wantError: true,
 		},
 
 		{
 			name:      "limit pipelineruns greater than maximum case",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", 7)},
 			wantError: false,
 		},
 		{
 			name:      "limit pipelineruns with output flag set",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "--limit", fmt.Sprintf("%d", 2)},
 			wantError: false,
 		},
 		{
 			name:      "print in reverse",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "namespace"},
 			wantError: false,
 		},
 		{
 			name:      "print in reverse with output flag",
-			command:   command(t, prs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "namespace", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:      "print pipelineruns in all namespaces",
-			command:   command(t, prsMultipleNs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prsMultipleNs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
 		{
 			name:      "print pipelineruns without headers",
-			command:   command(t, prsMultipleNs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prsMultipleNs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--no-headers"},
 			wantError: false,
 		},
 		{
 			name:      "print pipelineruns in all namespaces without headers",
-			command:   command(t, prsMultipleNs, clock.Now(), ns, version, dc1),
+			command:   commandV1beta1(t, prsMultipleNs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "--all-namespaces", "--no-headers"},
 			wantError: false,
 		},
@@ -489,12 +525,25 @@ func TestListPipeline_empty(t *testing.T) {
 	test.AssertOutput(t, "No PipelineRuns found\n", output)
 }
 
-func command(t *testing.T, prs []*v1alpha1.PipelineRun, now time.Time, ns []*corev1.Namespace, version string, dc dynamic.Interface) *cobra.Command {
+func commandV1alpha1(t *testing.T, prs []*v1alpha1.PipelineRun, now time.Time, ns []*corev1.Namespace, version string, dc dynamic.Interface) *cobra.Command {
 	// fake clock advanced by 1 hour
 	clock := clockwork.NewFakeClockAt(now)
 	clock.Advance(time.Duration(60) * time.Minute)
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
+
+	return Command(p)
+}
+
+func commandV1beta1(t *testing.T, prs []*v1beta1.PipelineRun, now time.Time, ns []*corev1.Namespace, version string, dc dynamic.Interface) *cobra.Command {
+	// fake clock advanced by 1 hour
+	clock := clockwork.NewFakeClockAt(now)
+	clock.Advance(time.Duration(60) * time.Minute)
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
 
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -16,6 +16,7 @@ package task
 
 import (
 	"fmt"
+
 	"testing"
 	"time"
 
@@ -24,6 +25,8 @@ import (
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	"gotest.tools/v3/golden"
@@ -121,13 +124,58 @@ func TestTaskList_Only_Tasks_v1alpha1(t *testing.T) {
 func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	tasks := []*v1alpha1.Task{
-		tb.Task("tomatoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-1*time.Minute))),
-		tb.Task("mangoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-20*time.Second))),
-		tb.Task("bananas", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-512*time.Hour))),
-		tb.Task("apples", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("")), cb.TaskCreationTime(clock.Now().Add(-513*time.Hour))),
-		tb.Task("potatoes", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task")), cb.TaskCreationTime(clock.Now().Add(-514*time.Hour))),
-		tb.Task("onionss", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task to test description of task")), cb.TaskCreationTime(clock.Now().Add(-515*time.Hour))),
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tomatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "mangoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bananas",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "apples",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "potatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "onionss",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-515 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task to test description of task",
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -141,18 +189,18 @@ func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 	version := "v1beta1"
 	tdc := testDynamic.Options{}
 	dynamic, err := tdc.Client(
-		cb.UnstructuredT(tasks[0], version),
-		cb.UnstructuredT(tasks[1], version),
-		cb.UnstructuredT(tasks[2], version),
-		cb.UnstructuredT(tasks[3], version),
-		cb.UnstructuredT(tasks[4], version),
-		cb.UnstructuredT(tasks[5], version),
+		cb.UnstructuredV1beta1T(tasks[0], version),
+		cb.UnstructuredV1beta1T(tasks[1], version),
+		cb.UnstructuredV1beta1T(tasks[2], version),
+		cb.UnstructuredV1beta1T(tasks[3], version),
+		cb.UnstructuredV1beta1T(tasks[4], version),
+		cb.UnstructuredV1beta1T(tasks[5], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Tasks: tasks, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks, Namespaces: ns})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 	task := Command(p)
@@ -168,13 +216,58 @@ func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	tasks := []*v1alpha1.Task{
-		tb.Task("tomatoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-1*time.Minute))),
-		tb.Task("mangoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-20*time.Second))),
-		tb.Task("bananas", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-512*time.Hour))),
-		tb.Task("apples", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("")), cb.TaskCreationTime(clock.Now().Add(-513*time.Hour))),
-		tb.Task("potatoes", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task")), cb.TaskCreationTime(clock.Now().Add(-514*time.Hour))),
-		tb.Task("onions", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task to test description of task")), cb.TaskCreationTime(clock.Now().Add(-515*time.Hour))),
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tomatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "mangoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bananas",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "apples",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "potatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "onions",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-515 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task to test description of task",
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -188,18 +281,18 @@ func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
 	version := "v1beta1"
 	tdc := testDynamic.Options{}
 	dynamic, err := tdc.Client(
-		cb.UnstructuredT(tasks[0], version),
-		cb.UnstructuredT(tasks[1], version),
-		cb.UnstructuredT(tasks[2], version),
-		cb.UnstructuredT(tasks[3], version),
-		cb.UnstructuredT(tasks[4], version),
-		cb.UnstructuredT(tasks[5], version),
+		cb.UnstructuredV1beta1T(tasks[0], version),
+		cb.UnstructuredV1beta1T(tasks[1], version),
+		cb.UnstructuredV1beta1T(tasks[2], version),
+		cb.UnstructuredV1beta1T(tasks[3], version),
+		cb.UnstructuredV1beta1T(tasks[4], version),
+		cb.UnstructuredV1beta1T(tasks[5], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Tasks: tasks, Namespaces: ns})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks, Namespaces: ns})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 	task := Command(p)
@@ -215,42 +308,132 @@ func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
 func TestTaskList_Only_Tasks_all_namespaces_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	tasks := []*v1alpha1.Task{
-		tb.Task("tomatoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-1*time.Minute))),
-		tb.Task("mangoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-20*time.Second))),
-		tb.Task("bananas", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-512*time.Hour))),
-		tb.Task("apples", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("")), cb.TaskCreationTime(clock.Now().Add(-513*time.Hour))),
-		tb.Task("potatoes", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task")), cb.TaskCreationTime(clock.Now().Add(-514*time.Hour))),
-		tb.Task("onions", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task to test description of task")), cb.TaskCreationTime(clock.Now().Add(-515*time.Hour))),
-		tb.Task("tomates", tb.TaskNamespace("espace-de-nom"), cb.TaskCreationTime(clock.Now().Add(-1*time.Minute))),
-		tb.Task("mangues", tb.TaskNamespace("espace-de-nom"), cb.TaskCreationTime(clock.Now().Add(-20*time.Second))),
-		tb.Task("bananes", tb.TaskNamespace("espace-de-nom"), cb.TaskCreationTime(clock.Now().Add(-512*time.Hour))),
-		tb.Task("pommes", tb.TaskNamespace("espace-de-nom"), tb.TaskSpec(tb.TaskDescription("")), cb.TaskCreationTime(clock.Now().Add(-513*time.Hour))),
-		tb.Task("patates", tb.TaskNamespace("espace-de-nom"), tb.TaskSpec(tb.TaskDescription("a test task")), cb.TaskCreationTime(clock.Now().Add(-514*time.Hour))),
-		tb.Task("oignons", tb.TaskNamespace("espace-de-nom"), tb.TaskSpec(tb.TaskDescription("a test task to test description of task")), cb.TaskCreationTime(clock.Now().Add(-515*time.Hour))),
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tomatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "mangoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bananas",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "apples",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "potatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "onions",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-515 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task to test description of task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tomates",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "mangues",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bananes",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pommes",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "patates",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "oignons",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-515 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task to test description of task",
+			},
+		},
 	}
 
 	version := "v1beta1"
 	tdc := testDynamic.Options{}
 	dynamic, err := tdc.Client(
-		cb.UnstructuredT(tasks[0], version),
-		cb.UnstructuredT(tasks[1], version),
-		cb.UnstructuredT(tasks[2], version),
-		cb.UnstructuredT(tasks[3], version),
-		cb.UnstructuredT(tasks[4], version),
-		cb.UnstructuredT(tasks[5], version),
-		cb.UnstructuredT(tasks[6], version),
-		cb.UnstructuredT(tasks[7], version),
-		cb.UnstructuredT(tasks[8], version),
-		cb.UnstructuredT(tasks[9], version),
-		cb.UnstructuredT(tasks[10], version),
-		cb.UnstructuredT(tasks[11], version),
+		cb.UnstructuredV1beta1T(tasks[0], version),
+		cb.UnstructuredV1beta1T(tasks[1], version),
+		cb.UnstructuredV1beta1T(tasks[2], version),
+		cb.UnstructuredV1beta1T(tasks[3], version),
+		cb.UnstructuredV1beta1T(tasks[4], version),
+		cb.UnstructuredV1beta1T(tasks[5], version),
+		cb.UnstructuredV1beta1T(tasks[6], version),
+		cb.UnstructuredV1beta1T(tasks[7], version),
+		cb.UnstructuredV1beta1T(tasks[8], version),
+		cb.UnstructuredV1beta1T(tasks[9], version),
+		cb.UnstructuredV1beta1T(tasks[10], version),
+		cb.UnstructuredV1beta1T(tasks[11], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Tasks: tasks})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 	task := Command(p)
@@ -265,43 +448,132 @@ func TestTaskList_Only_Tasks_all_namespaces_v1beta1(t *testing.T) {
 
 func TestTaskList_Only_Tasks_all_namespaces_no_headers_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-
-	tasks := []*v1alpha1.Task{
-		tb.Task("tomatoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-1*time.Minute))),
-		tb.Task("mangoes", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-20*time.Second))),
-		tb.Task("bananas", tb.TaskNamespace("namespace"), cb.TaskCreationTime(clock.Now().Add(-512*time.Hour))),
-		tb.Task("apples", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("")), cb.TaskCreationTime(clock.Now().Add(-513*time.Hour))),
-		tb.Task("potatoes", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task")), cb.TaskCreationTime(clock.Now().Add(-514*time.Hour))),
-		tb.Task("onions", tb.TaskNamespace("namespace"), tb.TaskSpec(tb.TaskDescription("a test task to test description of task")), cb.TaskCreationTime(clock.Now().Add(-515*time.Hour))),
-		tb.Task("tomates", tb.TaskNamespace("espace-de-nom"), cb.TaskCreationTime(clock.Now().Add(-1*time.Minute))),
-		tb.Task("mangues", tb.TaskNamespace("espace-de-nom"), cb.TaskCreationTime(clock.Now().Add(-20*time.Second))),
-		tb.Task("bananes", tb.TaskNamespace("espace-de-nom"), cb.TaskCreationTime(clock.Now().Add(-512*time.Hour))),
-		tb.Task("pommes", tb.TaskNamespace("espace-de-nom"), tb.TaskSpec(tb.TaskDescription("")), cb.TaskCreationTime(clock.Now().Add(-513*time.Hour))),
-		tb.Task("patates", tb.TaskNamespace("espace-de-nom"), tb.TaskSpec(tb.TaskDescription("a test task")), cb.TaskCreationTime(clock.Now().Add(-514*time.Hour))),
-		tb.Task("oignons", tb.TaskNamespace("espace-de-nom"), tb.TaskSpec(tb.TaskDescription("a test task to test description of task")), cb.TaskCreationTime(clock.Now().Add(-515*time.Hour))),
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tomatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "mangoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bananas",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "apples",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "potatoes",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "onions",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-515 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task to test description of task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tomates",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "mangues",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bananes",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pommes",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "patates",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "oignons",
+				Namespace:         "espace-de-nom",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-515 * time.Hour)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test task to test description of task",
+			},
+		},
 	}
 
 	version := "v1beta1"
 	tdc := testDynamic.Options{}
 	dynamic, err := tdc.Client(
-		cb.UnstructuredT(tasks[0], version),
-		cb.UnstructuredT(tasks[1], version),
-		cb.UnstructuredT(tasks[2], version),
-		cb.UnstructuredT(tasks[3], version),
-		cb.UnstructuredT(tasks[4], version),
-		cb.UnstructuredT(tasks[5], version),
-		cb.UnstructuredT(tasks[6], version),
-		cb.UnstructuredT(tasks[7], version),
-		cb.UnstructuredT(tasks[8], version),
-		cb.UnstructuredT(tasks[9], version),
-		cb.UnstructuredT(tasks[10], version),
-		cb.UnstructuredT(tasks[11], version),
+		cb.UnstructuredV1beta1T(tasks[0], version),
+		cb.UnstructuredV1beta1T(tasks[1], version),
+		cb.UnstructuredV1beta1T(tasks[2], version),
+		cb.UnstructuredV1beta1T(tasks[3], version),
+		cb.UnstructuredV1beta1T(tasks[4], version),
+		cb.UnstructuredV1beta1T(tasks[5], version),
+		cb.UnstructuredV1beta1T(tasks[6], version),
+		cb.UnstructuredV1beta1T(tasks[7], version),
+		cb.UnstructuredV1beta1T(tasks[8], version),
+		cb.UnstructuredV1beta1T(tasks[9], version),
+		cb.UnstructuredV1beta1T(tasks[10], version),
+		cb.UnstructuredV1beta1T(tasks[11], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Tasks: tasks})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 	task := Command(p)

--- a/pkg/cmd/task/logs_test.go
+++ b/pkg/cmd/task/logs_test.go
@@ -30,13 +30,16 @@ import (
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/cli/test/prompt"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func init() {
@@ -176,8 +179,16 @@ func TestTaskLog(t *testing.T) {
 func TestTaskLog_v1beta1(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
-	task1 := []*v1alpha1.Task{tb.Task("task", tb.TaskNamespace("ns"))}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+
+	task1 := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task",
+				Namespace: "ns",
+			},
+		},
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Tasks: task1,
 		Namespaces: []*corev1.Namespace{
 			{
@@ -190,16 +201,21 @@ func TestTaskLog_v1beta1(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun"})
 	tdc1 := testDynamic.Options{}
 	dc1, err := tdc1.Client(
-		cb.UnstructuredT(task1[0], versionB1),
+		cb.UnstructuredV1beta1T(task1[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	task2 := []*v1alpha1.Task{
-		tb.Task("task", tb.TaskNamespace("namespace")),
+	task2 := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task",
+				Namespace: "namespace",
+			},
+		},
 	}
-	cs2, _ := test.SeedTestData(t, pipelinetest.Data{
+	cs2, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Tasks: task2,
 		Namespaces: []*corev1.Namespace{
 			{
@@ -212,7 +228,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 	cs2.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun"})
 	tdc2 := testDynamic.Options{}
 	dc2, err := tdc2.Client(
-		cb.UnstructuredT(task2[0], versionB1),
+		cb.UnstructuredV1beta1T(task2[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -221,7 +237,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 	testParams := []struct {
 		name      string
 		command   []string
-		input     pipelinetest.Clients
+		input     pipelinev1beta1test.Clients
 		dc        dynamic.Interface
 		wantError bool
 		want      string
@@ -676,26 +692,46 @@ func TestLogs_Auto_Select_FirstTask(t *testing.T) {
 	ns := "dummyNamespaces"
 	clock := clockwork.NewFakeClock()
 
-	tdata := []*v1alpha1.Task{
-		tb.Task(taskName, tb.TaskNamespace(ns)),
+	tdata := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      taskName,
+				Namespace: ns,
+			},
+		},
 	}
 
-	trdata := []*v1alpha1.TaskRun{
-		tb.TaskRun("dummyTR", tb.TaskRunNamespace(ns),
-			cb.TaskRunCreationTime(clock.Now().Add(-10*time.Minute)),
-			tb.TaskRunLabel("tekton.dev/task", taskName),
-			tb.TaskRunSelfLink(taskName),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				tb.TaskRunStartTime(clock.Now().Add(-5*time.Minute)),
-				cb.TaskRunCompletionTime(clock.Now().Add(10*time.Minute)),
-			),
-		),
+	trdata := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      "dummyTR",
+				Labels:    map[string]string{"tekton.dev/task": taskName},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
 	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Tasks:    tdata,
 		TaskRuns: trdata,
 		Namespaces: []*corev1.Namespace{
@@ -709,8 +745,8 @@ func TestLogs_Auto_Select_FirstTask(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client(
-		cb.UnstructuredT(tdata[0], versionB1),
-		cb.UnstructuredTR(trdata[0], versionB1),
+		cb.UnstructuredV1beta1T(tdata[0], versionB1),
+		cb.UnstructuredV1beta1TR(trdata[0], versionB1),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -219,8 +219,8 @@ func Test_start_has_task_filename_v1beta1(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
-	cs.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun"})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client()
 	if err != nil {
@@ -245,8 +245,8 @@ func Test_start_with_filename_invalid_v1beta1(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns})
-	cs.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun"})
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun"})
 	tdc := testDynamic.Options{}
 	dc, err := tdc.Client()
 	if err != nil {

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -26,7 +26,9 @@ import (
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	"gotest.tools/v3/golden"
@@ -34,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func TestListTaskRuns(t *testing.T) {
@@ -200,108 +203,108 @@ func TestListTaskRuns(t *testing.T) {
 	}{
 		{
 			name:      "by Task name",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "bar", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "by output as name",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "-o", "name"},
 			wantError: false,
 		},
 		{
 			name:      "all in namespace",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "print by template",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:    "empty list",
-			command: command(t, trs, now, ns, version, dc1),
+			command: commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:    []string{"list", "-n", "random"},
 		},
 		{
 			name:      "limit taskruns returned to 1",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", 1)},
 			wantError: false,
 		},
 		{
 			name:      "limit taskruns negative case",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", -1)},
 			wantError: true,
 		},
 		{
 			name:      "limit taskruns greater than maximum case",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", 7)},
 			wantError: false,
 		},
 		{
 			name:      "limit taskruns with output flag set",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "--limit", fmt.Sprintf("%d", 2)},
 			wantError: false,
 		},
 		{
 			name:      "error from invalid namespace",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "invalid"},
 			wantError: true,
 		},
 		{
 			name:      "filter taskruns by label",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--label", "pot=honey"},
 			wantError: false,
 		},
 		{
 			name:      "filter taskruns by label with in query",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--label", "pot in (honey,nutella)"},
 			wantError: false,
 		},
 		{
 			name:      "no mixing pipelinename and labels",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--label", "honey=nutella", "tr3-1"},
 			wantError: true,
 		},
 		{
 			name:      "print in reverse",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "print in reverse with output flag",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1alpha1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:      "print taskruns in all namespaces",
-			command:   command(t, trsMultipleNs, now, ns, version, dc2),
+			command:   commandV1alpha1(t, trsMultipleNs, now, ns, version, dc2),
 			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
 		{
 			name:      "print taskruns without headers",
-			command:   command(t, trsMultipleNs, now, ns, version, dc2),
+			command:   commandV1alpha1(t, trsMultipleNs, now, ns, version, dc2),
 			args:      []string{"list", "--no-headers", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "print taskruns in all namespaces without headers",
-			command:   command(t, trsMultipleNs, now, ns, version, dc2),
+			command:   commandV1alpha1(t, trsMultipleNs, now, ns, version, dc2),
 			args:      []string{"list", "--all-namespaces", "--no-headers"},
 			wantError: false,
 		},
@@ -325,108 +328,228 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 	aMinute, _ := time.ParseDuration("1m")
 	twoMinute, _ := time.ParseDuration("2m")
 
-	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("tr0-1", tb.TaskRunNamespace("foo"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-			),
-		),
-		tb.TaskRun("tr1-1", tb.TaskRunNamespace("foo"),
-			tb.TaskRunLabel("tekton.dev/task", "bar"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("bar", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-				tb.TaskRunStartTime(now),
-				taskRunCompletionTime(now.Add(aMinute)),
-			),
-		),
-		tb.TaskRun("tr2-1", tb.TaskRunNamespace("foo"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionUnknown,
-					Reason: resources.ReasonRunning,
-				}),
-				tb.TaskRunStartTime(now),
-			),
-		),
-		tb.TaskRun("tr2-2", tb.TaskRunNamespace("foo"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunLabel("pot", "nutella"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionFalse,
-					Reason: resources.ReasonFailed,
-				}),
-				tb.TaskRunStartTime(now.Add(aMinute)),
-				taskRunCompletionTime(now.Add(twoMinute)),
-			),
-		),
-		tb.TaskRun("tr3-1", tb.TaskRunNamespace("foo"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunLabel("pot", "honey"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionFalse,
-					Reason: resources.ReasonFailed,
-				}),
-			),
-		),
-		tb.TaskRun("tr4-1", tb.TaskRunNamespace("foo"),
-			tb.TaskRunLabel("tekton.dev/task", "bar"),
-			tb.TaskRunLabel("pot", "honey"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("bar", tb.TaskRefKind(v1alpha1.ClusterTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionFalse,
-					Reason: resources.ReasonFailed,
-				}),
-			),
-		),
+	trs := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "tr0-1",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "tr1-1",
+				Labels:    map[string]string{"tekton.dev/task": "bar"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "bar",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: now},
+					CompletionTime: &metav1.Time{Time: now.Add(aMinute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "tr2-1",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionUnknown,
+							Reason: resources.ReasonRunning,
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime: &metav1.Time{Time: now},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "tr2-2",
+				Labels:    map[string]string{"tekton.dev/task": "random", "pot": "nutella"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: resources.ReasonFailed,
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: now.Add(aMinute)},
+					CompletionTime: &metav1.Time{Time: now.Add(twoMinute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "tr3-1",
+				Labels:    map[string]string{"tekton.dev/task": "random", "pot": "honey"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: resources.ReasonFailed,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "tr4-1",
+				Labels:    map[string]string{"tekton.dev/task": "bar", "pot": "honey"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "bar",
+					Kind: v1beta1.ClusterTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: resources.ReasonFailed,
+						},
+					},
+				},
+			},
+		},
 	}
 
-	trsMultipleNs := []*v1alpha1.TaskRun{
-		tb.TaskRun("tr4-1", tb.TaskRunNamespace("tout"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-			),
-		),
-		tb.TaskRun("tr4-2", tb.TaskRunNamespace("lacher"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-			),
-		),
-		tb.TaskRun("tr5-1", tb.TaskRunNamespace("lacher"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.ClusterTaskKind))),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: resources.ReasonSucceeded,
-				}),
-			),
-		),
+	trsMultipleNs := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "tout",
+				Name:      "tr4-1",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "lacher",
+				Name:      "tr4-2",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "lacher",
+				Name:      "tr5-1",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "random",
+					Kind: v1beta1.ClusterTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: resources.ReasonSucceeded,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -443,24 +566,24 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 	}
 	tdc1 := testDynamic.Options{}
 	dc1, err := tdc1.Client(
-		cb.UnstructuredTR(trs[0], version),
-		cb.UnstructuredTR(trs[1], version),
-		cb.UnstructuredTR(trs[2], version),
-		cb.UnstructuredTR(trs[3], version),
-		cb.UnstructuredTR(trs[4], version),
-		cb.UnstructuredTR(trs[5], version),
-		cb.UnstructuredTR(trsMultipleNs[0], version),
-		cb.UnstructuredTR(trsMultipleNs[1], version),
-		cb.UnstructuredTR(trsMultipleNs[2], version),
+		cb.UnstructuredV1beta1TR(trs[0], version),
+		cb.UnstructuredV1beta1TR(trs[1], version),
+		cb.UnstructuredV1beta1TR(trs[2], version),
+		cb.UnstructuredV1beta1TR(trs[3], version),
+		cb.UnstructuredV1beta1TR(trs[4], version),
+		cb.UnstructuredV1beta1TR(trs[5], version),
+		cb.UnstructuredV1beta1TR(trsMultipleNs[0], version),
+		cb.UnstructuredV1beta1TR(trsMultipleNs[1], version),
+		cb.UnstructuredV1beta1TR(trsMultipleNs[2], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 	tdc2 := testDynamic.Options{}
 	dc2, err := tdc2.Client(
-		cb.UnstructuredTR(trsMultipleNs[0], version),
-		cb.UnstructuredTR(trsMultipleNs[1], version),
-		cb.UnstructuredTR(trsMultipleNs[2], version),
+		cb.UnstructuredV1beta1TR(trsMultipleNs[0], version),
+		cb.UnstructuredV1beta1TR(trsMultipleNs[1], version),
+		cb.UnstructuredV1beta1TR(trsMultipleNs[2], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -474,96 +597,96 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 	}{
 		{
 			name:      "by Task name",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "bar", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "by output as name",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "-o", "name"},
 			wantError: false,
 		},
 		{
 			name:      "all in namespace",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "print by template",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:    "empty list",
-			command: command(t, trs, now, ns, version, dc1),
+			command: commandV1beta1(t, trs, now, ns, version, dc1),
 			args:    []string{"list", "-n", "random"},
 		},
 		{
 			name:      "limit taskruns returned to 1",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", 1)},
 			wantError: false,
 		},
 		{
 			name:      "limit taskruns negative case",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", -1)},
 			wantError: true,
 		},
 		{
 			name:      "limit taskruns greater than maximum case",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", 7)},
 			wantError: false,
 		},
 		{
 			name:      "limit taskruns with output flag set",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}", "--limit", fmt.Sprintf("%d", 2)},
 			wantError: false,
 		},
 		{
 			name:      "error from invalid namespace",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "invalid"},
 			wantError: true,
 		},
 		{
 			name:      "filter taskruns by label",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--label", "pot=honey"},
 			wantError: false,
 		},
 		{
 			name:      "filter taskruns by label with in query",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--label", "pot in (honey,nutella)"},
 			wantError: false,
 		},
 		{
 			name:      "no mixing pipelinename and labels",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--label", "honey=nutella", "tr3-1"},
 			wantError: true,
 		},
 		{
 			name:      "print in reverse",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "foo"},
 			wantError: false,
 		},
 		{
 			name:      "print in reverse with output flag",
-			command:   command(t, trs, now, ns, version, dc1),
+			command:   commandV1beta1(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "--reverse", "-n", "foo", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
 		{
 			name:      "print taskruns in all namespaces",
-			command:   command(t, trsMultipleNs, now, ns, version, dc2),
+			command:   commandV1beta1(t, trsMultipleNs, now, ns, version, dc2),
 			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
@@ -612,7 +735,7 @@ func TestListTaskRuns_no_condition(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	cmd := command(t, trs, now, ns, version, dc)
+	cmd := commandV1alpha1(t, trs, now, ns, version, dc)
 	got, err := test.ExecuteCommand(cmd, "list", "bar", "-n", "foo")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -620,12 +743,22 @@ func TestListTaskRuns_no_condition(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func command(t *testing.T, trs []*v1alpha1.TaskRun, now time.Time, ns []*corev1.Namespace, version string, dc dynamic.Interface) *cobra.Command {
+func commandV1alpha1(t *testing.T, trs []*v1alpha1.TaskRun, now time.Time, ns []*corev1.Namespace, version string, dc dynamic.Interface) *cobra.Command {
 	// fake clock advanced by 1 hour
 	clock := clockwork.NewFakeClockAt(now)
 	clock.Advance(time.Duration(60) * time.Minute)
-
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
+
+	return Command(p)
+}
+
+func commandV1beta1(t *testing.T, trs []*v1beta1.TaskRun, now time.Time, ns []*corev1.Namespace, version string, dc dynamic.Interface) *cobra.Command {
+	// fake clock advanced by 1 hour
+	clock := clockwork.NewFakeClockAt(now)
+	clock.Advance(time.Duration(60) * time.Minute)
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{TaskRuns: trs, Namespaces: ns})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Refactored v1beta1 unit tests to use only `v1beta1` structs, earlier it was using `v1aplha1` structs in `v1beta1 unit tests`.

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

Fixes: #1008


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->


