### PR TITLE
Fix Debian package having an incorrect package name

### DIFF
--- a/tekton/debbuild/container/buildpackage.sh
+++ b/tekton/debbuild/container/buildpackage.sh
@@ -31,7 +31,8 @@ cd ${TMPD}
 curl -C- -L -# -o tektoncd-cli_${version}.orig.tar.gz -L https://github.com/tektoncd/cli/archive/v${version}.tar.gz
 tar xzf ${TMPD}/tektoncd-cli_${version}.orig.tar.gz
 
-cd cli-${version}
+mv cli-${version} tektoncd-cli-${version}
+cd tektoncd-cli-${version}
 
 # Make it easy for devs
 [[ -d /debian ]] && { rm -rf debian && cp -a /debian . ; }

--- a/tekton/debbuild/container/buildpackage.sh
+++ b/tekton/debbuild/container/buildpackage.sh
@@ -3,7 +3,7 @@ set -eux
 # Increase this on minor *package* releases (ie fix on the packaging),
 # decrease it to 0 on major *package* release
 # (need ot find a better way to do that)
-RELEASE=2
+RELEASE=0
 
 [[ -z ${GPG_KEY} ]] && {
     echo "You need to setup your GPG_KEY."


### PR DESCRIPTION
# Changes

debbuild is using base dir for its name and not using the control file, let's
rename then from cli to tektoncd-cli

I tested it and checked the dsc file and it's should now shows as
tektoncd-cli (haven't tested it properly since the upload should only happen on
upload):

```
root@e54c45581b31:/tmp/tmp.aPTgbvPrXi# cat tektoncd-cli_0.9.0-2.dsc
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA512

Format: 3.0 (native)
Source: tektoncd-cli
Binary: tektoncd-cli
Architecture: any
Version: 0.9.0-2
Maintainer: Chmouel Boudjnah <chmouel@redhat.com>
Standards-Version: 4.3.0
Vcs-Git: https://github.com/tektoncd/cli.git
Build-Depends: debhelper (>= 11), dh-golang (>= 1.34~), golang-any (>= 2:1.12~)
Package-List:
 tektoncd-cli deb misc optional arch=any
Checksums-Sha1:
 3f5e6a84345e0258395d3c6a75ddd50c81a35786 3852588 tektoncd-cli_0.9.0-2.tar.xz
Checksums-Sha256:
 e36414c9276d204de0e71a453b521cac3778f7e8ffb35a33e603d7c0b0c7bb6f 3852588 tektoncd-cli_0.9.0-2.tar.xz
Files:
 974e49408ab411636c6e5f923063d8aa 3852588 tektoncd-cli_0.9.0-2.tar.xz
```

Closes #997

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
debian package should have now a proper name, instead of cli showing as tektoncd-cli
```