### PR TITLE
Common Way of Referring to Tekton Resources for User Facing Messages: Pipelines

### DIFF
--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -27,9 +27,9 @@ Manage pipelines
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn pipeline delete](tkn_pipeline_delete.md)	 - Delete pipelines in a namespace
-* [tkn pipeline describe](tkn_pipeline_describe.md)	 - Describes a pipeline in a namespace
-* [tkn pipeline list](tkn_pipeline_list.md)	 - Lists pipelines in a namespace
-* [tkn pipeline logs](tkn_pipeline_logs.md)	 - Show pipeline logs
-* [tkn pipeline start](tkn_pipeline_start.md)	 - Start pipelines
+* [tkn pipeline delete](tkn_pipeline_delete.md)	 - Delete Pipelines in a namespace
+* [tkn pipeline describe](tkn_pipeline_describe.md)	 - Describes a Pipeline in a namespace
+* [tkn pipeline list](tkn_pipeline_list.md)	 - Lists Pipelines in a namespace
+* [tkn pipeline logs](tkn_pipeline_logs.md)	 - Show Pipeline logs
+* [tkn pipeline start](tkn_pipeline_start.md)	 - Start Pipelines
 

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -1,6 +1,6 @@
 ## tkn pipeline delete
 
-Delete pipelines in a namespace
+Delete Pipelines in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn pipeline delete
 
 ### Synopsis
 
-Delete pipelines in a namespace
+Delete Pipelines in a namespace
 
 ### Examples
 
@@ -33,7 +33,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
-      --prs                           Whether to delete pipeline(s) and related resources (pipelineruns) (default: false)
+      --prs                           Whether to delete Pipeline(s) and related resources (PipelineRuns) (default: false)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -1,6 +1,6 @@
 ## tkn pipeline describe
 
-Describes a pipeline in a namespace
+Describes a Pipeline in a namespace
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn pipeline describe
 
 ### Synopsis
 
-Describes a pipeline in a namespace
+Describes a Pipeline in a namespace
 
 ### Options
 

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -1,6 +1,6 @@
 ## tkn pipeline list
 
-Lists pipelines in a namespace
+Lists Pipelines in a namespace
 
 ***Aliases**: ls*
 
@@ -12,12 +12,12 @@ tkn pipeline list
 
 ### Synopsis
 
-Lists pipelines in a namespace
+Lists Pipelines in a namespace
 
 ### Options
 
 ```
-  -A, --all-namespaces                list pipelines from all namespaces
+  -A, --all-namespaces                list Pipelines from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --no-headers                    do not print column headers with output (default print column headers with output)

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -1,6 +1,6 @@
 ## tkn pipeline logs
 
-Show pipeline logs
+Show Pipeline logs
 
 ### Usage
 
@@ -10,24 +10,24 @@ tkn pipeline logs
 
 ### Synopsis
 
-Show pipeline logs
+Show Pipeline logs
 
 ### Examples
 
 
-Interactive mode: shows logs of the selected pipelinerun:
+Interactive mode: shows logs of the selected PipelineRun:
 
     tkn pipeline logs -n namespace
 
-Interactive mode: shows logs of the selected pipelinerun of the given pipeline:
+Interactive mode: shows logs of the selected PipelineRun of the given Pipeline:
 
     tkn pipeline logs pipeline -n namespace
 
-Show logs of given pipeline for last run:
+Show logs of given Pipeline for last run:
 
     tkn pipeline logs pipeline -n namespace --last
 
-Show logs for given pipeline and pipelinerun:
+Show logs for given Pipeline and PipelineRun:
 
     tkn pipeline logs pipeline run -n namespace
 
@@ -38,8 +38,8 @@ Show logs for given pipeline and pipelinerun:
   -a, --all         show all logs including init steps injected by tekton
   -f, --follow      stream live logs
   -h, --help        help for logs
-  -L, --last        show logs for last run
-      --limit int   lists number of pipelineruns (default 5)
+  -L, --last        show logs for last PipelineRun
+      --limit int   lists number of PipelineRuns (default 5)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -1,11 +1,11 @@
 ## tkn pipeline start
 
-Start pipelines
+Start Pipelines
 
 ### Usage
 
 ```
-tkn pipeline start pipeline [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]
+tkn pipeline start
 ```
 
 ### Synopsis
@@ -39,19 +39,19 @@ my-secret and my-empty-dir)
 ### Options
 
 ```
-      --dry-run                       preview pipelinerun without running it
-  -f, --filename string               local or remote file name containing a pipeline definition to start a pipelinerun
+      --dry-run                       preview PipelineRun without running it
+  -f, --filename string               local or remote file name containing a Pipeline definition to start a PipelineRun
   -h, --help                          help for start
   -l, --labels strings                pass labels as label=value.
-  -L, --last                          re-run the pipeline using last pipelinerun values
-      --output string                 format of pipelinerun dry-run (yaml or json)
+  -L, --last                          re-run the Pipeline using last PipelineRun values
+      --output string                 format of PipelineRun dry-run (yaml or json)
   -p, --param stringArray             pass the param as key=value for string type, or key=value1,value2,... for array type
-      --prefix-name string            specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)
+      --prefix-name string            specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name
-      --showlog                       show logs right after starting the pipeline
+      --showlog                       show logs right after starting the Pipeline
       --task-serviceaccount strings   pass the service account corresponding to the task
-      --timeout string                timeout for pipelinerun
+      --timeout string                timeout for PipelineRun
       --use-param-defaults            use default parameter values without prompting for input
       --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
   -w, --workspace stringArray         pass the workspace.

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipeline\-delete \- Delete pipelines in a namespace
+tkn\-pipeline\-delete \- Delete Pipelines in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipeline\-delete \- Delete pipelines in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete pipelines in a namespace
+Delete Pipelines in a namespace
 
 
 .SH OPTIONS
