### PR TITLE
Fix go lint Errors from 1.27 upgrade

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -236,7 +236,7 @@ func startClusterTask(opt startOptions, args []string) error {
 
 	fmt.Fprintf(opt.stream.Out, "Taskrun started: %s\n", trCreated.Name)
 	if !opt.ShowLog {
-		inOrderString := fmt.Sprint("\nIn order to track the taskrun progress run:\ntkn taskrun ")
+		inOrderString := "\nIn order to track the taskrun progress run:\ntkn taskrun "
 		if opt.TektonOptions.Context != "" {
 			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
 		}

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -300,7 +300,7 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 
 	fmt.Fprintf(opt.stream.Out, "Pipelinerun started: %s\n", prCreated.Name)
 	if !opt.ShowLog {
-		inOrderString := fmt.Sprint("\nIn order to track the pipelinerun progress run:\ntkn pipelinerun ")
+		inOrderString := "\nIn order to track the pipelinerun progress run:\ntkn pipelinerun "
 		if opt.TektonOptions.Context != "" {
 			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
 		}

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -367,7 +367,7 @@ func startTask(opt startOptions, args []string) error {
 
 	fmt.Fprintf(opt.stream.Out, "Taskrun started: %s\n", trCreated.Name)
 	if !opt.ShowLog {
-		inOrderString := fmt.Sprint("\nIn order to track the taskrun progress run:\ntkn taskrun ")
+		inOrderString := "\nIn order to track the taskrun progress run:\ntkn taskrun "
 		if opt.TektonOptions.Context != "" {
 			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
 		}


### PR DESCRIPTION
As noted in #1027 in this [comment](https://github.com/tektoncd/cli/pull/1027#issuecomment-646153464), the upgrade in plumbing to golangci-lint to v1.27.0 has new linting standards that `tkn` does not meet currently.

This pull request addresses the linting violations introduced by #1022.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
N/A
```
