### PR TITLE
Common Way of Referring to Tekton Resources for User Facing Messages: TaskRun

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -23,7 +23,7 @@ CLI for tekton pipelines
 * [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
 * [tkn resource](tkn_resource.md)	 - Manage pipeline resources
 * [tkn task](tkn_task.md)	 - Manage tasks
-* [tkn taskrun](tkn_taskrun.md)	 - Manage taskruns
+* [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 * [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage triggerbindings
 * [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates
 * [tkn version](tkn_version.md)	 - Prints version information

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -1,12 +1,12 @@
 ## tkn taskrun
 
-Manage taskruns
+Manage TaskRuns
 
 ***Aliases**: tr,taskruns*
 
 ### Synopsis
 
-Manage taskruns
+Manage TaskRuns
 
 ### Options
 
@@ -22,8 +22,8 @@ Manage taskruns
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn taskrun cancel](tkn_taskrun_cancel.md)	 - Cancel a TaskRun in a namespace
-* [tkn taskrun delete](tkn_taskrun_delete.md)	 - Delete taskruns in a namespace
-* [tkn taskrun describe](tkn_taskrun_describe.md)	 - Describe a taskrun in a namespace
+* [tkn taskrun delete](tkn_taskrun_delete.md)	 - Delete TaskRuns in a namespace
+* [tkn taskrun describe](tkn_taskrun_describe.md)	 - Describe a TaskRun in a namespace
 * [tkn taskrun list](tkn_taskrun_list.md)	 - Lists TaskRuns in a namespace
-* [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show taskruns logs
+* [tkn taskrun logs](tkn_taskrun_logs.md)	 - Show TaskRuns logs
 

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -36,5 +36,5 @@ Cancel the TaskRun named 'foo' from namespace 'bar':
 
 ### SEE ALSO
 
-* [tkn taskrun](tkn_taskrun.md)	 - Manage taskruns
+* [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -1,6 +1,6 @@
 ## tkn taskrun delete
 
-Delete taskruns in a namespace
+Delete TaskRuns in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn taskrun delete
 
 ### Synopsis
 
-Delete taskruns in a namespace
+Delete TaskRuns in a namespace
 
 ### Examples
 
@@ -28,13 +28,13 @@ or
 ### Options
 
 ```
-      --all                           Delete all taskruns in a namespace (default: false)
+      --all                           Delete all TaskRuns in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-      --keep int                      Keep n most recent number of taskruns
+      --keep int                      Keep n most recent number of TaskRuns
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
-  -t, --task string                   The name of a task whose taskruns should be deleted (does not delete the task)
+  -t, --task string                   The name of a Task whose TaskRuns should be deleted (does not delete the task)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
@@ -49,5 +49,5 @@ or
 
 ### SEE ALSO
 
-* [tkn taskrun](tkn_taskrun.md)	 - Manage taskruns
+* [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -1,6 +1,6 @@
 ## tkn taskrun describe
 
-Describe a taskrun in a namespace
+Describe a TaskRun in a namespace
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn taskrun describe
 
 ### Synopsis
 
-Describe a taskrun in a namespace
+Describe a TaskRun in a namespace
 
 ### Examples
 
@@ -31,8 +31,8 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -F, --fzf                           use fzf to select a taskrun to describe
   -h, --help                          help for describe
-  -L, --last                          show description for last taskrun
-      --limit int                     lists number of taskruns when selecting a taskrun to describe (default 5)
+  -L, --last                          show description for last TaskRun
+      --limit int                     lists number of TaskRuns when selecting a TaskRun to describe (default 5)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
@@ -48,5 +48,5 @@ or
 
 ### SEE ALSO
 
-* [tkn taskrun](tkn_taskrun.md)	 - Manage taskruns
+* [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -28,14 +28,14 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 ### Options
 
 ```
-  -A, --all-namespaces                list taskruns from all namespaces
+  -A, --all-namespaces                list TaskRuns from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='
-      --limit int                     limit taskruns listed (default: return all taskruns)
+      --limit int                     limit TaskRuns listed (default: return all TaskRuns)
       --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
-      --reverse                       list taskruns in reverse order
+      --reverse                       list TaskRuns in reverse order
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
@@ -50,5 +50,5 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 
 ### SEE ALSO
 
-* [tkn taskrun](tkn_taskrun.md)	 - Manage taskruns
+* [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -1,6 +1,6 @@
 ## tkn taskrun logs
 
-Show taskruns logs
+Show TaskRuns logs
 
 ### Usage
 
@@ -10,7 +10,7 @@ tkn taskrun logs
 
 ### Synopsis
 
-Show taskruns logs
+Show TaskRuns logs
 
 ### Examples
 
@@ -32,10 +32,10 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 ```
   -a, --all            show all logs including init steps injected by tekton
   -f, --follow         stream live logs
-  -F, --fzf            use fzf to select a taskrun
+  -F, --fzf            use fzf to select a TaskRun
   -h, --help           help for logs
-  -L, --last           show logs for last taskrun
-      --limit int      lists number of taskruns (default 5)
+  -L, --last           show logs for last TaskRun
+      --limit int      lists number of TaskRuns (default 5)
   -s, --step strings   show logs for mentioned steps only
 ```
 
@@ -50,5 +50,5 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 
 ### SEE ALSO
 
-* [tkn taskrun](tkn_taskrun.md)	 - Manage taskruns
+* [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun\-delete \- Delete taskruns in a namespace
+tkn\-taskrun\-delete \- Delete TaskRuns in a namespace
 
 
 .SH SYNOPSIS
@@ -15,13 +15,13 @@ tkn\-taskrun\-delete \- Delete taskruns in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete taskruns in a namespace
+Delete TaskRuns in a namespace
 
 
 .SH OPTIONS
 .PP
 \fB\-\-all\fP[=false]
-    Delete all taskruns in a namespace (default: false)
+    Delete all TaskRuns in a namespace (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
@@ -37,7 +37,7 @@ Delete taskruns in a namespace
 
 .PP
 \fB\-\-keep\fP=0
-    Keep n most recent number of taskruns
+    Keep n most recent number of TaskRuns
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""
@@ -45,7 +45,7 @@ Delete taskruns in a namespace
 
 .PP
 \fB\-t\fP, \fB\-\-task\fP=""
-    The name of a task whose taskruns should be deleted (does not delete the task)
+    The name of a Task whose TaskRuns should be deleted (does not delete the task)
 
 .PP
 \fB\-\-template\fP=""

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun\-describe \- Describe a taskrun in a namespace
+tkn\-taskrun\-describe \- Describe a TaskRun in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-taskrun\-describe \- Describe a taskrun in a namespace
 
 .SH DESCRIPTION
 .PP
-Describe a taskrun in a namespace
+Describe a TaskRun in a namespace
 
 
 .SH OPTIONS
@@ -33,11 +33,11 @@ Describe a taskrun in a namespace
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    show description for last taskrun
+    show description for last TaskRun
 
 .PP
 \fB\-\-limit\fP=5
-    lists number of taskruns when selecting a taskrun to describe
+    lists number of TaskRuns when selecting a TaskRun to describe
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -21,7 +21,7 @@ Lists TaskRuns in a namespace
 .SH OPTIONS
 .PP
 \fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
-    list taskruns from all namespaces
+    list TaskRuns from all namespaces
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
@@ -37,7 +37,7 @@ Lists TaskRuns in a namespace
 
 .PP
 \fB\-\-limit\fP=0
-    limit taskruns listed (default: return all taskruns)
+    limit TaskRuns listed (default: return all TaskRuns)
 
 .PP
 \fB\-\-no\-headers\fP[=false]
@@ -49,7 +49,7 @@ Lists TaskRuns in a namespace
 
 .PP
 \fB\-\-reverse\fP[=false]
-    list taskruns in reverse order
+    list TaskRuns in reverse order
 
 .PP
 \fB\-\-template\fP=""

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun\-logs \- Show taskruns logs
+tkn\-taskrun\-logs \- Show TaskRuns logs
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-taskrun\-logs \- Show taskruns logs
 
 .SH DESCRIPTION
 .PP
-Show taskruns logs
+Show TaskRuns logs
 
 
 .SH OPTIONS
@@ -29,7 +29,7 @@ Show taskruns logs
 
 .PP
 \fB\-F\fP, \fB\-\-fzf\fP[=false]
-    use fzf to select a taskrun
+    use fzf to select a TaskRun
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -37,11 +37,11 @@ Show taskruns logs
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    show logs for last taskrun
+    show logs for last TaskRun
 
 .PP
 \fB\-\-limit\fP=5
-    lists number of taskruns
+    lists number of TaskRuns
 
 .PP
 \fB\-s\fP, \fB\-\-step\fP=[]

--- a/docs/man/man1/tkn-taskrun.1
+++ b/docs/man/man1/tkn-taskrun.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-taskrun \- Manage taskruns
+tkn\-taskrun \- Manage TaskRuns
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-taskrun \- Manage taskruns
 
 .SH DESCRIPTION
 .PP
-Manage taskruns
+Manage TaskRuns
 
 
 .SH OPTIONS

--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -72,16 +72,16 @@ func cancelTaskRun(p cli.Params, s *cli.Stream, trName string) error {
 
 	tr, err := taskrun.GetV1beta1(cs, trName, metav1.GetOptions{}, p.Namespace())
 	if err != nil {
-		return fmt.Errorf("failed to find taskrun: %s", trName)
+		return fmt.Errorf("failed to find TaskRun: %s", trName)
 	}
 
 	taskrunCond := formatted.Condition(tr.Status.Conditions)
 	if taskrunCond == succeeded || taskrunCond == failed || taskrunCond == taskrunCancelled {
-		return fmt.Errorf("failed to cancel taskrun %s: taskrun has already finished execution", trName)
+		return fmt.Errorf("failed to cancel TaskRun %s: TaskRun has already finished execution", trName)
 	}
 
 	if _, err := taskrun.Patch(cs, trName, metav1.PatchOptions{}, p.Namespace()); err != nil {
-		return fmt.Errorf("failed to cancel taskrun %q: %s", trName, err)
+		return fmt.Errorf("failed to cancel TaskRun %s: %v", trName, err)
 	}
 
 	fmt.Fprintf(s.Out, "TaskRun cancelled: %s\n", tr.Name)

--- a/pkg/cmd/taskrun/cancel_test.go
+++ b/pkg/cmd/taskrun/cancel_test.go
@@ -174,7 +174,7 @@ func TestTaskRunCancel(t *testing.T) {
 			dynamic:   seeds[0].dynamicClient,
 			input:     seeds[0].pipelineClient,
 			wantError: true,
-			want:      "failed to find taskrun: nonexistent",
+			want:      "failed to find TaskRun: nonexistent",
 		},
 		{
 			name:      "Failed canceling taskrun",
@@ -182,7 +182,7 @@ func TestTaskRunCancel(t *testing.T) {
 			dynamic:   failures[0].dynamicClient,
 			input:     failures[0].pipelineClient,
 			wantError: true,
-			want:      "failed to cancel taskrun \"failure-taskrun-1\": test error",
+			want:      "failed to cancel TaskRun failure-taskrun-1: test error",
 		},
 		{
 			name:      "Failed canceling taskrun that succeeded",
@@ -190,7 +190,7 @@ func TestTaskRunCancel(t *testing.T) {
 			dynamic:   seeds[0].dynamicClient,
 			input:     seeds[0].pipelineClient,
 			wantError: true,
-			want:      "failed to cancel taskrun taskrun-2: taskrun has already finished execution",
+			want:      "failed to cancel TaskRun taskrun-2: TaskRun has already finished execution",
 		},
 		{
 			name:      "Failed canceling taskrun that was cancelled",
@@ -198,7 +198,7 @@ func TestTaskRunCancel(t *testing.T) {
 			dynamic:   cancels[0].dynamicClient,
 			input:     cancels[0].pipelineClient,
 			wantError: true,
-			want:      "failed to cancel taskrun cancel-taskrun-1: taskrun has already finished execution",
+			want:      "failed to cancel TaskRun cancel-taskrun-1: TaskRun has already finished execution",
 		},
 	}
 
@@ -363,7 +363,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 			dynamic:   seeds[0].dynamicClient,
 			input:     seeds[0].pipelineClient,
 			wantError: true,
-			want:      "failed to find taskrun: nonexistent",
+			want:      "failed to find TaskRun: nonexistent",
 		},
 		{
 			name:      "Failed canceling taskrun",
@@ -371,7 +371,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 			dynamic:   failures[0].dynamicClient,
 			input:     failures[0].pipelineClient,
 			wantError: true,
-			want:      "failed to cancel taskrun \"failure-taskrun-1\": test error",
+			want:      "failed to cancel TaskRun failure-taskrun-1: test error",
 		},
 		{
 			name:      "Failed canceling taskrun that succeeded",
@@ -379,7 +379,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 			dynamic:   seeds[0].dynamicClient,
 			input:     seeds[0].pipelineClient,
 			wantError: true,
-			want:      "failed to cancel taskrun taskrun-2: taskrun has already finished execution",
+			want:      "failed to cancel TaskRun taskrun-2: TaskRun has already finished execution",
 		},
 		{
 			name:      "Failed canceling taskrun that was cancelled",
@@ -387,7 +387,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 			dynamic:   cancels[0].dynamicClient,
 			input:     cancels[0].pipelineClient,
 			wantError: true,
-			want:      "failed to cancel taskrun cancel-taskrun-1: taskrun has already finished execution",
+			want:      "failed to cancel TaskRun cancel-taskrun-1: TaskRun has already finished execution",
 		},
 	}
 

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -34,7 +34,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "taskrun", ForceDelete: false, ParentResource: "task", DeleteAllNs: false}
+	opts := &options.DeleteOptions{Resource: "TaskRun", ForceDelete: false, ParentResource: "Task", DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete TaskRuns with names 'foo' and 'bar' in namespace 'quux':
 
@@ -48,7 +48,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete taskruns in a namespace",
+		Short:        "Delete TaskRuns in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
@@ -83,9 +83,9 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().StringVarP(&opts.ParentResourceName, "task", "t", "", "The name of a task whose taskruns should be deleted (does not delete the task)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all taskruns in a namespace (default: false)")
-	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of taskruns")
+	c.Flags().StringVarP(&opts.ParentResourceName, "task", "t", "", "The name of a Task whose TaskRuns should be deleted (does not delete the task)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all TaskRuns in a namespace (default: false)")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of TaskRuns")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_taskrun")
 	return c
 }
@@ -114,7 +114,7 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 		d.Delete(s, trNames)
 	default:
 		d = deleter.New("Task", func(_ string) error {
-			return errors.New("the task should not be deleted")
+			return errors.New("the Task should not be deleted")
 		})
 		d.WithRelated("TaskRun", taskRunLister(p, opts.Keep, cs), func(taskRunName string) error {
 			return actions.Delete(trGroupResource, cs, taskRunName, p.Namespace(), &metav1.DeleteOptions{})

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -148,7 +148,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting taskrun \"tr0-1\"",
+			want:        "canceled deleting TaskRun \"tr0-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -157,7 +157,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete taskrun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
+			want:        "Are you sure you want to delete TaskRun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -184,7 +184,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide taskrun name(s) or use --task flag or --all flag to use delete",
+			want:        "must provide TaskRun name(s) or use --task flag or --all flag to use delete",
 		},
 		{
 			name:        "Remove taskruns of a task",
@@ -193,7 +193,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all taskruns related to task \"random\" (y/n): All TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all TaskRuns related to Task \"random\" (y/n): All TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -202,7 +202,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all taskruns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all TaskRuns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -256,7 +256,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Are you sure you want to delete all taskruns related to task \"random\" keeping 2 taskruns (y/n): All but 2 TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all TaskRuns related to Task \"random\" keeping 2 TaskRuns (y/n): All but 2 TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Error from using argument with --keep",
@@ -411,7 +411,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting taskrun \"tr0-1\"",
+			want:        "canceled deleting TaskRun \"tr0-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -420,7 +420,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete taskrun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
+			want:        "Are you sure you want to delete TaskRun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -447,7 +447,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide taskrun name(s) or use --task flag or --all flag to use delete",
+			want:        "must provide TaskRun name(s) or use --task flag or --all flag to use delete",
 		},
 		{
 			name:        "Remove taskruns of a task",
@@ -456,7 +456,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all taskruns related to task \"random\" (y/n): All TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all TaskRuns related to Task \"random\" (y/n): All TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -465,7 +465,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all taskruns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all TaskRuns in namespace \"ns\" (y/n): All TaskRuns deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -510,7 +510,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Are you sure you want to delete all taskruns related to task \"random\" keeping 2 taskruns (y/n): All but 2 TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all TaskRuns related to Task \"random\" keeping 2 TaskRuns (y/n): All but 2 TaskRuns associated with Task \"random\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Error from using argument with --keep",

--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -50,7 +50,7 @@ or
 	c := &cobra.Command{
 		Use:          "describe",
 		Aliases:      []string{"desc"},
-		Short:        "Describe a taskrun in a namespace",
+		Short:        "Describe a TaskRun in a namespace",
 		Example:      eg,
 		SilenceUsage: true,
 		Annotations: map[string]string{
@@ -67,8 +67,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if !opts.Fzf {
@@ -104,8 +103,8 @@ or
 		},
 	}
 
-	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show description for last taskrun")
-	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultTaskRunLimit, "lists number of taskruns when selecting a taskrun to describe")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show description for last TaskRun")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultTaskRunLimit, "lists number of TaskRuns when selecting a TaskRun to describe")
 	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a taskrun to describe")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_taskrun")
@@ -127,7 +126,7 @@ func askTaskRunName(opts *options.DescribeOptions, p cli.Params) error {
 		return err
 	}
 	if len(trs) == 0 {
-		return fmt.Errorf("no taskruns found")
+		return fmt.Errorf("no TaskRuns found")
 	}
 
 	if opts.Fzf {

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -94,14 +94,12 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 			}
 
 			if opts.Limit < 0 {
-				fmt.Fprintf(os.Stderr, "Limit was %d but must be a positive number\n", opts.Limit)
-				return nil
+				return fmt.Errorf("limit was %d but must be a positive number", opts.Limit)
 			}
 
 			trs, err := list(p, task, opts.Limit, opts.LabelSelector, opts.AllNamespaces)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to list taskruns from %s namespace \n", p.Namespace())
-				return err
+				return fmt.Errorf("failed to list TaskRuns from namespace %s: %v", p.Namespace(), err)
 			}
 
 			if trs != nil && opts.Reverse {
@@ -110,8 +108,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 			if output == "name" && trs != nil {
 				w := cmd.OutOrStdout()
@@ -136,7 +133,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 			}
 
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Failed to print taskruns \n")
+				fmt.Fprint(os.Stderr, "failed to print TaskRuns \n")
 				return err
 			}
 
@@ -145,10 +142,10 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 	}
 
 	f.AddFlags(c)
-	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit taskruns listed (default: return all taskruns)")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit TaskRuns listed (default: return all TaskRuns)")
 	c.Flags().StringVarP(&opts.LabelSelector, "label", "", opts.LabelSelector, "A selector (label query) to filter on, supports '=', '==', and '!='")
-	c.Flags().BoolVarP(&opts.Reverse, "reverse", "", opts.Reverse, "list taskruns in reverse order")
-	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list taskruns from all namespaces")
+	c.Flags().BoolVarP(&opts.Reverse, "reverse", "", opts.Reverse, "list TaskRuns in reverse order")
+	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list TaskRuns from all namespaces")
 	c.Flags().BoolVarP(&opts.NoHeaders, "no-headers", "", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 	return c
 }
@@ -170,7 +167,7 @@ func list(p cli.Params, task string, limit int, labelselector string, allnamespa
 	var options v1.ListOptions
 
 	if task != "" && labelselector != "" {
-		return nil, fmt.Errorf("specifying a task and labels are not compatible")
+		return nil, fmt.Errorf("specifying a Task and labels are not compatible")
 	}
 
 	if task != "" {
@@ -215,12 +212,12 @@ func list(p cli.Params, task string, limit int, labelselector string, allnamespa
 		}
 	}
 
-	// If greater than maximum amount of taskruns, return all taskruns by setting limit to default
+	// If greater than maximum amount of TaskRuns, return all TaskRuns by setting limit to default
 	if limit > trslen {
 		limit = 0
 	}
 
-	// Return all taskruns if limit is 0 or is same as trslen
+	// Return all TaskRuns if limit is 0 or is same as trslen
 	if limit != 0 && trslen > limit {
 		trs.Items = trs.Items[0:limit]
 	}

--- a/pkg/cmd/taskrun/list_test.go
+++ b/pkg/cmd/taskrun/list_test.go
@@ -237,7 +237,7 @@ func TestListTaskRuns(t *testing.T) {
 			name:      "limit taskruns negative case",
 			command:   command(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", -1)},
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name:      "limit taskruns greater than maximum case",
@@ -511,7 +511,7 @@ func TestListTaskRuns_v1beta1(t *testing.T) {
 			name:      "limit taskruns negative case",
 			command:   command(t, trs, now, ns, version, dc1),
 			args:      []string{"list", "-n", "foo", "--limit", fmt.Sprintf("%d", -1)},
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name:      "limit taskruns greater than maximum case",

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -48,7 +48,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 `
 	c := &cobra.Command{
 		Use:          "logs",
-		Short:        "Show taskruns logs",
+		Short:        "Show TaskRuns logs",
 		Example:      eg,
 		SilenceUsage: true,
 		Annotations: map[string]string{
@@ -82,11 +82,11 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 		},
 	}
 
-	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last taskrun")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last TaskRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
-	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of taskruns")
-	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a taskrun")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of TaskRuns")
+	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a TaskRun")
 	c.Flags().StringSliceVarP(&opts.Steps, "step", "s", []string{}, "show logs for mentioned steps only")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_taskrun")
@@ -132,7 +132,7 @@ func askRunName(opts *options.LogOptions) error {
 	}
 
 	if len(trs) == 0 {
-		return fmt.Errorf("No taskruns found")
+		return fmt.Errorf("No TaskRuns found")
 	}
 
 	if len(trs) == 1 || opts.Last {

--- a/pkg/cmd/taskrun/taskrun.go
+++ b/pkg/cmd/taskrun/taskrun.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "taskrun",
 		Aliases: []string{"tr", "taskruns"},
-		Short:   "Manage taskruns",
+		Short:   "Manage TaskRuns",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_negative_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_negative_case.golden
@@ -1,0 +1,1 @@
+Error: limit was -1 but must be a positive number

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-no_mixing_pipelinename_and_labels.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-no_mixing_pipelinename_and_labels.golden
@@ -1,1 +1,1 @@
-Error: specifying a task and labels are not compatible
+Error: failed to list TaskRuns from namespace foo: specifying a Task and labels are not compatible

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-limit_taskruns_negative_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-limit_taskruns_negative_case.golden
@@ -1,0 +1,1 @@
+Error: limit was -1 but must be a positive number

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-no_mixing_pipelinename_and_labels.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-no_mixing_pipelinename_and_labels.golden
@@ -1,1 +1,1 @@
-Error: specifying a task and labels are not compatible
+Error: failed to list TaskRuns from namespace foo: specifying a Task and labels are not compatible

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -80,7 +80,7 @@ func (d *Deleter) deleteRelatedList(streams *cli.Stream, resourceName string) {
 	} else {
 		for _, subresource := range related {
 			if err := d.deleteRelated(subresource); err != nil {
-				err = fmt.Errorf("failed to delete %s %q: %s", strings.ToLower(d.relatedKind), subresource, err)
+				err = fmt.Errorf("failed to delete %s %q: %s", d.relatedKind, subresource, err)
 				d.appendError(streams, err)
 			} else {
 				d.successfulRelatedDeletes = append(d.successfulRelatedDeletes, subresource)

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -50,7 +50,7 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	// make sure either resource names are provided, name of related resource,
 	// or --all specified if deleting PipelineRuns or TaskRuns
 	if namesLen == 0 && o.ParentResource != "" && o.ParentResourceName == "" && !o.DeleteAllNs {
-		return fmt.Errorf("must provide %s name(s) or use --%s flag or --all flag to use delete", o.Resource, o.ParentResource)
+		return fmt.Errorf("must provide %s name(s) or use --%s flag or --all flag to use delete", o.Resource, strings.ToLower(o.ParentResource))
 	}
 
 	// make sure that resource name or --all flag is specified to use delete

--- a/pkg/taskrun/description/description.go
+++ b/pkg/taskrun/description/description.go
@@ -191,7 +191,7 @@ func PrintTaskRunDescription(s *cli.Stream, trName string, p cli.Params) error {
 
 	tr, err := taskrun.Get(cs, trName, metav1.GetOptions{}, p.Namespace())
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get taskrun %s\n", trName)
+		fmt.Fprintf(s.Err, "failed to get TaskRun %s\n", trName)
 		return err
 	}
 
@@ -218,7 +218,7 @@ func PrintTaskRunDescription(s *cli.Stream, trName string, p cli.Params) error {
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	t := template.Must(template.New("Describe taskrun").Funcs(funcMap).Parse(templ))
+	t := template.Must(template.New("Describe TaskRun").Funcs(funcMap).Parse(templ))
 
 	err = t.Execute(w, data)
 	if err != nil {

--- a/pkg/taskrun/get.go
+++ b/pkg/taskrun/get.go
@@ -17,7 +17,6 @@ package taskrun
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -58,8 +57,7 @@ func GetV1beta1(c *cli.Clients, trname string, opts metav1.GetOptions, ns string
 
 	var taskrun *v1beta1.TaskRun
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTR.UnstructuredContent(), &taskrun); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get taskrun from %s namespace \n", ns)
-		return nil, err
+		return nil, fmt.Errorf("failed to get TaskRun from namespace %s", ns)
 	}
 	return taskrun, nil
 }
@@ -73,8 +71,7 @@ func getV1alpha1(c *cli.Clients, trname string, opts metav1.GetOptions, ns strin
 
 	var taskrun *v1alpha1.TaskRun
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTR.UnstructuredContent(), &taskrun); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get taskrun from %s namespace \n", ns)
-		return nil, err
+		return nil, fmt.Errorf("failed to get TaskRun from namespace %s", ns)
 	}
 	return taskrun, nil
 }


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `TaskRun` instead of a variety of ways it is referenced throughout `tkn` (e.g., `taskrun`, `TaskRun`, etc.). 

This pull request only focuses of `tkn taskrun` commands, but there are other TaskRun references throughout `tkn` that should be updated as well, but will be addressed in pull requests pertaining to the commands or helper packages where TaskRun is referenced. 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Standardize the use of TaskRun in user-facing messages for tkn taskrun commands
```