@@ -41,7 +41,7 @@ Delete pipelines in a namespace
 
 .PP
 \fB\-\-prs\fP[=false]
-    Whether to delete pipeline(s) and related resources (pipelineruns) (default: false)
+    Whether to delete Pipeline(s) and related resources (PipelineRuns) (default: false)
 
 .PP
 \fB\-\-template\fP=""

--- a/docs/man/man1/tkn-pipeline-describe.1
+++ b/docs/man/man1/tkn-pipeline-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipeline\-describe \- Describes a pipeline in a namespace
+tkn\-pipeline\-describe \- Describes a Pipeline in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipeline\-describe \- Describes a pipeline in a namespace
 
 .SH DESCRIPTION
 .PP
-Describes a pipeline in a namespace
+Describes a Pipeline in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-pipeline-list.1
+++ b/docs/man/man1/tkn-pipeline-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipeline\-list \- Lists pipelines in a namespace
+tkn\-pipeline\-list \- Lists Pipelines in a namespace
 
 
 .SH SYNOPSIS
@@ -15,13 +15,13 @@ tkn\-pipeline\-list \- Lists pipelines in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists pipelines in a namespace
+Lists Pipelines in a namespace
 
 
 .SH OPTIONS
 .PP
 \fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
-    list pipelines from all namespaces
+    list Pipelines from all namespaces
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipeline\-logs \- Show pipeline logs
+tkn\-pipeline\-logs \- Show Pipeline logs
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipeline\-logs \- Show pipeline logs
 
 .SH DESCRIPTION
 .PP
-Show pipeline logs
+Show Pipeline logs
 
 
 .SH OPTIONS
@@ -33,11 +33,11 @@ Show pipeline logs
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    show logs for last run
+    show logs for last PipelineRun
 
 .PP
 \fB\-\-limit\fP=5
-    lists number of pipelineruns
+    lists number of PipelineRuns
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -60,7 +60,7 @@ Show pipeline logs
 
 .SH EXAMPLE
 .PP
-Interactive mode: shows logs of the selected pipelinerun:
+Interactive mode: shows logs of the selected PipelineRun:
 
 .PP
 .RS
@@ -72,7 +72,7 @@ tkn pipeline logs \-n namespace
 .RE
 
 .PP
-Interactive mode: shows logs of the selected pipelinerun of the given pipeline:
+Interactive mode: shows logs of the selected PipelineRun of the given Pipeline:
 
 .PP
 .RS
@@ -84,7 +84,7 @@ tkn pipeline logs pipeline \-n namespace
 .RE
 
 .PP
-Show logs of given pipeline for last run:
+Show logs of given Pipeline for last run:
 
 .PP
 .RS
@@ -96,7 +96,7 @@ tkn pipeline logs pipeline \-n namespace \-\-last
 .RE
 
 .PP
-Show logs for given pipeline and pipelinerun:
+Show logs for given Pipeline and PipelineRun:
 
 .PP
 .RS

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -5,12 +5,12 @@
 
 .SH NAME
 .PP
-tkn\-pipeline\-start \- Start pipelines
+tkn\-pipeline\-start \- Start Pipelines
 
 
 .SH SYNOPSIS
 .PP
-\fBtkn pipeline start pipeline [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]\fP
+\fBtkn pipeline start\fP
 
 
 .SH DESCRIPTION
@@ -29,11 +29,11 @@ Parameters, at least those that have no default value
 .SH OPTIONS
 .PP
 \fB\-\-dry\-run\fP[=false]
-    preview pipelinerun without running it
+    preview PipelineRun without running it
 
 .PP
 \fB\-f\fP, \fB\-\-filename\fP=""
-    local or remote file name containing a pipeline definition to start a pipelinerun
+    local or remote file name containing a Pipeline definition to start a PipelineRun
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -45,11 +45,11 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    re\-run the pipeline using last pipelinerun values
+    re\-run the Pipeline using last PipelineRun values
 
 .PP
 \fB\-\-output\fP=""
-    format of pipelinerun dry\-run (yaml or json)
+    format of PipelineRun dry\-run (yaml or json)
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
@@ -57,7 +57,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-\-prefix\-name\fP=""
-    specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)
+    specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)
 
 .PP
 \fB\-r\fP, \fB\-\-resource\fP=[]
@@ -69,7 +69,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-\-showlog\fP[=false]
-    show logs right after starting the pipeline
+    show logs right after starting the Pipeline
 
 .PP
 \fB\-\-task\-serviceaccount\fP=[]
@@ -77,7 +77,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-\-timeout\fP=""
-    timeout for pipelinerun
+    timeout for PipelineRun
 
 .PP
 \fB\-\-use\-param\-defaults\fP[=false]

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -31,7 +31,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "clustertask", ForceDelete: false, DeleteAll: false}
+	opts := &options.DeleteOptions{Resource: "ClusterTask", ForceDelete: false, DeleteAll: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete ClusterTasks with names 'foo' and 'bar':
 

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -153,7 +153,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting clustertask \"tomatoes\"",
+			want:        "canceled deleting ClusterTask(s) \"tomatoes\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -162,7 +162,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask \"tomatoes\" (y/n): ClusterTasks deleted: \"tomatoes\"\n",
+			want:        "Are you sure you want to delete ClusterTask(s) \"tomatoes\" (y/n): ClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -198,7 +198,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask and related resources \"tomatoes\" (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nClusterTasks deleted: \"tomatoes\"\n",
+			want:        "Are you sure you want to delete ClusterTask(s) \"tomatoes\" and related resources (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "With force delete flag, reply yes, multiple clustertasks",
@@ -216,7 +216,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask \"tomatoes2\", \"tomatoes3\" (y/n): ClusterTasks deleted: \"tomatoes2\", \"tomatoes3\"\n",
+			want:        "Are you sure you want to delete ClusterTask(s) \"tomatoes2\", \"tomatoes3\" (y/n): ClusterTasks deleted: \"tomatoes2\", \"tomatoes3\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -225,7 +225,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all clustertasks (y/n): All ClusterTasks deleted\n",
+			want:        "Are you sure you want to delete all ClusterTasks (y/n): All ClusterTasks deleted\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -252,7 +252,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide clustertask name(s) or use --all flag with delete",
+			want:        "must provide ClusterTask name(s) or use --all flag with delete",
 		},
 	}
 
