### PR TITLE
Common Way of Referring to Tekton Resources for User Facing Messages: Task

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -22,7 +22,7 @@ CLI for tekton pipelines
 * [tkn pipeline](tkn_pipeline.md)	 - Manage pipelines
 * [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
 * [tkn resource](tkn_resource.md)	 - Manage pipeline resources
-* [tkn task](tkn_task.md)	 - Manage tasks
+* [tkn task](tkn_task.md)	 - Manage Tasks
 * [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 * [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage triggerbindings
 * [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -1,12 +1,12 @@
 ## tkn task
 
-Manage tasks
+Manage Tasks
 
 ***Aliases**: t,tasks*
 
 ### Synopsis
 
-Manage tasks
+Manage Tasks
 
 ### Options
 
@@ -21,9 +21,9 @@ Manage tasks
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn task delete](tkn_task_delete.md)	 - Delete task resources in a namespace
-* [tkn task describe](tkn_task_describe.md)	 - Describes a task in a namespace
-* [tkn task list](tkn_task_list.md)	 - Lists tasks in a namespace
-* [tkn task logs](tkn_task_logs.md)	 - Show task logs
-* [tkn task start](tkn_task_start.md)	 - Start tasks
+* [tkn task delete](tkn_task_delete.md)	 - Delete Tasks in a namespace
+* [tkn task describe](tkn_task_describe.md)	 - Describe a Task in a namespace
+* [tkn task list](tkn_task_list.md)	 - Lists Tasks in a namespace
+* [tkn task logs](tkn_task_logs.md)	 - Show Task logs
+* [tkn task start](tkn_task_start.md)	 - Start Tasks
 

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -1,6 +1,6 @@
 ## tkn task delete
 
-Delete task resources in a namespace
+Delete Tasks in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn task delete
 
 ### Synopsis
 
-Delete task resources in a namespace
+Delete Tasks in a namespace
 
 ### Examples
 
@@ -48,5 +48,5 @@ or
 
 ### SEE ALSO
 
-* [tkn task](tkn_task.md)	 - Manage tasks
+* [tkn task](tkn_task.md)	 - Manage Tasks
 

--- a/docs/cmd/tkn_task_describe.md
+++ b/docs/cmd/tkn_task_describe.md
@@ -1,6 +1,6 @@
 ## tkn task describe
 
-Describes a task in a namespace
+Describe a Task in a namespace
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn task describe
 
 ### Synopsis
 
-Describes a task in a namespace
+Describe a Task in a namespace
 
 ### Examples
 
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn task](tkn_task.md)	 - Manage tasks
+* [tkn task](tkn_task.md)	 - Manage Tasks
 

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -1,6 +1,6 @@
 ## tkn task list
 
-Lists tasks in a namespace
+Lists Tasks in a namespace
 
 ***Aliases**: ls*
 
@@ -12,12 +12,12 @@ tkn task list
 
 ### Synopsis
 
-Lists tasks in a namespace
+Lists Tasks in a namespace
 
 ### Options
 
 ```
-  -A, --all-namespaces                list tasks from all namespaces
+  -A, --all-namespaces                list Tasks from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --no-headers                    do not print column headers with output (default print column headers with output)
@@ -36,5 +36,5 @@ Lists tasks in a namespace
 
 ### SEE ALSO
 
-* [tkn task](tkn_task.md)	 - Manage tasks
+* [tkn task](tkn_task.md)	 - Manage Tasks
 

--- a/docs/cmd/tkn_task_logs.md
+++ b/docs/cmd/tkn_task_logs.md
@@ -1,6 +1,6 @@
 ## tkn task logs
 
-Show task logs
+Show Task logs
 
 ### Usage
 
@@ -10,7 +10,7 @@ tkn task logs
 
 ### Synopsis
 
-Show task logs
+Show Task logs
 
 ### Examples
 
@@ -26,7 +26,7 @@ Show logs of given Task for last TaskRun:
 
     tkn task logs task -n namespace --last
 
-Show logs for given task and taskrun:
+Show logs for given Task and associated TaskRun:
 
     tkn task logs task taskrun -n namespace
 
@@ -37,8 +37,8 @@ Show logs for given task and taskrun:
   -a, --all         show all logs including init steps injected by tekton
   -f, --follow      stream live logs
   -h, --help        help for logs
-  -L, --last        show logs for last taskrun
-      --limit int   lists number of taskruns (default 5)
+  -L, --last        show logs for last TaskRun
+      --limit int   lists number of TaskRuns (default 5)
 ```
 
 ### Options inherited from parent commands
@@ -52,5 +52,5 @@ Show logs for given task and taskrun:
 
 ### SEE ALSO
 
-* [tkn task](tkn_task.md)	 - Manage tasks
+* [tkn task](tkn_task.md)	 - Manage Tasks
 

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -1,16 +1,16 @@
 ## tkn task start
 
-Start tasks
+Start Tasks
 
 ### Usage
 
 ```
-tkn task start task [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]
+tkn task start [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]
 ```
 
 ### Synopsis
 
-Start tasks
+Start Tasks
 
 ### Examples
 
@@ -18,30 +18,30 @@ Start Task foo by creating a TaskRun named "foo-run-xyz123" from namespace 'bar'
 
     tkn task start foo -s ServiceAccountName -n bar
 
-The task can either be specified by reference in a cluster using the positional argument
+The Task can either be specified by reference in a cluster using the positional argument
 or in a file using the --filename argument.
 
-For params value, if you want to provide multiple values, provide them comma separated
+For params values, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
 
 
 ### Options
 
 ```
-      --dry-run                  preview taskrun without running it
-  -f, --filename string          local or remote file name containing a task definition to start a taskrun
+      --dry-run                  preview TaskRun without running it
+  -f, --filename string          local or remote file name containing a Task definition to start a TaskRun
   -h, --help                     help for start
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.
-  -L, --last                     re-run the task using last taskrun values
-      --output string            format of taskrun dry-run (yaml or json)
+  -L, --last                     re-run the Task using last TaskRun values
+      --output string            format of TaskRun dry-run (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
-      --prefix-name string       specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
+      --prefix-name string       specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string    pass the serviceaccount name
-      --showlog                  show logs right after starting the task
-      --timeout string           timeout for taskrun
-      --use-taskrun string       specify a taskrun name to use its values to re-run the taskrun
+      --showlog                  show logs right after starting the Task
+      --timeout string           timeout for TaskRun
+      --use-taskrun string       specify a TaskRun name to use its values to re-run the TaskRun
   -w, --workspace stringArray    pass the workspace.
 ```
 
@@ -56,5 +56,5 @@ like cat,foo,bar
 
 ### SEE ALSO
 
-* [tkn task](tkn_task.md)	 - Manage tasks
+* [tkn task](tkn_task.md)	 - Manage Tasks
 

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-task\-delete \- Delete task resources in a namespace
+tkn\-task\-delete \- Delete Tasks in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-task\-delete \- Delete task resources in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete task resources in a namespace
+Delete Tasks in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-task-describe.1
+++ b/docs/man/man1/tkn-task-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-task\-describe \- Describes a task in a namespace
+tkn\-task\-describe \- Describe a Task in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-task\-describe \- Describes a task in a namespace
 
 .SH DESCRIPTION
 .PP
-Describes a task in a namespace
+Describe a Task in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-task-list.1
+++ b/docs/man/man1/tkn-task-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-task\-list \- Lists tasks in a namespace
+tkn\-task\-list \- Lists Tasks in a namespace
 
 
 .SH SYNOPSIS
@@ -15,13 +15,13 @@ tkn\-task\-list \- Lists tasks in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists tasks in a namespace
+Lists Tasks in a namespace
 
 
 .SH OPTIONS
 .PP
 \fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
-    list tasks from all namespaces
+    list Tasks from all namespaces
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]

--- a/docs/man/man1/tkn-task-logs.1
+++ b/docs/man/man1/tkn-task-logs.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-task\-logs \- Show task logs
+tkn\-task\-logs \- Show Task logs
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-task\-logs \- Show task logs
 
 .SH DESCRIPTION
 .PP
-Show task logs
+Show Task logs
 
 
 .SH OPTIONS
@@ -33,11 +33,11 @@ Show task logs
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    show logs for last taskrun
+    show logs for last TaskRun
 
 .PP
 \fB\-\-limit\fP=5
-    lists number of taskruns
+    lists number of TaskRuns
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -96,7 +96,7 @@ tkn task logs task \-n namespace \-\-last
 .RE
 
 .PP
-Show logs for given task and taskrun:
+Show logs for given Task and associated TaskRun:
 
 .PP
 .RS

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -5,27 +5,27 @@
 
 .SH NAME
 .PP
-tkn\-task\-start \- Start tasks
+tkn\-task\-start \- Start Tasks
 
 
 .SH SYNOPSIS
 .PP
-\fBtkn task start task [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]\fP
+\fBtkn task start [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]\fP
 
 
 .SH DESCRIPTION
 .PP
-Start tasks
+Start Tasks
 
 
 .SH OPTIONS
 .PP
 \fB\-\-dry\-run\fP[=false]
-    preview taskrun without running it
+    preview TaskRun without running it
 
 .PP
 \fB\-f\fP, \fB\-\-filename\fP=""
-    local or remote file name containing a task definition to start a taskrun
+    local or remote file name containing a Task definition to start a TaskRun
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -41,11 +41,11 @@ Start tasks
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    re\-run the task using last taskrun values
+    re\-run the Task using last TaskRun values
 
 .PP
 \fB\-\-output\fP=""
-    format of taskrun dry\-run (yaml or json)
+    format of TaskRun dry\-run (yaml or json)
 
 .PP
 \fB\-o\fP, \fB\-\-outputresource\fP=[]
@@ -57,7 +57,7 @@ Start tasks
 
 .PP
 \fB\-\-prefix\-name\fP=""
-    specify a prefix for the taskrun name (must be lowercase alphanumeric characters)
+    specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
 
 .PP
 \fB\-s\fP, \fB\-\-serviceaccount\fP=""
@@ -65,15 +65,15 @@ Start tasks
 
 .PP
 \fB\-\-showlog\fP[=false]
-    show logs right after starting the task
+    show logs right after starting the Task
 
 .PP
 \fB\-\-timeout\fP=""
-    timeout for taskrun
+    timeout for TaskRun
 
 .PP
 \fB\-\-use\-taskrun\fP=""
-    specify a taskrun name to use its values to re\-run the taskrun
+    specify a TaskRun name to use its values to re\-run the TaskRun
 
 .PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
@@ -112,11 +112,11 @@ tkn task start foo \-s ServiceAccountName \-n bar
 .RE
 
 .PP
-The task can either be specified by reference in a cluster using the positional argument
+The Task can either be specified by reference in a cluster using the positional argument
 or in a file using the \-\-filename argument.
 
 .PP
-For params value, if you want to provide multiple values, provide them comma separated
+For params values, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
 
 

--- a/docs/man/man1/tkn-task.1
+++ b/docs/man/man1/tkn-task.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-task \- Manage tasks
+tkn\-task \- Manage Tasks
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-task \- Manage tasks
 
 .SH DESCRIPTION
 .PP
-Manage tasks
+Manage Tasks
 
 
 .SH OPTIONS

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -45,7 +45,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete task resources in a namespace",
+		Short:        "Delete Tasks in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,

--- a/pkg/cmd/task/describe_test.go
+++ b/pkg/cmd/task/describe_test.go
@@ -72,12 +72,12 @@ func TestTaskDescribe_Empty(t *testing.T) {
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
 
 	task := Command(p)
-	_, err = test.ExecuteCommand(task, "desc", "bar", "-n", "ns")
+	out, err := test.ExecuteCommand(task, "desc", "bar", "-n", "ns")
 	if err == nil {
 		t.Errorf("Error expected here")
 	}
-	expected := "tasks.tekton.dev \"bar\" not found"
-	test.AssertOutput(t, expected, err.Error())
+	expected := "Error: failed to get Task bar: tasks.tekton.dev \"bar\" not found\n"
+	test.AssertOutput(t, expected, out)
 }
 
 func TestTaskDescribe_OnlyName(t *testing.T) {
@@ -354,9 +354,8 @@ func TestTaskDescribe_TaskRunError(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error got nil")
 	}
-	expected := "failed to get taskruns for task task-1 \nError: fake list taskrun error\n"
+	expected := "Error: failed to get TaskRuns for Task task-1: fake list taskrun error\n"
 	test.AssertOutput(t, expected, out)
-	test.AssertOutput(t, "fake list taskrun error", err.Error())
 }
 
 func TestTaskDescribe_custom_output(t *testing.T) {

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -16,7 +16,6 @@ package task
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"text/template"
 
@@ -64,7 +63,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists tasks in a namespace",
+		Short:   "Lists Tasks in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -78,8 +77,7 @@ func listCommand(p cli.Params) *cobra.Command {
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "error: output option not set properly \n")
-				return err
+				return fmt.Errorf("error: output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -94,7 +92,7 @@ func listCommand(p cli.Params) *cobra.Command {
 		},
 	}
 	f.AddFlags(c)
