### PR TITLE
Common Way of Referring to Tekton Resources for User Facing Messages: ClusterTask

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -14,7 +14,7 @@ CLI for tekton pipelines
 
 ### SEE ALSO
 
-* [tkn clustertask](tkn_clustertask.md)	 - Manage clustertasks
+* [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
 * [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
 * [tkn completion](tkn_completion.md)	 - Prints shell completion scripts
 * [tkn condition](tkn_condition.md)	 - Manage conditions

--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -1,12 +1,12 @@
 ## tkn clustertask
 
-Manage clustertasks
+Manage ClusterTasks
 
 ***Aliases**: ct,clustertasks*
 
 ### Synopsis
 
-Manage clustertasks
+Manage ClusterTasks
 
 ### Options
 
@@ -20,8 +20,8 @@ Manage clustertasks
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn clustertask delete](tkn_clustertask_delete.md)	 - Delete clustertask resources in a cluster
-* [tkn clustertask describe](tkn_clustertask_describe.md)	 - Describes a clustertask
-* [tkn clustertask list](tkn_clustertask_list.md)	 - Lists clustertasks in a namespace
-* [tkn clustertask start](tkn_clustertask_start.md)	 - Start clustertasks
+* [tkn clustertask delete](tkn_clustertask_delete.md)	 - Delete ClusterTasks in a cluster
+* [tkn clustertask describe](tkn_clustertask_describe.md)	 - Describe a ClusterTask
+* [tkn clustertask list](tkn_clustertask_list.md)	 - Lists ClusterTasks
+* [tkn clustertask start](tkn_clustertask_start.md)	 - Start ClusterTasks
 

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -1,6 +1,6 @@
 ## tkn clustertask delete
 
-Delete clustertask resources in a cluster
+Delete ClusterTasks in a cluster
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn clustertask delete
 
 ### Synopsis
 
-Delete clustertask resources in a cluster
+Delete ClusterTasks in a cluster
 
 ### Examples
 
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all clustertasks (default: false)
+      --all                           Delete all ClusterTasks (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
@@ -47,5 +47,5 @@ or
 
 ### SEE ALSO
 
-* [tkn clustertask](tkn_clustertask.md)	 - Manage clustertasks
+* [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
 

--- a/docs/cmd/tkn_clustertask_describe.md
+++ b/docs/cmd/tkn_clustertask_describe.md
@@ -1,6 +1,6 @@
 ## tkn clustertask describe
 
-Describes a clustertask
+Describe a ClusterTask
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn clustertask describe
 
 ### Synopsis
 
-Describes a clustertask
+Describe a ClusterTask
 
 ### Examples
 
@@ -44,5 +44,5 @@ or
 
 ### SEE ALSO
 
-* [tkn clustertask](tkn_clustertask.md)	 - Manage clustertasks
+* [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
 

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -1,6 +1,6 @@
 ## tkn clustertask list
 
-Lists clustertasks in a namespace
+Lists ClusterTasks
 
 ***Aliases**: ls*
 
@@ -12,7 +12,7 @@ tkn clustertask list
 
 ### Synopsis
 
-Lists clustertasks in a namespace
+Lists ClusterTasks
 
 ### Options
 
@@ -33,5 +33,5 @@ Lists clustertasks in a namespace
 
 ### SEE ALSO
 
-* [tkn clustertask](tkn_clustertask.md)	 - Manage clustertasks
+* [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
 

--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -1,16 +1,16 @@
 ## tkn clustertask start
 
-Start clustertasks
+Start ClusterTasks
 
 ### Usage
 
 ```
-tkn clustertask start clustertask [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]
+tkn clustertask start
 ```
 
 ### Synopsis
 
-Start clustertasks
+Start ClusterTasks
 
 ### Examples
 
@@ -29,17 +29,17 @@ like cat,foo,bar
 ### Options
 
 ```
-      --dry-run                  preview taskrun without running it
+      --dry-run                  preview TaskRun without running it
   -h, --help                     help for start
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.
-  -L, --last                     re-run the clustertask using last taskrun values
-      --output string            format of taskrun dry-run (yaml or json)
+  -L, --last                     re-run the ClusterTask using last TaskRun values
+      --output string            format of TaskRun dry-run (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
   -s, --serviceaccount string    pass the serviceaccount name
-      --showlog                  show logs right after starting the clustertask
-      --timeout string           timeout for taskrun
+      --showlog                  show logs right after starting the ClusterTask
+      --timeout string           timeout for TaskRun
 ```
 
 ### Options inherited from parent commands
@@ -52,5 +52,5 @@ like cat,foo,bar
 
 ### SEE ALSO
 
-* [tkn clustertask](tkn_clustertask.md)	 - Manage clustertasks
+* [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
 

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertask\-delete \- Delete clustertask resources in a cluster
+tkn\-clustertask\-delete \- Delete ClusterTasks in a cluster
 
 
 .SH SYNOPSIS
@@ -15,13 +15,13 @@ tkn\-clustertask\-delete \- Delete clustertask resources in a cluster
 
 .SH DESCRIPTION
 .PP
-Delete clustertask resources in a cluster
+Delete ClusterTasks in a cluster
 
 
 .SH OPTIONS
 .PP
 \fB\-\-all\fP[=false]
-    Delete all clustertasks (default: false)
+    Delete all ClusterTasks (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]

--- a/docs/man/man1/tkn-clustertask-describe.1
+++ b/docs/man/man1/tkn-clustertask-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertask\-describe \- Describes a clustertask
+tkn\-clustertask\-describe \- Describe a ClusterTask
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertask\-describe \- Describes a clustertask
 
 .SH DESCRIPTION
 .PP
-Describes a clustertask
+Describe a ClusterTask
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertask\-list \- Lists clustertasks in a namespace
+tkn\-clustertask\-list \- Lists ClusterTasks
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertask\-list \- Lists clustertasks in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists clustertasks in a namespace
+Lists ClusterTasks
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -5,23 +5,23 @@
 
 .SH NAME
 .PP
-tkn\-clustertask\-start \- Start clustertasks
+tkn\-clustertask\-start \- Start ClusterTasks
 
 
 .SH SYNOPSIS
 .PP
-\fBtkn clustertask start clustertask [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]\fP
+\fBtkn clustertask start\fP
 
 
 .SH DESCRIPTION
 .PP
-Start clustertasks
+Start ClusterTasks
 
 
 .SH OPTIONS
 .PP
 \fB\-\-dry\-run\fP[=false]
-    preview taskrun without running it
+    preview TaskRun without running it
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -37,11 +37,11 @@ Start clustertasks
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    re\-run the clustertask using last taskrun values
+    re\-run the ClusterTask using last TaskRun values
 
 .PP
 \fB\-\-output\fP=""
-    format of taskrun dry\-run (yaml or json)
+    format of TaskRun dry\-run (yaml or json)
 
 .PP
 \fB\-o\fP, \fB\-\-outputresource\fP=[]
@@ -57,11 +57,11 @@ Start clustertasks
 
 .PP
 \fB\-\-showlog\fP[=false]
-    show logs right after starting the clustertask
+    show logs right after starting the ClusterTask
 
 .PP
 \fB\-\-timeout\fP=""
-    timeout for taskrun
+    timeout for TaskRun
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/docs/man/man1/tkn-clustertask.1
+++ b/docs/man/man1/tkn-clustertask.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertask \- Manage clustertasks
+tkn\-clustertask \- Manage ClusterTasks
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertask \- Manage clustertasks
 
 .SH DESCRIPTION
 .PP
-Manage clustertasks
+Manage ClusterTasks
 
 
 .SH OPTIONS

--- a/pkg/cmd/clustertask/clustertask.go
+++ b/pkg/cmd/clustertask/clustertask.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "clustertask",
 		Aliases: []string{"ct", "clustertasks"},
-		Short:   "Manage clustertasks",
+		Short:   "Manage ClusterTasks",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -45,7 +45,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete clustertask resources in a cluster",
+		Short:        "Delete ClusterTasks in a cluster",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
@@ -68,7 +68,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAll, "all", "", false, "Delete all clustertasks (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAll, "all", "", false, "Delete all ClusterTasks (default: false)")
 	c.Flags().BoolVarP(&opts.DeleteRelated, "trs", "", false, "Whether to delete ClusterTask(s) and related resources (TaskRuns) (default: false)")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_clustertasks")
 	return c

--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -16,7 +16,6 @@ package clustertask
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"text/tabwriter"
 	"text/template"
@@ -128,7 +127,7 @@ or
 	c := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"desc"},
-		Short:   "Describes a clustertask",
+		Short:   "Describe a ClusterTask",
 		Example: eg,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -142,8 +141,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if len(args) == 0 {
@@ -177,8 +175,7 @@ func printClusterTaskDescription(s *cli.Stream, p cli.Params, tname string) erro
 
 	ct, err := clustertask.Get(cs, tname, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get clustertask %s\n", tname)
-		return err
+		return fmt.Errorf("failed to get ClusterTask %s", tname)
 	}
 
 	if ct.Spec.Resources != nil {
@@ -191,8 +188,7 @@ func printClusterTaskDescription(s *cli.Stream, p cli.Params, tname string) erro
 	}
 	taskRuns, err := list.TaskRuns(cs, opts, p.Namespace())
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get taskruns for clustertask %s \n", tname)
-		return err
+		return fmt.Errorf("failed to get TaskRuns for ClusterTask %s", tname)
 	}
 
 	// this is required as the same label is getting added for both task and ClusterTask
@@ -223,8 +219,7 @@ func printClusterTaskDescription(s *cli.Stream, p cli.Params, tname string) erro
 	t := template.Must(template.New("Describe ClusterTask").Funcs(funcMap).Parse(describeTemplate))
 	err = t.Execute(w, data)
 	if err != nil {
-		fmt.Fprintf(s.Err, "Failed to execute template \n")
-		return err
+		return fmt.Errorf("failed to execute template")
 	}
 	return nil
 }
@@ -256,7 +251,7 @@ func askClusterTaskName(opts *options.DescribeOptions, p cli.Params) error {
 		return err
 	}
 	if len(clusterTaskNames) == 0 {
-		return fmt.Errorf("no clustertasks found")
+		return fmt.Errorf("no ClusterTasks found")
 	}
 
 	err = opts.Ask(options.ResourceNameClusterTask, clusterTaskNames)

--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -16,7 +16,6 @@ package clustertask
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -30,7 +29,7 @@ import (
 )
 
 const (
-	emptyMsg = "No clustertasks found"
+	emptyMsg = "No ClusterTasks found"
 	header   = "NAME\tDESCRIPTION\tAGE"
 	body     = "%s\t%s\t%s\n"
 )
@@ -41,7 +40,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists clustertasks in a namespace",
+		Short:   "Lists ClusterTasks",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -49,8 +48,7 @@ func listCommand(p cli.Params) *cobra.Command {
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -70,7 +68,6 @@ func listCommand(p cli.Params) *cobra.Command {
 }
 
 func printClusterTaskDetails(s *cli.Stream, p cli.Params) error {
-
 	cs, err := p.Clients()
 	if err != nil {
 		return err
@@ -78,12 +75,11 @@ func printClusterTaskDetails(s *cli.Stream, p cli.Params) error {
 
 	clustertasks, err := clustertask.List(cs, metav1.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to list clustertasks\n")
-		return err
+		return fmt.Errorf("failed to list ClusterTasks")
 	}
 
 	if len(clustertasks.Items) == 0 {
-		fmt.Fprintln(s.Err, emptyMsg)
+		fmt.Fprint(s.Out, emptyMsg)
 		return nil
 	}
 

--- a/pkg/cmd/clustertask/list_test.go
+++ b/pkg/cmd/clustertask/list_test.go
@@ -49,7 +49,7 @@ func TestClusterTaskList_Empty(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	test.AssertOutput(t, emptyMsg+"\n", output)
+	test.AssertOutput(t, emptyMsg, output)
 }
 
 func TestClusterTaskListOnlyClusterTasksv1alpha1(t *testing.T) {

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -39,8 +39,8 @@ import (
 )
 
 var (
-	errNoClusterTask      = errors.New("missing clustertask name")
-	errInvalidClusterTask = "clustertask name %s does not exist"
+	errNoClusterTask      = errors.New("missing ClusterTask name")
+	errInvalidClusterTask = "ClusterTask name %s does not exist"
 )
 
 const invalidResource = "invalid input format for resource parameter: "
@@ -103,8 +103,8 @@ like cat,foo,bar
 `
 
 	c := &cobra.Command{
-		Use:   "start clustertask [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
-		Short: "Start clustertasks",
+		Use:   "start",
+		Short: "Start ClusterTasks",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -138,12 +138,12 @@ like cat,foo,bar
 	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
-	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the clustertask using last taskrun values")
+	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the ClusterTask using last TaskRun values")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
-	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the clustertask")
-	c.Flags().StringVar(&opt.TimeOut, "timeout", "", "timeout for taskrun")
-	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview taskrun without running it")
-	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of taskrun dry-run (yaml or json)")
+	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the ClusterTask")
+	c.Flags().StringVar(&opt.TimeOut, "timeout", "", "timeout for TaskRun")
+	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview TaskRun without running it")
+	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of TaskRun dry-run (yaml or json)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_clustertask")
 
@@ -234,9 +234,9 @@ func startClusterTask(opt startOptions, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(opt.stream.Out, "Taskrun started: %s\n", trCreated.Name)
+	fmt.Fprintf(opt.stream.Out, "TaskRun started: %s\n", trCreated.Name)
 	if !opt.ShowLog {
-		inOrderString := "\nIn order to track the taskrun progress run:\ntkn taskrun "
+		inOrderString := "\nIn order to track the TaskRun progress run:\ntkn taskrun "
 		if opt.TektonOptions.Context != "" {
 			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
 		}

--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -284,7 +284,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "missing clustertask name",
+			want:        "missing ClusterTask name",
 		},
 		{
 			name:        "ClusterTask doesn't exist",
@@ -293,7 +293,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "clustertask name notexist does not exist",
+			want:        "ClusterTask name notexist does not exist",
 		},
 		{
 			name:        "Use --last with no taskruns",
@@ -302,7 +302,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "no taskruns related to ClusterTask clustertask-1 found in namespace ns",
+			want:        "no TaskRuns related to ClusterTask clustertask-1 found in namespace ns",
 		},
 		{
 			name: "Start clustertask",
@@ -318,7 +318,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Taskrun started: taskrun-1\n\nIn order to track the taskrun progress run:\ntkn taskrun logs taskrun-1 -f -n ns\n",
+			want:        "TaskRun started: taskrun-1\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-1 -f -n ns\n",
 		},
 		{
 			name: "Start clustertask with different context",
@@ -335,7 +335,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Taskrun started: \n\nIn order to track the taskrun progress run:\ntkn taskrun --context=ronaldinho logs  -f -n ns\n",
+			want:        "TaskRun started: \n\nIn order to track the TaskRun progress run:\ntkn taskrun --context=ronaldinho logs  -f -n ns\n",
 		},
 		{
 			name:        "Start with --last option",
@@ -344,7 +344,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			input:       seeds[1].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Taskrun started: taskrun-2\n\nIn order to track the taskrun progress run:\ntkn taskrun logs taskrun-2 -f -n ns\n",
+			want:        "TaskRun started: taskrun-2\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-2 -f -n ns\n",
 		},
 		{
 			name: "Invalid input format",
@@ -799,7 +799,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "missing clustertask name",
+			want:        "missing ClusterTask name",
 		},
 		{
 			name:        "ClusterTask doesn't exist",
@@ -808,7 +808,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "clustertask name notexist does not exist",
+			want:        "ClusterTask name notexist does not exist",
 		},
 		{
 			name:        "Use --last with no taskruns",
@@ -817,7 +817,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "no taskruns related to ClusterTask clustertask-1 found in namespace ns",
+			want:        "no TaskRuns related to ClusterTask clustertask-1 found in namespace ns",
 		},
 		{
 			name: "Start clustertask",
@@ -833,7 +833,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Taskrun started: taskrun-1\n\nIn order to track the taskrun progress run:\ntkn taskrun logs taskrun-1 -f -n ns\n",
+			want:        "TaskRun started: taskrun-1\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-1 -f -n ns\n",
 		},
 		{
 			name:        "Start with --last option",
@@ -842,7 +842,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			input:       seeds[1].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Taskrun started: taskrun-2\n\nIn order to track the taskrun progress run:\ntkn taskrun logs taskrun-2 -f -n ns\n",
+			want:        "TaskRun started: taskrun-2\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-2 -f -n ns\n",
 		},
 		{
 			name: "Invalid input format",

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -2312,7 +2312,7 @@ func Test_start_task_last_with_inputs_v1beta1(t *testing.T) {
 	test.AssertOutput(t, "svc1", tr.Spec.ServiceAccountName)
 }
 
-func Test_start_task_last_without_pipelinerun(t *testing.T) {
+func Test_start_task_last_without_taskrun(t *testing.T) {
 	tasks := []*v1alpha1.Task{
 		tb.Task("task-1",
 			tb.TaskNamespace("ns"),
@@ -2356,11 +2356,11 @@ func Test_start_task_last_without_pipelinerun(t *testing.T) {
 
 	task := Command(p)
 	got, _ := test.ExecuteCommand(task, "start", "task-1", "--last", "-n", "ns")
-	expected := "Error: no taskruns related to Task task-1 found in namespace ns\n"
+	expected := "Error: no TaskRuns related to Task task-1 found in namespace ns\n"
 	test.AssertOutput(t, expected, got)
 }
 
-func Test_start_task_last_without_pipelinerun_v1beta1(t *testing.T) {
+func Test_start_task_last_without_taskrun_v1beta1(t *testing.T) {
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: v1.ObjectMeta{
@@ -2448,7 +2448,7 @@ func Test_start_task_last_without_pipelinerun_v1beta1(t *testing.T) {
 
 	task := Command(p)
 	got, _ := test.ExecuteCommand(task, "start", "task-1", "--last", "-n", "ns")
-	expected := "Error: no taskruns related to Task task-1 found in namespace ns\n"
+	expected := "Error: no TaskRuns related to Task task-1 found in namespace ns\n"
 	test.AssertOutput(t, expected, got)
 }
 

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -42,7 +42,7 @@ func LastRun(cs *cli.Clients, task string, ns, kind string) (*v1beta1.TaskRun, e
 	runs.Items = FilterByRef(runs.Items, kind)
 
 	if len(runs.Items) == 0 {
-		return nil, fmt.Errorf("no taskruns related to %s %s found in namespace %s", kind, task, ns)
+		return nil, fmt.Errorf("no TaskRuns related to %s %s found in namespace %s", kind, task, ns)
 	}
 
 	latest := runs.Items[0]

--- a/pkg/task/tasklastrun_test.go
+++ b/pkg/task/tasklastrun_test.go
@@ -132,6 +132,6 @@ func TestTaskrunLatest_no_run(t *testing.T) {
 		t.Errorf("Expected error, got nil")
 	}
 
-	expected := "no taskruns related to Task task found in namespace ns"
+	expected := "no TaskRuns related to Task task found in namespace ns"
 	test.AssertOutput(t, expected, err.Error())
 }


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `ClusterTask` and `TaskRun` instead of a variety of ways it is referenced throughout `tkn` (e.g., `taskrun`, `TaskRun`, etc.). 

This pull request only focuses on `tkn clustertask` commands, but there are other ClusterTask/TaskRun references throughout `tkn` that should be updated as well, but will be addressed in pull requests pertaining to the commands or helper packages where TaskRun is referenced. 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Standardize the use of ClusterTask/TaskRun in user-facing messages for tkn clustertask commands
```