@@ -442,7 +442,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting clustertask \"tomatoes\"",
+			want:        "canceled deleting ClusterTask(s) \"tomatoes\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -451,7 +451,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask \"tomatoes\" (y/n): ClusterTasks deleted: \"tomatoes\"\n",
+			want:        "Are you sure you want to delete ClusterTask(s) \"tomatoes\" (y/n): ClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -487,7 +487,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask and related resources \"tomatoes\" (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nClusterTasks deleted: \"tomatoes\"\n",
+			want:        "Are you sure you want to delete ClusterTask(s) \"tomatoes\" and related resources (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nClusterTasks deleted: \"tomatoes\"\n",
 		},
 		{
 			name:        "With force delete flag, reply yes, multiple clustertasks",
@@ -505,7 +505,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertask \"tomatoes2\", \"tomatoes3\" (y/n): ClusterTasks deleted: \"tomatoes2\", \"tomatoes3\"\n",
+			want:        "Are you sure you want to delete ClusterTask(s) \"tomatoes2\", \"tomatoes3\" (y/n): ClusterTasks deleted: \"tomatoes2\", \"tomatoes3\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -514,7 +514,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all clustertasks (y/n): All ClusterTasks deleted\n",
+			want:        "Are you sure you want to delete all ClusterTasks (y/n): All ClusterTasks deleted\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -541,7 +541,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide clustertask name(s) or use --all flag with delete",
+			want:        "must provide ClusterTask name(s) or use --all flag with delete",
 		},
 	}
 