-	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list tasks from all namespaces")
+	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list Tasks from all namespaces")
 	c.Flags().BoolVarP(&opts.NoHeaders, "no-headers", "", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 
 	return c
@@ -112,8 +110,7 @@ func printTaskDetails(s *cli.Stream, p cli.Params, allnamespaces bool, noheaders
 	}
 	tasks, err := task.List(cs, metav1.ListOptions{}, ns)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to list tasks from %s namespace \n", ns)
-		return err
+		return fmt.Errorf("failed to list Tasks from namespace %s: %v", ns, err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/task/logs.go
+++ b/pkg/cmd/task/logs.go
@@ -58,14 +58,14 @@ Show logs of given Task for last TaskRun:
 
     tkn task logs task -n namespace --last
 
-Show logs for given task and taskrun:
+Show logs for given Task and associated TaskRun:
 
     tkn task logs task taskrun -n namespace
 `
 	c := &cobra.Command{
 		Use:                   "logs",
 		DisableFlagsInUseLine: true,
-		Short:                 "Show task logs",
+		Short:                 "Show Task logs",
 		Example:               eg,
 		SilenceUsage:          true,
 		Annotations: map[string]string{
@@ -90,10 +90,10 @@ Show logs for given task and taskrun:
 			return run(opts, args)
 		},
 	}
-	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last taskrun")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last TaskRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
-	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of taskruns")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of TaskRuns")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_task")
 	return c
@@ -146,8 +146,7 @@ func getAllInputs(opts *options.LogOptions) error {
 	}
 
 	if len(ts) == 0 {
-		fmt.Fprintln(opts.Stream.Err, "No tasks found in namespace:", opts.Params.Namespace())
-		return nil
+		return fmt.Errorf("no Tasks found in namespace %s", opts.Params.Namespace())
 	}
 
 	if len(ts) == 1 {
@@ -174,8 +173,7 @@ func askRunName(opts *options.LogOptions) error {
 	}
 
 	if len(trs) == 0 {
-		fmt.Fprintln(opts.Stream.Err, "No taskruns found for task:", opts.TaskName)
-		return nil
+		return fmt.Errorf("no TaskRuns found for Task %s", opts.TaskName)
 	}
 
 	if len(trs) == 1 {

--- a/pkg/cmd/task/logs_test.go
+++ b/pkg/cmd/task/logs_test.go
@@ -108,23 +108,23 @@ func TestTaskLog(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "namespaces \"invalid\" not found",
+			want:      "Error: namespaces \"invalid\" not found\n",
 		},
 		{
 			name:      "Found no tasks",
 			command:   []string{"logs", "-n", "ns"},
 			input:     cs2,
 			dc:        dc2,
-			wantError: false,
-			want:      "No tasks found in namespace: ns\n",
+			wantError: true,
+			want:      "Error: no Tasks found in namespace ns\n",
 		},
 		{
 			name:      "Found no taskruns",
 			command:   []string{"logs", "task", "-n", "ns"},
 			input:     cs,
 			dc:        dc1,
-			wantError: false,
-			want:      "No taskruns found for task: task\n",
+			wantError: true,
+			want:      "Error: no TaskRuns found for Task task\n",
 		},
 		{
 			name:      "Specify notexist task name",
@@ -132,7 +132,7 @@ func TestTaskLog(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "tasks.tekton.dev \"notexist\" not found",
+			want:      "Error: tasks.tekton.dev \"notexist\" not found\n",
 		},
 		{
 			name:      "Specify notexist taskrun name",
@@ -140,7 +140,7 @@ func TestTaskLog(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "Unable to get Taskrun: taskruns.tekton.dev \"notexist\" not found",
+			want:      "Error: Unable to get Taskrun: taskruns.tekton.dev \"notexist\" not found\n",
 		},
 		{
 			name:      "Specify negative number to limit",
@@ -148,7 +148,7 @@ func TestTaskLog(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "limit was -1 but must be a positive number",
+			want:      "Error: limit was -1 but must be a positive number\n",
 		},
 	}
 
@@ -162,7 +162,7 @@ func TestTaskLog(t *testing.T) {
 				if err == nil {
 					t.Errorf("error expected here")
 				}
-				test.AssertOutput(t, tp.want, err.Error())
+				test.AssertOutput(t, tp.want, out)
 			} else {
 				if err != nil {
 					t.Errorf("unexpected Error")
@@ -174,7 +174,6 @@ func TestTaskLog(t *testing.T) {
 }
 
 func TestTaskLog_v1beta1(t *testing.T) {
-
 	clock := clockwork.NewFakeClock()
 	task1 := []*v1alpha1.Task{tb.Task("task", tb.TaskNamespace("ns"))}
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
@@ -232,23 +231,23 @@ func TestTaskLog_v1beta1(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "namespaces \"invalid\" not found",
+			want:      "Error: namespaces \"invalid\" not found\n",
 		},
 		{
 			name:      "Found no tasks",
 			command:   []string{"logs", "-n", "ns"},
 			input:     cs2,
 			dc:        dc2,
-			wantError: false,
-			want:      "No tasks found in namespace: ns\n",
+			wantError: true,
+			want:      "Error: no Tasks found in namespace ns\n",
 		},
 		{
 			name:      "Found no taskruns",
 			command:   []string{"logs", "task", "-n", "ns"},
 			input:     cs,
 			dc:        dc1,
-			wantError: false,
-			want:      "No taskruns found for task: task\n",
+			wantError: true,
+			want:      "Error: no TaskRuns found for Task task\n",
 		},
 		{
 			name:      "Specify notexist task name",
@@ -256,7 +255,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "tasks.tekton.dev \"notexist\" not found",
+			want:      "Error: tasks.tekton.dev \"notexist\" not found\n",
 		},
 		{
 			name:      "Specify notexist taskrun name",
@@ -264,7 +263,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "Unable to get Taskrun: taskruns.tekton.dev \"notexist\" not found",
+			want:      "Error: Unable to get Taskrun: taskruns.tekton.dev \"notexist\" not found\n",
 		},
 		{
 			name:      "Specify negative number to limit",
@@ -272,7 +271,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 			input:     cs,
 			dc:        dc1,
 			wantError: true,
-			want:      "limit was -1 but must be a positive number",
+			want:      "Error: limit was -1 but must be a positive number\n",
 		},
 	}
 
@@ -286,7 +285,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 				if err == nil {
 					t.Errorf("error expected here")
 				}
-				test.AssertOutput(t, tp.want, err.Error())
+				test.AssertOutput(t, tp.want, out)
 			} else {
 				if err != nil {
 					t.Errorf("unexpected Error")

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -47,8 +47,8 @@ import (
 )
 
 var (
-	errNoTask      = errors.New("missing task name")
-	errInvalidTask = "task name %s does not exist in namespace %s"
+	errNoTask      = errors.New("missing Task name")
+	errInvalidTask = "Task name %s does not exist in namespace %s"
 )
 
 const invalidResource = "invalid input format for resource parameter: "
@@ -117,8 +117,8 @@ func startCommand(p cli.Params) *cobra.Command {
 	}
 
 	c := &cobra.Command{
-		Use:   "start task [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
-		Short: "Start tasks",
+		Use:   "start [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
+		Short: "Start Tasks",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -126,10 +126,10 @@ func startCommand(p cli.Params) *cobra.Command {
 
     tkn task start foo -s ServiceAccountName -n bar
 
-The task can either be specified by reference in a cluster using the positional argument
+The Task can either be specified by reference in a cluster using the positional argument
 or in a file using the --filename argument.
 
-For params value, if you want to provide multiple values, provide them comma separated
+For params values, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
 `,
 		SilenceUsage: true,
@@ -147,7 +147,7 @@ like cat,foo,bar
 				return NameArg(args, p, &opt)
 			}
 			if opt.Filename == "" {
-				return errors.New("either a task name or a --filename parameter must be supplied")
+				return errors.New("either a Task name or a --filename argument must be supplied")
 			}
 			if opt.Filename != "" && opt.Last {
 				return errors.New("cannot use --last option with --filename option")
@@ -174,17 +174,17 @@ like cat,foo,bar
 	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
-	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the task using last taskrun values")
-	c.Flags().StringVarP(&opt.UseTaskRun, "use-taskrun", "", "", "specify a taskrun name to use its values to re-run the taskrun")
+	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the Task using last TaskRun values")
+	c.Flags().StringVarP(&opt.UseTaskRun, "use-taskrun", "", "", "specify a TaskRun name to use its values to re-run the TaskRun")
 	flags.AddShellCompletion(c.Flags().Lookup("use-taskrun"), "__tkn_get_taskrun")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
 	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass the workspace.")
-	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the task")
-	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a task definition to start a taskrun")
-	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for taskrun")
-	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview taskrun without running it")
-	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of taskrun dry-run (yaml or json)")
-	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the taskrun name (must be lowercase alphanumeric characters)")
+	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the Task")
+	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a Task definition to start a TaskRun")
+	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for TaskRun")
+	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview TaskRun without running it")
+	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of TaskRun dry-run (yaml or json)")
+	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_task")
 
@@ -365,9 +365,9 @@ func startTask(opt startOptions, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(opt.stream.Out, "Taskrun started: %s\n", trCreated.Name)
+	fmt.Fprintf(opt.stream.Out, "TaskRun started: %s\n", trCreated.Name)
 	if !opt.ShowLog {
-		inOrderString := "\nIn order to track the taskrun progress run:\ntkn taskrun "
+		inOrderString := "\nIn order to track the TaskRun progress run:\ntkn taskrun "
 		if opt.TektonOptions.Context != "" {
 			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
 		}

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -142,11 +142,11 @@ func Test_start_invalid_namespace(t *testing.T) {
 func Test_start_has_no_task_arg(t *testing.T) {
 	c := Command(&test.Params{})
 
-	_, err := test.ExecuteCommand(c, "start", "-n", "ns")
+	out, err := test.ExecuteCommand(c, "start", "-n", "ns")
 	if err == nil {
 		t.Error("Expecting an error but it's empty")
 	}
-	test.AssertOutput(t, "either a task name or a --filename parameter must be supplied", err.Error())
+	test.AssertOutput(t, "Error: either a Task name or a --filename argument must be supplied\n", out)
 }
 
 func Test_start_has_filename_arg_with_last(t *testing.T) {
@@ -181,7 +181,7 @@ func Test_start_has_task_filename_v1alpha1(t *testing.T) {
 		t.Errorf("Not expecting an error, but got %s", err.Error())
 	}
 
-	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	expected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -233,7 +233,7 @@ func Test_start_has_task_filename_v1beta1(t *testing.T) {
 		t.Errorf("Not expecting an error, but got %s", err.Error())
 	}
 
-	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	expected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -305,7 +305,7 @@ func Test_start_task_not_found(t *testing.T) {
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc}
 	task := Command(p)
 	got, _ := test.ExecuteCommand(task, "start", "task-2", "-n", "ns")
-	expected := "Error: task name task-2 does not exist in namespace ns\n"
+	expected := "Error: Task name task-2 does not exist in namespace ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -387,7 +387,7 @@ func Test_start_task_not_found_v1beta1(t *testing.T) {
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc}
 	task := Command(p)
 	got, _ := test.ExecuteCommand(task, "start", "task-2", "-n", "ns")
-	expected := "Error: task name task-2 does not exist in namespace ns\n"
+	expected := "Error: Task name task-2 does not exist in namespace ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
@@ -445,7 +445,7 @@ func Test_start_task(t *testing.T) {
 		"-s=svc1",
 		"-n=ns")
 
-	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	expected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := trlist.TaskRuns(clients, v1.ListOptions{}, "ns")
@@ -587,7 +587,7 @@ func Test_start_task_v1beta1_context(t *testing.T) {
 		"-s=svc1",
 		"-n=ns")
 
-	gcExpected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun --context=NinjaRabbit logs  -f -n ns\n"
+	gcExpected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun --context=NinjaRabbit logs  -f -n ns\n"
 	test.AssertOutput(t, gcExpected, gotConfig)
 
 }
@@ -682,7 +682,7 @@ func Test_start_task_v1beta1(t *testing.T) {
 		"-s=svc1",
 		"-n=ns")
 
-	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	expected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := trlist.TaskRuns(clients, v1.ListOptions{}, "ns")
@@ -804,7 +804,7 @@ func Test_start_task_last(t *testing.T) {
 		"--last",
 		"-n=ns")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	gotTR, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
 	if err != nil {
@@ -998,7 +998,7 @@ func Test_start_task_last_v1beta1(t *testing.T) {
 		"--last",
 		"-n=ns")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	gotTR, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
 	if err != nil {
@@ -1113,7 +1113,7 @@ func Test_start_use_taskrun(t *testing.T) {
 		"--use-taskrun", "camper",
 		"-n=ns")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
@@ -1252,7 +1252,7 @@ func Test_start_use_taskrun_v1beta1(t *testing.T) {
 		"--use-taskrun", "camper",
 		"-n=ns")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
@@ -1335,7 +1335,7 @@ func Test_start_task_last_generate_name(t *testing.T) {
 		"--last",
 		"-n=ns")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
@@ -1503,7 +1503,7 @@ func Test_start_task_last_generate_name_v1beta1(t *testing.T) {
 		"--last",
 		"-n=ns")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
@@ -1584,7 +1584,7 @@ func Test_start_task_last_with_prefix_name(t *testing.T) {
 		"--prefix-name=mytrname",
 	)
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
@@ -1751,7 +1751,7 @@ func Test_start_task_last_with_prefix_name_v1beta1(t *testing.T) {
 		"--prefix-name=mytrname",
 	)
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := traction.Get(clients, "random", metav1.GetOptions{}, "ns")
@@ -1831,7 +1831,7 @@ func Test_start_task_with_prefix_name(t *testing.T) {
 		"--last",
 	)
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	clients, _ := p.Clients()
@@ -1998,7 +1998,7 @@ func Test_start_task_with_prefix_name_v1beta1(t *testing.T) {
 		"--last",
 	)
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	clients, _ := p.Clients()
@@ -2079,7 +2079,7 @@ func Test_start_task_last_with_inputs(t *testing.T) {
 		"-n=ns",
 		"--last")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	clients, _ := p.Clients()
@@ -2274,7 +2274,7 @@ func Test_start_task_last_with_inputs_v1beta1(t *testing.T) {
 		"-n=ns",
 		"--last")
 
-	expected := "Taskrun started: random\n\nIn order to track the taskrun progress run:\ntkn taskrun logs random -f -n ns\n"
+	expected := "TaskRun started: random\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	clients, _ := p.Clients()
@@ -3360,7 +3360,7 @@ func Test_start_task_allkindparam(t *testing.T) {
 		"-s=svc1",
 		"-n=ns")
 
-	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	expected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := trlist.TaskRuns(clients, metav1.ListOptions{}, "ns")
@@ -3503,7 +3503,7 @@ func Test_start_task_allkindparam_v1beta1(t *testing.T) {
 		"-s=svc1",
 		"-n=ns")
 
-	expected := "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun logs  -f -n ns\n"
+	expected := "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 	clients, _ := p.Clients()
 	tr, err := trlist.TaskRuns(clients, metav1.ListOptions{}, "ns")

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "task",
 		Aliases: []string{"t", "tasks"},
-		Short:   "Manage tasks",
+		Short:   "Manage Tasks",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/test/e2e/task/task_start_test.go
+++ b/test/e2e/task/task_start_test.go
@@ -79,7 +79,7 @@ func TestTaskStartE2E(t *testing.T) {
 		vars := make(map[string]interface{})
 		taskRunGeneratedName := e2e.GetTaskRunListWithName(c, "read-task").Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
-		expected := e2e.ProcessString(`(Taskrun started: {{.Taskrun}}
+		expected := e2e.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
 .*)`, vars)
 


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `Task` and `TaskRun` instead of a variety of ways it is referenced throughout `tkn` (e.g., `taskrun`, `TaskRun`, etc.). 

This pull request only focuses on `tkn task` commands, but there are other Task/TaskRun references throughout `tkn` that should be updated as well, but will be addressed in pull requests pertaining to the commands or helper packages where TaskRun is referenced. 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Standardize the use of Task/TaskRun in user-facing messages for tkn task commands
```
