### PR TITLE
Pass k8 context when printing the log command for the start commands

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -58,6 +58,7 @@ type startOptions struct {
 	TimeOut            string
 	DryRun             bool
 	Output             string
+	TektonOptions      flags.TektonOptions
 }
 
 // NameArg validates that the first argument is a valid clustertask name
@@ -127,6 +128,7 @@ like cat,foo,bar
 				Err: cmd.OutOrStderr(),
 			}
 
+			opt.TektonOptions = flags.GetTektonOptions(cmd)
 			return startClusterTask(opt, args)
 		},
 	}
@@ -234,7 +236,13 @@ func startClusterTask(opt startOptions, args []string) error {
 
 	fmt.Fprintf(opt.stream.Out, "Taskrun started: %s\n", trCreated.Name)
 	if !opt.ShowLog {
-		fmt.Fprintf(opt.stream.Out, "\nIn order to track the taskrun progress run:\ntkn taskrun logs %s -f -n %s\n", trCreated.Name, trCreated.Namespace)
+		inOrderString := fmt.Sprint("\nIn order to track the taskrun progress run:\ntkn taskrun ")
+		if opt.TektonOptions.Context != "" {
+			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
+		}
+		inOrderString += fmt.Sprintf("logs %s -f -n %s\n", trCreated.Name, trCreated.Namespace)
+
+		fmt.Fprint(opt.stream.Out, inOrderString)
 		return nil
 	}
 

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -77,6 +77,7 @@ type startOptions struct {
 	Filename           string
 	Workspaces         []string
 	UseParamDefaults   bool
+	TektonOptions      flags.TektonOptions
 }
 
 type resourceOptionsFilter struct {
@@ -131,6 +132,7 @@ like cat,foo,bar
 					return fmt.Errorf("output format specified is %s but must be yaml or json", opt.Output)
 				}
 			}
+			opt.TektonOptions = flags.GetTektonOptions(cmd)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -298,7 +300,13 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 
 	fmt.Fprintf(opt.stream.Out, "Pipelinerun started: %s\n", prCreated.Name)
 	if !opt.ShowLog {
-		fmt.Fprintf(opt.stream.Out, "\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs %s -f -n %s\n", prCreated.Name, prCreated.Namespace)
+		inOrderString := fmt.Sprint("\nIn order to track the pipelinerun progress run:\ntkn pipelinerun ")
+		if opt.TektonOptions.Context != "" {
+			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
+		}
+		inOrderString += fmt.Sprintf("logs %s -f -n %s\n", prCreated.Name, prCreated.Namespace)
+
+		fmt.Fprint(opt.stream.Out, inOrderString)
 		return nil
 	}
 

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -290,6 +290,17 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 	}
 	c6 := &test.Params{Tekton: cs6.Pipeline, Kube: cs6.Kube, Dynamic: dc6, Clock: clock, Resource: cs6.Resource}
 
+	cs7, _ := test.SeedTestData(t, pipelinetest.Data{Pipelines: pipeline, Namespaces: namespaces})
+	cs7.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"pipeline", "pipelinerun"})
+	tdc7 := testDynamic.Options{}
+	dc7, err := tdc7.Client(
+		cb.UnstructuredP(pipeline[0], versionA1),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	c7 := &test.Params{Tekton: cs7.Pipeline, Kube: cs7.Kube, Dynamic: dc7, Clock: clock, Resource: cs7.Resource}
+
 	testParams := []struct {
 		name       string
 		command    []string
@@ -337,6 +348,22 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			input:     c2,
 			wantError: false,
 			want:      "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n",
+		},
+		{
+			name: "Start pipeline with different context",
+			command: []string{"start", "test-pipeline",
+				"--context=GummyBear",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-l=jemange=desfrites",
+				"-w=name=password-vault,secret=secret-name",
+				"-n", "ns",
+			},
+			namespace: "",
+			input:     c7,
+			wantError: false,
+			want:      "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun --context=GummyBear logs  -f -n ns\n",
 		},
 		{
 			name: "Start pipeline with showlog flag false",

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -72,6 +72,7 @@ type startOptions struct {
 	Workspaces         []string
 	task               *v1beta1.Task
 	askOpts            survey.AskOpt
+	TektonOptions      flags.TektonOptions
 }
 
 // NameArg validates that the first argument is a valid task name
@@ -163,6 +164,7 @@ like cat,foo,bar
 				return fmt.Errorf("using --last and --use-taskrun are not compatible")
 			}
 
+			opt.TektonOptions = flags.GetTektonOptions(cmd)
 			return startTask(opt, args)
 		},
 	}
@@ -365,7 +367,13 @@ func startTask(opt startOptions, args []string) error {
 
 	fmt.Fprintf(opt.stream.Out, "Taskrun started: %s\n", trCreated.Name)
 	if !opt.ShowLog {
-		fmt.Fprintf(opt.stream.Out, "\nIn order to track the taskrun progress run:\ntkn taskrun logs %s -f -n %s\n", trCreated.Name, trCreated.Namespace)
+		inOrderString := fmt.Sprint("\nIn order to track the taskrun progress run:\ntkn taskrun ")
+		if opt.TektonOptions.Context != "" {
+			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
+		}
+		inOrderString += fmt.Sprintf("logs %s -f -n %s\n", trCreated.Name, trCreated.Namespace)
+
+		fmt.Fprint(opt.stream.Out, inOrderString)
 		return nil
 	}
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -32,6 +32,12 @@ const (
 	nocolour   = "nocolour"
 )
 
+// TektonOptions all global tekton options
+type TektonOptions struct {
+	KubeConfig, Context, Namespace string
+	Nocolour                       bool
+}
+
 // AddTektonOptions amends command to add flags required to initialise a cli.Param
 func AddTektonOptions(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP(
@@ -55,6 +61,20 @@ func AddTektonOptions(cmd *cobra.Command) {
 	for name, completion := range completion.ShellCompletionMap {
 		pflag := cmd.PersistentFlags().Lookup(name)
 		AddShellCompletion(pflag, completion)
+	}
+}
+
+// GetTektonOptions get the global tekton Options that are not passed to a subcommands
+func GetTektonOptions(cmd *cobra.Command) TektonOptions {
+	kcPath, _ := cmd.Flags().GetString(kubeConfig)
+	kContext, _ := cmd.Flags().GetString(context)
+	ns, _ := cmd.Flags().GetString(namespace)
+	nocolourFlag, _ := cmd.Flags().GetBool(nocolour)
+	return TektonOptions{
+		KubeConfig: kcPath,
+		Context:    kContext,
+		Namespace:  ns,
+		Nocolour:   nocolourFlag,
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We were not passing the desired context to the printed command line for the user
to paste.

With this change we can as well add --kubeconfig easily as well in subsequent PR
and other global options if we want to.

Closes #1021 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Pass --context when printing the log command after starting task or pipelines
```