--- a/pkg/cmd/clustertriggerbinding/delete_test.go
+++ b/pkg/cmd/clustertriggerbinding/delete_test.go
@@ -77,7 +77,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting clustertriggerbinding \"ctb-1\"",
+			want:        "canceled deleting clustertriggerbinding(s) \"ctb-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -85,7 +85,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertriggerbinding \"ctb-1\" (y/n): ClusterTriggerBindings deleted: \"ctb-1\"\n",
+			want:        "Are you sure you want to delete clustertriggerbinding(s) \"ctb-1\" (y/n): ClusterTriggerBindings deleted: \"ctb-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply yes, multiple ClusterTriggerBindings",
@@ -93,7 +93,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete clustertriggerbinding \"ctb-2\", \"ctb-3\" (y/n): ClusterTriggerBindings deleted: \"ctb-2\", \"ctb-3\"\n",
+			want:        "Are you sure you want to delete clustertriggerbinding(s) \"ctb-2\", \"ctb-3\" (y/n): ClusterTriggerBindings deleted: \"ctb-2\", \"ctb-3\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/condition/delete_test.go
+++ b/pkg/cmd/condition/delete_test.go
@@ -108,7 +108,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting condition \"condition1\"",
+			want:        "canceled deleting condition(s) \"condition1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -116,7 +116,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete condition \"condition1\" (y/n): Conditions deleted: \"condition1\"\n",
+			want:        "Are you sure you want to delete condition(s) \"condition1\" (y/n): Conditions deleted: \"condition1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply yes, multiple conditions",
@@ -124,7 +124,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete condition \"condition2\", \"condition3\" (y/n): Conditions deleted: \"condition2\", \"condition3\"\n",
+			want:        "Are you sure you want to delete condition(s) \"condition2\", \"condition3\" (y/n): Conditions deleted: \"condition2\", \"condition3\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/eventlistener/delete_test.go
+++ b/pkg/cmd/eventlistener/delete_test.go
@@ -95,7 +95,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting eventlistener \"el-1\"",
+			want:        "canceled deleting eventlistener(s) \"el-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -103,7 +103,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete eventlistener \"el-1\" (y/n): EventListeners deleted: \"el-1\"\n",
+			want:        "Are you sure you want to delete eventlistener(s) \"el-1\" (y/n): EventListeners deleted: \"el-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply yes, multiple eventlisteners",
@@ -111,7 +111,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete eventlistener \"el-2\", \"el-3\" (y/n): EventListeners deleted: \"el-2\", \"el-3\"\n",
+			want:        "Are you sure you want to delete eventlistener(s) \"el-2\", \"el-3\" (y/n): EventListeners deleted: \"el-2\", \"el-3\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -31,7 +31,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "pipeline", ForceDelete: false, DeleteRelated: false, DeleteAllNs: false}
+	opts := &options.DeleteOptions{Resource: "Pipeline", ForceDelete: false, DeleteRelated: false, DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete Pipelines with names 'foo' and 'bar' in namespace 'quux'
 
@@ -45,7 +45,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete pipelines in a namespace",
+		Short:        "Delete Pipelines in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
@@ -72,7 +72,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteRelated, "prs", "", false, "Whether to delete pipeline(s) and related resources (pipelineruns) (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteRelated, "prs", "", false, "Whether to delete Pipeline(s) and related resources (PipelineRuns) (default: false)")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all Pipelines in a namespace (default: false)")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
@@ -134,7 +134,6 @@ func pipelineRunLister(cs *cli.Clients, ns string) func(string) ([]string, error
 }
 
 func allPipelineNames(cs *cli.Clients, ns string) ([]string, error) {
-
 	ps, err := pipeline.List(cs, metav1.ListOptions{}, ns)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -164,7 +164,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipeline \"pipeline\"",
+			want:        "canceled deleting Pipeline(s) \"pipeline\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -173,7 +173,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipeline \"pipeline\" (y/n): Pipelines deleted: \"pipeline\"\n",
+			want:        "Are you sure you want to delete Pipeline(s) \"pipeline\" (y/n): Pipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -209,7 +209,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipeline and related resources \"pipeline\" (y/n): PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
+			want:        "Are you sure you want to delete Pipeline(s) \"pipeline\" and related resources (y/n): PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "With --prs and force delete flag",
@@ -227,7 +227,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelines in namespace \"ns\" (y/n): All Pipelines deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all Pipelines in namespace \"ns\" (y/n): All Pipelines deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -453,7 +453,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipeline \"pipeline\"",
+			want:        "canceled deleting Pipeline(s) \"pipeline\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -462,7 +462,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipeline \"pipeline\" (y/n): Pipelines deleted: \"pipeline\"\n",
+			want:        "Are you sure you want to delete Pipeline(s) \"pipeline\" (y/n): Pipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -498,7 +498,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipeline and related resources \"pipeline\" (y/n): PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
+			want:        "Are you sure you want to delete Pipeline(s) \"pipeline\" and related resources (y/n): PipelineRuns deleted: \"pipeline-run-1\", \"pipeline-run-2\"\nPipelines deleted: \"pipeline\"\n",
 		},
 		{
 			name:        "With delete all and force delete flag",
@@ -516,7 +516,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelines in namespace \"ns\" (y/n): All Pipelines deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all Pipelines in namespace \"ns\" (y/n): All Pipelines deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",

--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -100,7 +100,7 @@ func describeCommand(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"desc"},
-		Short:   "Describes a pipeline in a namespace",
+		Short:   "Describes a Pipeline in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -113,8 +113,7 @@ func describeCommand(p cli.Params) *cobra.Command {
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if len(args) == 0 {
@@ -220,8 +219,10 @@ func askPipelineName(opts *options.DescribeOptions, p cli.Params) error {
 	if err != nil {
 		return err
 	}
+
 	if len(pipelineNames) == 0 {
-		return fmt.Errorf("no pipelines found")
+		fmt.Fprint(os.Stdout, "no Pipelines found")
+		return nil
 	}
 
 	err = opts.Ask(options.ResourceNamePipeline, pipelineNames)

--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -16,7 +16,6 @@ package pipeline
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"text/template"
 
@@ -73,7 +72,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists pipelines in a namespace",
+		Short:   "Lists Pipelines in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -88,8 +87,7 @@ func listCommand(p cli.Params) *cobra.Command {
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -104,7 +102,7 @@ func listCommand(p cli.Params) *cobra.Command {
 		},
 	}
 	f.AddFlags(c)
-	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list pipelines from all namespaces")
+	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list Pipelines from all namespaces")
 	c.Flags().BoolVarP(&opts.NoHeaders, "no-headers", "", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 
 	return c
@@ -122,10 +120,8 @@ func printPipelineDetails(s *cli.Stream, p cli.Params, allnamespaces bool, nohea
 		ns = ""
 	}
 	ps, prs, err := listPipelineDetails(cs, ns)
-
 	if err != nil {
-		fmt.Fprintf(s.Err, "Failed to list pipelines from %s namespace\n", ns)
-		return err
+		return fmt.Errorf("failed to list Pipelines from namespace %s: %v", ns, err)
 	}
 
 	var data = struct {
@@ -167,7 +163,6 @@ func printPipelineDetails(s *cli.Stream, p cli.Params, allnamespaces bool, nohea
 type pipelineruns map[string]v1beta1.PipelineRun
 
 func listPipelineDetails(cs *cli.Clients, ns string) (*v1beta1.PipelineList, pipelineruns, error) {
-
 	ps, err := pipeline.List(cs, metav1.ListOptions{}, ns)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -48,26 +48,26 @@ func logCommand(p cli.Params) *cobra.Command {
 	opts := options.NewLogOptions(p)
 
 	eg := `
-Interactive mode: shows logs of the selected pipelinerun:
+Interactive mode: shows logs of the selected PipelineRun:
 
     tkn pipeline logs -n namespace
 
-Interactive mode: shows logs of the selected pipelinerun of the given pipeline:
+Interactive mode: shows logs of the selected PipelineRun of the given Pipeline:
 
     tkn pipeline logs pipeline -n namespace
 
-Show logs of given pipeline for last run:
+Show logs of given Pipeline for last run:
 
     tkn pipeline logs pipeline -n namespace --last
 
-Show logs for given pipeline and pipelinerun:
+Show logs for given Pipeline and PipelineRun:
 
     tkn pipeline logs pipeline run -n namespace
 `
 	c := &cobra.Command{
 		Use:                   "logs",
 		DisableFlagsInUseLine: true,
-		Short:                 "Show pipeline logs",
+		Short:                 "Show Pipeline logs",
 		Example:               eg,
 		SilenceUsage:          true,
 		Annotations: map[string]string{
@@ -92,10 +92,10 @@ Show logs for given pipeline and pipelinerun:
 			return run(opts, args)
 		},
 	}
-	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last run")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last PipelineRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
-	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of pipelineruns")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of PipelineRuns")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
 	return c
@@ -148,7 +148,7 @@ func getAllInputs(opts *options.LogOptions) error {
 	}
 
 	if len(ps) == 0 {
-		fmt.Fprintln(opts.Stream.Err, "No pipelines found in namespace:", opts.Params.Namespace())
+		fmt.Fprintf(opts.Stream.Out, "No Pipelines found in namespace %s", opts.Params.Namespace())
 		return nil
 	}
 
@@ -180,7 +180,7 @@ func askRunName(opts *options.LogOptions) error {
 	}
 
 	if len(prs) == 0 {
-		fmt.Fprintln(opts.Stream.Err, "No pipelineruns found for pipeline:", opts.PipelineName)
+		fmt.Fprintf(opts.Stream.Out, "No PipelineRuns found for Pipeline %s", opts.PipelineName)
 		return nil
 	}
 

--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -191,7 +191,7 @@ func TestPipelineLog(t *testing.T) {
 			dynamic:   dc,
 			input:     cs,
 			wantError: false,
-			want:      "No pipelines found in namespace: ns\n",
+			want:      "No Pipelines found in namespace ns",
 		},
 		{
 			name:      "Found no pipelineruns",
@@ -200,7 +200,7 @@ func TestPipelineLog(t *testing.T) {
 			dynamic:   dc2,
 			input:     cs2,
 			wantError: false,
-			want:      "No pipelineruns found for pipeline: output-pipeline\n",
+			want:      "No PipelineRuns found for Pipeline output-pipeline",
 		},
 		{
 			name:      "Pipeline does not exist",
@@ -428,7 +428,7 @@ func TestPipelineLog_v1beta1(t *testing.T) {
 			dynamic:   dc,
 			input:     cs,
 			wantError: false,
-			want:      "No pipelines found in namespace: ns\n",
+			want:      "No Pipelines found in namespace ns",
 		},
 		{
 			name:      "Found no pipelineruns",
@@ -437,7 +437,7 @@ func TestPipelineLog_v1beta1(t *testing.T) {
 			dynamic:   dc2,
 			input:     cs2,
 			wantError: false,
-			want:      "No pipelineruns found for pipeline: output-pipeline\n",
+			want:      "No PipelineRuns found for Pipeline output-pipeline",
 		},
 		{
 			name:      "Pipeline does not exist",

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -49,8 +49,8 @@ import (
 )
 
 var (
-	errNoPipeline      = errors.New("missing pipeline name")
-	errInvalidPipeline = "pipeline name %s does not exist in namespace %s"
+	errNoPipeline      = errors.New("missing Pipeline name")
+	errInvalidPipeline = "Pipeline name %s does not exist in namespace %s"
 )
 
 const (
@@ -103,8 +103,8 @@ func startCommand(p cli.Params) *cobra.Command {
 	}
 
 	c := &cobra.Command{
-		Use:   "start pipeline [RESOURCES...] [PARAMS...] [SERVICEACCOUNT]",
-		Short: "Start pipelines",
+		Use:   "start",
+		Short: "Start Pipelines",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -150,23 +150,23 @@ like cat,foo,bar
 		},
 	}
 
-	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the pipeline")
+	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the Pipeline")
 	c.Flags().StringSliceVarP(&opt.Resources, "resource", "r", []string{}, "pass the resource name and ref as name=ref")
 	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().StringSliceVar(&opt.ServiceAccounts, "task-serviceaccount", []string{}, "pass the service account corresponding to the task")
 	flags.AddShellCompletion(c.Flags().Lookup("task-serviceaccount"), "__kubectl_get_serviceaccount")
-	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the pipeline using last pipelinerun values")
+	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the Pipeline using last PipelineRun values")
 	c.Flags().StringVarP(&opt.UsePipelineRun, "use-pipelinerun", "", "", "use this pipelinerun values to re-run the pipeline. ")
 	flags.AddShellCompletion(c.Flags().Lookup("use-pipelinerun"), "__tkn_get_pipelinerun")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
 	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass the workspace.")
-	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview pipelinerun without running it")
-	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of pipelinerun dry-run (yaml or json)")
-	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the pipelinerun name (must be lowercase alphanumeric characters)")
-	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for pipelinerun")
-	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a pipeline definition to start a pipelinerun")
+	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview PipelineRun without running it")
+	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of PipelineRun dry-run (yaml or json)")
+	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)")
+	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for PipelineRun")
+	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a Pipeline definition to start a PipelineRun")
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipeline")
@@ -298,9 +298,9 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 		return err
 	}
 
-	fmt.Fprintf(opt.stream.Out, "Pipelinerun started: %s\n", prCreated.Name)
+	fmt.Fprintf(opt.stream.Out, "PipelineRun started: %s\n", prCreated.Name)
 	if !opt.ShowLog {
-		inOrderString := "\nIn order to track the pipelinerun progress run:\ntkn pipelinerun "
+		inOrderString := "\nIn order to track the PipelineRun progress run:\ntkn pipelinerun "
 		if opt.TektonOptions.Context != "" {
 			inOrderString += fmt.Sprintf("--context=%s ", opt.TektonOptions.Context)
 		}
@@ -336,8 +336,7 @@ func (opt *startOptions) getInput(pipeline *v1beta1.Pipeline) error {
 	if len(opt.Resources) == 0 && !opt.Last && opt.UsePipelineRun == "" {
 		pres, err := getPipelineResources(cs.Resource, opt.cliparams.Namespace())
 		if err != nil {
-			fmt.Fprintf(opt.stream.Err, "failed to list pipelineresources from %s namespace \n", opt.cliparams.Namespace())
-			return err
+			return fmt.Errorf("failed to list PipelineResources from namespace %s: %v", opt.cliparams.Namespace(), err)
 		}
 
 		resources := getPipelineResourcesByFormat(pres.Items)
@@ -401,8 +400,8 @@ func (opt *startOptions) getInputResources(resources resourceOptionsFilter, pipe
 		// directly create resource
 		if len(options) == 0 {
 			ns := opt.cliparams.Namespace()
-			fmt.Fprintf(opt.stream.Out, "no pipeline resource of type \"%s\" found in namespace: %s\n", string(res.Type), ns)
-			fmt.Fprintf(opt.stream.Out, "Please create a new \"%s\" resource for pipeline resource \"%s\"\n", string(res.Type), res.Name)
+			fmt.Fprintf(opt.stream.Out, "no PipelineResource of type \"%s\" found in namespace: %s\n", string(res.Type), ns)
+			fmt.Fprintf(opt.stream.Out, "Please create a new \"%s\" resource for PipelineResource \"%s\"\n", string(res.Type), res.Name)
 			newres, err := opt.createPipelineResource(res.Name, res.Type)
 			if err != nil {
 				return err
@@ -633,7 +632,7 @@ func parseTaskSvc(s []string) (map[string]v1beta1.PipelineRunSpecServiceAccountN
 		r := strings.Split(v, "=")
 		if len(r) != 2 || len(r[0]) == 0 {
 			errMsg := invalidSvc + v +
-				"\nPlease pass task service accounts as " +
+				"\nPlease pass Task service accounts as " +
 				"--task-serviceaccount TaskName=ServiceAccount"
 			return nil, errors.New(errMsg)
 		}

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -324,7 +324,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c1,
 			wantError: true,
-			want:      "missing pipeline name",
+			want:      "missing Pipeline name",
 		},
 		{
 			name:      "Found no pipelines",
@@ -332,7 +332,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: true,
-			want:      "pipeline name test-pipeline-2 does not exist in namespace ns",
+			want:      "Pipeline name test-pipeline-2 does not exist in namespace ns",
 		},
 		{
 			name: "Start pipeline with showlog flag false",
@@ -347,7 +347,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: false,
-			want:      "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n",
+			want:      "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs  -f -n ns\n",
 		},
 		{
 			name: "Start pipeline with different context",
@@ -363,10 +363,10 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c7,
 			wantError: false,
-			want:      "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun --context=GummyBear logs  -f -n ns\n",
+			want:      "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun --context=GummyBear logs  -f -n ns\n",
 		},
 		{
-			name: "Start pipeline with showlog flag false",
+			name: "Start pipeline with invalid workspace name",
 			command: []string{"start", "test-pipeline",
 				"-s=svc1",
 				"-r=source=scaffold-git",
@@ -452,7 +452,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: true,
-			want:      "invalid service account parameter: task3svc3\nPlease pass task service accounts as --task-serviceaccount TaskName=ServiceAccount",
+			want:      "invalid service account parameter: task3svc3\nPlease pass Task service accounts as --task-serviceaccount TaskName=ServiceAccount",
 		},
 		{
 			name: "List error with last flag",
@@ -660,7 +660,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c6,
 			wantError: false,
-			want:      "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n",
+			want:      "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n",
 		},
 		{
 			name: "Start pipeline using invalid --filename v1alpha1",
@@ -986,7 +986,7 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c1,
 			wantError: true,
-			want:      "missing pipeline name",
+			want:      "missing Pipeline name",
 		},
 		{
 			name:      "Found no pipelines",
@@ -994,7 +994,7 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: true,
-			want:      "pipeline name test-pipeline-2 does not exist in namespace ns",
+			want:      "Pipeline name test-pipeline-2 does not exist in namespace ns",
 		},
 		{
 			name: "Start pipeline with showlog flag false",
@@ -1009,10 +1009,10 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: false,
-			want:      "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n",
+			want:      "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs  -f -n ns\n",
 		},
 		{
-			name: "Start pipeline with showlog flag false",
+			name: "Start pipeline with invalid workspace name",
 			command: []string{"start", "test-pipeline",
 				"-s=svc1",
 				"-r=source=scaffold-git",
@@ -1098,7 +1098,7 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: true,
-			want:      "invalid service account parameter: task3svc3\nPlease pass task service accounts as --task-serviceaccount TaskName=ServiceAccount",
+			want:      "invalid service account parameter: task3svc3\nPlease pass Task service accounts as --task-serviceaccount TaskName=ServiceAccount",
 		},
 		{
 			name: "List error with last flag",
@@ -1290,7 +1290,7 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c6,
 			wantError: false,
-			want:      "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n",
+			want:      "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n",
 		},
 		{
 			name: "Start pipeline using invalid --filename v1beta1",
@@ -2857,7 +2857,7 @@ func Test_start_pipeline(t *testing.T) {
 		"-s=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n"
+	expected := "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -2976,7 +2976,7 @@ func Test_start_pipeline_v1beta1(t *testing.T) {
 		"-s=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n"
+	expected := "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -3079,7 +3079,7 @@ func Test_start_pipeline_last(t *testing.T) {
 		"-n", "ns",
 	)
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -3283,7 +3283,7 @@ func Test_start_pipeline_last_v1beta1(t *testing.T) {
 		"-n", "ns",
 	)
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -3379,7 +3379,7 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 		"--last",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -3563,7 +3563,7 @@ func Test_start_pipeline_last_without_res_param_v1beta1(t *testing.T) {
 		"--last",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -3664,7 +3664,7 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n=ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -3870,7 +3870,7 @@ func Test_start_pipeline_last_merge_v1beta1(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n=ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4208,7 +4208,7 @@ func Test_start_pipeline_allkindparam(t *testing.T) {
 		"-s=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n"
+	expected := "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4338,7 +4338,7 @@ func Test_start_pipeline_allkindparam_v1beta1(t *testing.T) {
 		"-s=svc1",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: \n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs  -f -n ns\n"
+	expected := "PipelineRun started: \n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs  -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4444,7 +4444,7 @@ func Test_start_pipeline_last_generate_name(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4622,7 +4622,7 @@ func Test_start_pipeline_last_generate_name_v1beta1(t *testing.T) {
 		"--task-serviceaccount=task5=task3svc5",
 		"-n", "ns")
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4708,7 +4708,7 @@ func Test_start_pipeline_last_with_prefix_name(t *testing.T) {
 		"--prefix-name", "myprname",
 	)
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4884,7 +4884,7 @@ func Test_start_pipeline_last_with_prefix_name_v1beta1(t *testing.T) {
 		"--prefix-name", "myprname",
 	)
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -4969,7 +4969,7 @@ func Test_start_pipeline_with_prefix_name(t *testing.T) {
 		"--prefix-name", "myprname",
 	)
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -5144,7 +5144,7 @@ func Test_start_pipeline_with_prefix_name_v1beta1(t *testing.T) {
 		"--prefix-name", "myprname",
 	)
 
-	expected := "Pipelinerun started: random\n\nIn order to track the pipelinerun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -88,7 +88,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipelineresource \"pre-1\"",
+			want:        "canceled deleting pipelineresource(s) \"pre-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -96,7 +96,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelineresource \"pre-1\" (y/n): PipelineResources deleted: \"pre-1\"\n",
+			want:        "Are you sure you want to delete pipelineresource(s) \"pre-1\" (y/n): PipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -176,7 +176,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipelinerun \"pipeline-run-1\"",
+			want:        "canceled deleting pipelinerun(s) \"pipeline-run-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -185,7 +185,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelinerun \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
+			want:        "Are you sure you want to delete pipelinerun(s) \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -503,7 +503,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipelinerun \"pipeline-run-1\"",
+			want:        "canceled deleting pipelinerun(s) \"pipeline-run-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -512,7 +512,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelinerun \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
+			want:        "Are you sure you want to delete pipelinerun(s) \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -31,7 +31,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "task", ForceDelete: false, DeleteRelated: false}
+	opts := &options.DeleteOptions{Resource: "Task", ForceDelete: false, DeleteRelated: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete Tasks with names 'foo' and 'bar' in namespace 'quux':
 

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -155,7 +155,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting task \"task\"",
+			want:        "canceled deleting Task(s) \"task\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -164,7 +164,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete task \"task\" (y/n): Tasks deleted: \"task\"\n",
+			want:        "Are you sure you want to delete Task(s) \"task\" (y/n): Tasks deleted: \"task\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -200,7 +200,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete task and related resources \"task\" (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
+			want:        "Are you sure you want to delete Task(s) \"task\" and related resources (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
 		},
 		{
 			name:        "With --trs and force delete flag",
@@ -227,7 +227,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all tasks in namespace \"ns\" (y/n): All Tasks deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all Tasks in namespace \"ns\" (y/n): All Tasks deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -460,7 +460,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting task \"task\"",
+			want:        "canceled deleting Task(s) \"task\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -469,7 +469,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete task \"task\" (y/n): Tasks deleted: \"task\"\n",
+			want:        "Are you sure you want to delete Task(s) \"task\" (y/n): Tasks deleted: \"task\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -505,7 +505,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete task and related resources \"task\" (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
+			want:        "Are you sure you want to delete Task(s) \"task\" and related resources (y/n): TaskRuns deleted: \"task-run-1\", \"task-run-2\"\nTasks deleted: \"task\"\n",
 		},
 		{
 			name:        "With delete all and force delete flag",
@@ -532,7 +532,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all tasks in namespace \"ns\" (y/n): All Tasks deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all Tasks in namespace \"ns\" (y/n): All Tasks deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -151,7 +151,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting TaskRun \"tr0-1\"",
+			want:        "canceled deleting TaskRun(s) \"tr0-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -160,7 +160,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete TaskRun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
+			want:        "Are you sure you want to delete TaskRun(s) \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -452,7 +452,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting TaskRun \"tr0-1\"",
+			want:        "canceled deleting TaskRun(s) \"tr0-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -461,7 +461,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete TaskRun \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
+			want:        "Are you sure you want to delete TaskRun(s) \"tr0-1\" (y/n): TaskRuns deleted: \"tr0-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/triggerbinding/delete_test.go
+++ b/pkg/cmd/triggerbinding/delete_test.go
@@ -95,7 +95,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting triggerbinding \"tb-1\"",
+			want:        "canceled deleting triggerbinding(s) \"tb-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -103,7 +103,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete triggerbinding \"tb-1\" (y/n): TriggerBindings deleted: \"tb-1\"\n",
+			want:        "Are you sure you want to delete triggerbinding(s) \"tb-1\" (y/n): TriggerBindings deleted: \"tb-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply yes, multiple TriggerBindings",
@@ -111,7 +111,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete triggerbinding \"tb-2\", \"tb-3\" (y/n): TriggerBindings deleted: \"tb-2\", \"tb-3\"\n",
+			want:        "Are you sure you want to delete triggerbinding(s) \"tb-2\", \"tb-3\" (y/n): TriggerBindings deleted: \"tb-2\", \"tb-3\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/cmd/triggertemplate/delete_test.go
+++ b/pkg/cmd/triggertemplate/delete_test.go
@@ -95,7 +95,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting triggertemplate \"tt-1\"",
+			want:        "canceled deleting triggertemplate(s) \"tt-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -103,7 +103,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete triggertemplate \"tt-1\" (y/n): TriggerTemplates deleted: \"tt-1\"\n",
+			want:        "Are you sure you want to delete triggertemplate(s) \"tt-1\" (y/n): TriggerTemplates deleted: \"tt-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply yes, multiple triggertemplates",
@@ -111,7 +111,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete triggertemplate \"tt-2\", \"tt-3\" (y/n): TriggerTemplates deleted: \"tt-2\", \"tt-3\"\n",
+			want:        "Are you sure you want to delete triggertemplate(s) \"tt-2\", \"tt-3\" (y/n): TriggerTemplates deleted: \"tt-2\", \"tt-3\"\n",
 		},
 		{
 			name:        "Remove non existent resource",

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -77,9 +77,9 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	case o.ParentResource != "" && o.ParentResourceName != "":
 		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss related to %s %q%s (y/n): ", o.Resource, o.ParentResource, o.ParentResourceName, keepStr)
 	case o.DeleteRelated:
-		fmt.Fprintf(s.Out, "Are you sure you want to delete %s and related resources %s (y/n): ", o.Resource, formattedNames)
+		fmt.Fprintf(s.Out, "Are you sure you want to delete %s(s) %s and related resources (y/n): ", o.Resource, formattedNames)
 	default:
-		fmt.Fprintf(s.Out, "Are you sure you want to delete %s %s (y/n): ", o.Resource, formattedNames)
+		fmt.Fprintf(s.Out, "Are you sure you want to delete %s(s) %s (y/n): ", o.Resource, formattedNames)
 	}
 
 	scanner := bufio.NewScanner(s.In)
@@ -88,7 +88,7 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 		if t == "y" {
 			break
 		} else if t == "n" {
-			return fmt.Errorf("canceled deleting %s %s", o.Resource, formattedNames)
+			return fmt.Errorf("canceled deleting %s(s) %s", o.Resource, formattedNames)
 		}
 		fmt.Fprint(s.Out, "Please enter (y/n): ")
 	}

--- a/pkg/options/delete_test.go
+++ b/pkg/options/delete_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestDeleteOptions(t *testing.T) {
-
 	testParams := []struct {
 		name           string
 		opt            *DeleteOptions
@@ -71,7 +70,7 @@ func TestDeleteOptions(t *testing.T) {
 			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
 			resourcesNames: []string{"test"},
 			wantError:      true,
-			want:           "canceled deleting testRes \"test\"",
+			want:           "canceled deleting testRes(s) \"test\"",
 		},
 		{
 			name:           "Specify multiple resources, answer yes",
@@ -87,7 +86,7 @@ func TestDeleteOptions(t *testing.T) {
 			stream:         &cli.Stream{In: strings.NewReader("n"), Out: os.Stdout},
 			resourcesNames: []string{"test1", "test2"},
 			wantError:      true,
-			want:           "canceled deleting testRes \"test1\", \"test2\"",
+			want:           "canceled deleting testRes(s) \"test1\", \"test2\"",
 		},
 		{
 			name:           "Specify parent resource, answer y",

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -180,7 +180,7 @@ func TestPipelinesE2E(t *testing.T) {
 
 		pipelineGeneratedName = e2e.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
 		vars["Element"] = pipelineGeneratedName
-		expected := e2e.ProcessString(`(Pipelinerun started: {{.Element}}
+		expected := e2e.ProcessString(`(PipelineRun started: {{.Element}}
 Waiting for logs to be available...
 .*)`, vars)
 		res.Assert(t, icmd.Expected{
@@ -389,7 +389,7 @@ func TestPipelinesNegativeE2E(t *testing.T) {
 
 		pipelineGeneratedName = e2e.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
 		vars["Element"] = pipelineGeneratedName
-		expected := e2e.ProcessString(`(Pipelinerun started: {{.Element}}
+		expected := e2e.ProcessString(`(PipelineRun started: {{.Element}}
 Waiting for logs to be available...
 .*)`, vars)
 		res.Assert(t, icmd.Expected{
@@ -495,7 +495,7 @@ func TestDeletePipelinesE2E(t *testing.T) {
 			"pipeline", "rm", tePipelineName+"-3")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      "Error: canceled deleting pipeline \"" + tePipelineName + "-3" + "\"\n",
+			Err:      "Error: canceled deleting Pipeline(s) \"" + tePipelineName + "-3" + "\"\n",
 		})
 	})
 
@@ -505,7 +505,7 @@ func TestDeletePipelinesE2E(t *testing.T) {
 		res.Assert(t, icmd.Expected{
 			ExitCode: 0,
 			Err:      icmd.None,
-			Out:      "Are you sure you want to delete pipeline \"" + tePipelineName + "-3" + "\" (y/n): Pipelines deleted: \"" + tePipelineName + "-3" + "\"\n",
+			Out:      "Are you sure you want to delete Pipeline(s) \"" + tePipelineName + "-3" + "\" (y/n): Pipelines deleted: \"" + tePipelineName + "-3" + "\"\n",
 		})
 	})
 

--- a/test/e2e/pipeline/start_test.go
+++ b/test/e2e/pipeline/start_test.go
@@ -113,7 +113,7 @@ func TestPipelineInteractiveStartWithNewResourceE2E(t *testing.T) {
 		tkn.RunInteractiveTests(t, &e2e.Prompt{
 			CmdArgs: []string{"pipeline", "start", "output-pipeline", "-s", "pipeline"},
 			Procedure: func(c *expect.Console) error {
-				if _, err := c.ExpectString("Please create a new \"git\" resource for pipeline resource \"source-repo\""); err != nil {
+				if _, err := c.ExpectString("Please create a new \"git\" resource for PipelineResource \"source-repo\""); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `Pipeline` and `PipelineRun` instead of a variety of ways it is referenced throughout `tkn`. 

This pull request only focuses on `tkn pipeline` commands, but there are other PipelineRun references throughout `tkn` that should be updated as well, but will be addressed in pull requests pertaining to the commands or helper packages where PipelineRun is referenced. 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead.

There is also a change to prompts for deleting resources, which are shared for all resources. Pipeline, ClusterTask, and Task names have all been capitalized for this section of `tkn` and message prompts will now feature `(s)` to account for situations where more than one resource is deleted.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Standardize the use of Pipeline/PipelineRun in user-facing messages for tkn pipeline commands and update prompts for deletion commands for tkn
```
