### PR TITLE
Common Way of Referring to Tekton Resources for User Facing Messages: PipelineRun

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -26,7 +26,7 @@ CLI for tekton pipelines
 * [tkn condition](tkn_condition.md)	 - Manage conditions
 * [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners
 * [tkn pipeline](tkn_pipeline.md)	 - Manage pipelines
-* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
+* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 * [tkn resource](tkn_resource.md)	 - Manage pipeline resources
 * [tkn task](tkn_task.md)	 - Manage Tasks
 * [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -1,6 +1,6 @@
 ## tkn pipelinerun
 
-Manage pipelineruns
+Manage PipelineRuns
 
 ***Aliases**: pr,pipelineruns*
 
@@ -12,7 +12,7 @@ tkn pipelinerun
 
 ### Synopsis
 
-Manage pipelineruns
+Manage PipelineRuns
 
 ### Options
 
@@ -28,8 +28,8 @@ Manage pipelineruns
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn pipelinerun cancel](tkn_pipelinerun_cancel.md)	 - Cancel a PipelineRun in a namespace
-* [tkn pipelinerun delete](tkn_pipelinerun_delete.md)	 - Delete pipelineruns in a namespace
-* [tkn pipelinerun describe](tkn_pipelinerun_describe.md)	 - Describe a pipelinerun in a namespace
-* [tkn pipelinerun list](tkn_pipelinerun_list.md)	 - Lists pipelineruns in a namespace
-* [tkn pipelinerun logs](tkn_pipelinerun_logs.md)	 - Show the logs of PipelineRun
+* [tkn pipelinerun delete](tkn_pipelinerun_delete.md)	 - Delete PipelineRuns in a namespace
+* [tkn pipelinerun describe](tkn_pipelinerun_describe.md)	 - Describe a PipelineRun in a namespace
+* [tkn pipelinerun list](tkn_pipelinerun_list.md)	 - Lists PipelineRuns in a namespace
+* [tkn pipelinerun logs](tkn_pipelinerun_logs.md)	 - Show the logs of a PipelineRun
 

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -36,5 +36,5 @@ Cancel the PipelineRun named 'foo' from namespace 'bar':
 
 ### SEE ALSO
 
-* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
+* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -1,6 +1,6 @@
 ## tkn pipelinerun delete
 
-Delete pipelineruns in a namespace
+Delete PipelineRuns in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn pipelinerun delete
 
 ### Synopsis
 
-Delete pipelineruns in a namespace
+Delete PipelineRuns in a namespace
 
 ### Examples
 
@@ -28,13 +28,13 @@ or
 ### Options
 
 ```
-      --all                           Delete all pipelineruns in a namespace (default: false)
+      --all                           Delete all PipelineRuns in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-      --keep int                      Keep n most recent number of pipelineruns
+      --keep int                      Keep n most recent number of PipelineRuns
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
-  -p, --pipeline string               The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
+  -p, --pipeline string               The name of a Pipeline whose PipelineRuns should be deleted (does not delete the Pipeline)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
@@ -49,5 +49,5 @@ or
 
 ### SEE ALSO
 
-* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
+* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -1,6 +1,6 @@
 ## tkn pipelinerun describe
 
-Describe a pipelinerun in a namespace
+Describe a PipelineRun in a namespace
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn pipelinerun describe
 
 ### Synopsis
 
-Describe a pipelinerun in a namespace
+Describe a PipelineRun in a namespace
 
 ### Examples
 
@@ -29,10 +29,10 @@ or
 
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
-  -F, --fzf                           use fzf to select a pipelinerun to describe
+  -F, --fzf                           use fzf to select a PipelineRun to describe
   -h, --help                          help for describe
-  -L, --last                          show description for last pipelinerun
-      --limit int                     lists number of pipelineruns when selecting a pipelinerun to describe (default 5)
+  -L, --last                          show description for last PipelineRun
+      --limit int                     lists number of PipelineRuns when selecting a PipelineRun to describe (default 5)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
@@ -48,5 +48,5 @@ or
 
 ### SEE ALSO
 
-* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
+* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -1,6 +1,6 @@
 ## tkn pipelinerun list
 
-Lists pipelineruns in a namespace
+Lists PipelineRuns in a namespace
 
 ***Aliases**: ls*
 
@@ -12,7 +12,7 @@ tkn pipelinerun list
 
 ### Synopsis
 
-Lists pipelineruns in a namespace
+Lists PipelineRuns in a namespace
 
 ### Examples
 
@@ -28,14 +28,14 @@ List all PipelineRuns in a namespace 'foo':
 ### Options
 
 ```
-  -A, --all-namespaces                list pipelineruns from all namespaces
+  -A, --all-namespaces                list PipelineRuns from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='
-      --limit int                     limit pipelineruns listed (default: return all pipelineruns)
+      --limit int                     limit PipelineRuns listed (default: return all PipelineRuns)
       --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
-      --reverse                       list pipelineruns in reverse order
+      --reverse                       list PipelineRuns in reverse order
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
@@ -50,5 +50,5 @@ List all PipelineRuns in a namespace 'foo':
 
 ### SEE ALSO
 
-* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
+* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -1,6 +1,6 @@
 ## tkn pipelinerun logs
 
-Show the logs of PipelineRun
+Show the logs of a PipelineRun
 
 ### Usage
 
@@ -10,7 +10,7 @@ tkn pipelinerun logs
 
 ### Synopsis
 
-Show the logs of PipelineRun
+Show the logs of a PipelineRun
 
 ### Examples
 
@@ -18,11 +18,11 @@ Show the logs of PipelineRun named 'foo' from namespace 'bar':
 
     tkn pipelinerun logs foo -n bar
 
-Show the logs of PipelineRun named 'microservice-1' for task 'build' only from namespace 'bar':
+Show the logs of PipelineRun named 'microservice-1' for Task 'build' only from namespace 'bar':
 
     tkn pr logs microservice-1 -t build -n bar
 
-Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (including init steps) from namespace 'foo':
+Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (including init steps) from namespace 'foo':
 
     tkn pr logs microservice-1 -a -n foo
    
@@ -32,11 +32,11 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 ```
   -a, --all            show all logs including init steps injected by tekton
   -f, --follow         stream live logs
-  -F, --fzf            use fzf to select a pipelinerun
+  -F, --fzf            use fzf to select a PipelineRun
   -h, --help           help for logs
-  -L, --last           show logs for last pipelinerun
-      --limit int      lists number of pipelineruns (default 5)
-  -t, --task strings   show logs for mentioned tasks only
+  -L, --last           show logs for last PipelineRun
+      --limit int      lists number of PipelineRuns (default 5)
+  -t, --task strings   show logs for mentioned Tasks only
 ```
 
 ### Options inherited from parent commands
@@ -50,5 +50,5 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 
 ### SEE ALSO
 
-* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage pipelineruns
+* [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun\-delete \- Delete pipelineruns in a namespace
+tkn\-pipelinerun\-delete \- Delete PipelineRuns in a namespace
 
 
 .SH SYNOPSIS
@@ -15,13 +15,13 @@ tkn\-pipelinerun\-delete \- Delete pipelineruns in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete pipelineruns in a namespace
+Delete PipelineRuns in a namespace
 
 
 .SH OPTIONS
 .PP
 \fB\-\-all\fP[=false]
-    Delete all pipelineruns in a namespace (default: false)
+    Delete all PipelineRuns in a namespace (default: false)
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
@@ -37,7 +37,7 @@ Delete pipelineruns in a namespace
 
 .PP
 \fB\-\-keep\fP=0
-    Keep n most recent number of pipelineruns
+    Keep n most recent number of PipelineRuns
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""
@@ -45,7 +45,7 @@ Delete pipelineruns in a namespace
 
 .PP
 \fB\-p\fP, \fB\-\-pipeline\fP=""
-    The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)
+    The name of a Pipeline whose PipelineRuns should be deleted (does not delete the Pipeline)
 
 .PP
 \fB\-\-template\fP=""

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun\-describe \- Describe a pipelinerun in a namespace
+tkn\-pipelinerun\-describe \- Describe a PipelineRun in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipelinerun\-describe \- Describe a pipelinerun in a namespace
 
 .SH DESCRIPTION
 .PP
-Describe a pipelinerun in a namespace
+Describe a PipelineRun in a namespace
 
 
 .SH OPTIONS
@@ -25,7 +25,7 @@ Describe a pipelinerun in a namespace
 
 .PP
 \fB\-F\fP, \fB\-\-fzf\fP[=false]
-    use fzf to select a pipelinerun to describe
+    use fzf to select a PipelineRun to describe
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -33,11 +33,11 @@ Describe a pipelinerun in a namespace
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    show description for last pipelinerun
+    show description for last PipelineRun
 
 .PP
 \fB\-\-limit\fP=5
-    lists number of pipelineruns when selecting a pipelinerun to describe
+    lists number of PipelineRuns when selecting a PipelineRun to describe
 
 .PP
 \fB\-o\fP, \fB\-\-output\fP=""

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun\-list \- Lists pipelineruns in a namespace
+tkn\-pipelinerun\-list \- Lists PipelineRuns in a namespace
 
 
 .SH SYNOPSIS
@@ -15,13 +15,13 @@ tkn\-pipelinerun\-list \- Lists pipelineruns in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists pipelineruns in a namespace
+Lists PipelineRuns in a namespace
 
 
 .SH OPTIONS
 .PP
 \fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
-    list pipelineruns from all namespaces
+    list PipelineRuns from all namespaces
 
 .PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
@@ -37,7 +37,7 @@ Lists pipelineruns in a namespace
 
 .PP
 \fB\-\-limit\fP=0
-    limit pipelineruns listed (default: return all pipelineruns)
+    limit PipelineRuns listed (default: return all PipelineRuns)
 
 .PP
 \fB\-\-no\-headers\fP[=false]
@@ -49,7 +49,7 @@ Lists pipelineruns in a namespace
 
 .PP
 \fB\-\-reverse\fP[=false]
-    list pipelineruns in reverse order
+    list PipelineRuns in reverse order
 
 .PP
 \fB\-\-template\fP=""

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun\-logs \- Show the logs of PipelineRun
+tkn\-pipelinerun\-logs \- Show the logs of a PipelineRun
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipelinerun\-logs \- Show the logs of PipelineRun
 
 .SH DESCRIPTION
 .PP
-Show the logs of PipelineRun
+Show the logs of a PipelineRun
 
 
 .SH OPTIONS
@@ -29,7 +29,7 @@ Show the logs of PipelineRun
 
 .PP
 \fB\-F\fP, \fB\-\-fzf\fP[=false]
-    use fzf to select a pipelinerun
+    use fzf to select a PipelineRun
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -37,15 +37,15 @@ Show the logs of PipelineRun
 
 .PP
 \fB\-L\fP, \fB\-\-last\fP[=false]
-    show logs for last pipelinerun
+    show logs for last PipelineRun
 
 .PP
 \fB\-\-limit\fP=5
-    lists number of pipelineruns
+    lists number of PipelineRuns
 
 .PP
 \fB\-t\fP, \fB\-\-task\fP=[]
-    show logs for mentioned tasks only
+    show logs for mentioned Tasks only
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -80,7 +80,7 @@ tkn pipelinerun logs foo \-n bar
 .RE
 
 .PP
-Show the logs of PipelineRun named 'microservice\-1' for task 'build' only from namespace 'bar':
+Show the logs of PipelineRun named 'microservice\-1' for Task 'build' only from namespace 'bar':
 
 .PP
 .RS
@@ -92,7 +92,7 @@ tkn pr logs microservice\-1 \-t build \-n bar
 .RE
 
 .PP
-Show the logs of PipelineRun named 'microservice\-1' for all tasks and steps (including init steps) from namespace 'foo':
+Show the logs of PipelineRun named 'microservice\-1' for all Tasks and steps (including init steps) from namespace 'foo':
 
 .PP
 .RS

--- a/docs/man/man1/tkn-pipelinerun.1
+++ b/docs/man/man1/tkn-pipelinerun.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-pipelinerun \- Manage pipelineruns
+tkn\-pipelinerun \- Manage PipelineRuns
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-pipelinerun \- Manage pipelineruns
 
 .SH DESCRIPTION
 .PP
-Manage pipelineruns
+Manage PipelineRuns
 
 
 .SH OPTIONS

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -171,7 +171,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
-			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -180,7 +180,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
-			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete clustertask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -189,7 +189,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete clustertask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskrun(s) flag, reply yes",
@@ -460,7 +460,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
-			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -469,7 +469,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
-			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete clustertask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -478,7 +478,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete clustertask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete clustertask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskrun(s) flag, reply yes",

--- a/pkg/cmd/clustertriggerbinding/delete_test.go
+++ b/pkg/cmd/clustertriggerbinding/delete_test.go
@@ -101,7 +101,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete clustertriggerbinding \"nonexistent\": clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete ClusterTriggerBinding \"nonexistent\": clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -109,7 +109,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete clustertriggerbinding \"nonexistent\": clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found; failed to delete clustertriggerbinding \"nonexistent2\": clustertriggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete ClusterTriggerBinding \"nonexistent\": clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found; failed to delete ClusterTriggerBinding \"nonexistent2\": clustertriggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",

--- a/pkg/cmd/condition/delete_test.go
+++ b/pkg/cmd/condition/delete_test.go
@@ -132,7 +132,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
-			want:        "failed to delete condition \"nonexistent\": conditions.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete Condition \"nonexistent\": conditions.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -140,7 +140,7 @@ func TestConditionDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete condition \"nonexistent\": conditions.tekton.dev \"nonexistent\" not found; failed to delete condition \"nonexistent2\": conditions.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Condition \"nonexistent\": conditions.tekton.dev \"nonexistent\" not found; failed to delete Condition \"nonexistent2\": conditions.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",

--- a/pkg/cmd/eventlistener/delete_test.go
+++ b/pkg/cmd/eventlistener/delete_test.go
@@ -119,7 +119,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete eventlistener \"nonexistent\": eventlisteners.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete EventListener \"nonexistent\": eventlisteners.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -127,7 +127,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete eventlistener \"nonexistent\": eventlisteners.triggers.tekton.dev \"nonexistent\" not found; failed to delete eventlistener \"nonexistent2\": eventlisteners.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete EventListener \"nonexistent\": eventlisteners.triggers.tekton.dev \"nonexistent\" not found; failed to delete EventListener \"nonexistent2\": eventlisteners.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -182,7 +182,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -191,7 +191,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --prs flag",
@@ -200,7 +200,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With --prs flag, reply yes",
@@ -471,7 +471,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -480,7 +480,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --prs flag",
@@ -489,7 +489,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete all flag, reply yes",

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -104,7 +104,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipelineresource \"nonexistent\": pipelineresources.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete PipelineResource \"nonexistent\": pipelineresources.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -112,7 +112,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipelineresource \"nonexistent\": pipelineresources.tekton.dev \"nonexistent\" not found; failed to delete pipelineresource \"nonexistent2\": pipelineresources.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete PipelineResource \"nonexistent\": pipelineresources.tekton.dev \"nonexistent\" not found; failed to delete PipelineResource \"nonexistent2\": pipelineresources.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",

--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -74,19 +74,19 @@ func cancelPipelineRun(p cli.Params, s *cli.Stream, prName string) error {
 
 	pr, err := pipelinerun.GetV1beta1(cs, prName, metav1.GetOptions{}, p.Namespace())
 	if err != nil {
-		return fmt.Errorf("failed to find pipelinerun: %s", prName)
+		return fmt.Errorf("failed to find PipelineRun: %s", prName)
 	}
 
 	prCond := formatted.Condition(pr.Status.Conditions)
 	if prCond == succeeded || prCond == failed || prCond == prCancelled {
-		return fmt.Errorf("failed to cancel pipelinerun %s: pipelinerun has already finished execution", prName)
+		return fmt.Errorf("failed to cancel PipelineRun %s: PipelineRun has already finished execution", prName)
 	}
 
 	if _, err = pipelinerun.Patch(cs, prName, metav1.PatchOptions{}, p.Namespace()); err != nil {
-		return fmt.Errorf("failed to cancel pipelinerun: %s, err: %s", prName, err.Error())
+		return fmt.Errorf("failed to cancel PipelineRun: %s: %v", prName, err)
 
 	}
 
-	fmt.Fprintf(s.Out, "Pipelinerun cancelled: %s\n", pr.Name)
+	fmt.Fprintf(s.Out, "PipelineRun cancelled: %s\n", pr.Name)
 	return nil
 }

--- a/pkg/cmd/pipelinerun/cancel_test.go
+++ b/pkg/cmd/pipelinerun/cancel_test.go
@@ -101,7 +101,7 @@ func Test_cancel_pipelinerun(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Pipelinerun cancelled: " + prName + "\n"
+	expected := "PipelineRun cancelled: " + prName + "\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -122,7 +122,7 @@ func Test_cancel_pipelinerun_not_found(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to find pipelinerun: " + prName + "\n"
+	expected := "Error: failed to find PipelineRun: " + prName + "\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -173,7 +173,7 @@ func Test_cancel_pipelinerun_client_err(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun: " + prName + ", err: " + errStr + "\n"
+	expected := "Error: failed to cancel PipelineRun: " + prName + ": " + errStr + "\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -219,7 +219,7 @@ func Test_finished_pipelinerun_success(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun " + prName + ": pipelinerun has already finished execution\n"
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -265,7 +265,7 @@ func Test_finished_pipelinerun_failure(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun " + prName + ": pipelinerun has already finished execution\n"
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -311,7 +311,7 @@ func Test_finished_pipelinerun_cancel(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun " + prName + ": pipelinerun has already finished execution\n"
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -386,7 +386,7 @@ func Test_cancel_pipelinerun_v1beta1(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Pipelinerun cancelled: " + prName + "\n"
+	expected := "PipelineRun cancelled: " + prName + "\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -469,7 +469,7 @@ func Test_cancel_pipelinerun_client_err_v1beta1(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun: " + prName + ", err: " + errStr + "\n"
+	expected := "Error: failed to cancel PipelineRun: " + prName + ": " + errStr + "\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -554,7 +554,7 @@ func Test_finished_pipelinerun_success_v1beta1(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun " + prName + ": pipelinerun has already finished execution\n"
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -639,7 +639,7 @@ func Test_finished_pipelinerun_failure_v1beta1(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun " + prName + ": pipelinerun has already finished execution\n"
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }
 
@@ -724,6 +724,6 @@ func Test_finished_pipelinerun_cancel_v1beta1(t *testing.T) {
 	pRun := Command(p)
 	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
 
-	expected := "Error: failed to cancel pipelinerun " + prName + ": pipelinerun has already finished execution\n"
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -33,7 +33,7 @@ import (
 )
 
 func deleteCommand(p cli.Params) *cobra.Command {
-	opts := &options.DeleteOptions{Resource: "pipelinerun", ForceDelete: false, ParentResource: "pipeline", DeleteAllNs: false}
+	opts := &options.DeleteOptions{Resource: "PipelineRun", ForceDelete: false, ParentResource: "Pipeline", DeleteAllNs: false}
 	f := cliopts.NewPrintFlags("delete")
 	eg := `Delete PipelineRuns with names 'foo' and 'bar' in namespace 'quux':
 
@@ -47,7 +47,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete pipelineruns in a namespace",
+		Short:        "Delete PipelineRuns in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
@@ -82,9 +82,9 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().StringVarP(&opts.ParentResourceName, "pipeline", "p", "", "The name of a pipeline whose pipelineruns should be deleted (does not delete the pipeline)")
-	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of pipelineruns")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all pipelineruns in a namespace (default: false)")
+	c.Flags().StringVarP(&opts.ParentResourceName, "pipeline", "p", "", "The name of a Pipeline whose PipelineRuns should be deleted (does not delete the Pipeline)")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of PipelineRuns")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all PipelineRuns in a namespace (default: false)")
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
 	return c
 }
@@ -114,7 +114,7 @@ func deletePipelineRuns(s *cli.Stream, p cli.Params, prNames []string, opts *opt
 		d.Delete(s, prNames)
 	default:
 		d = deleter.New("Pipeline", func(_ string) error {
-			return errors.New("the pipeline should not be deleted")
+			return errors.New("the Pipeline should not be deleted")
 		})
 		d.WithRelated("PipelineRun", pipelineRunLister(cs, opts.Keep, p.Namespace()), func(pipelineRunName string) error {
 			return actions.Delete(prGroupResource, cs, pipelineRunName, p.Namespace(), &metav1.DeleteOptions{})

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -176,7 +176,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipelinerun(s) \"pipeline-run-1\"",
+			want:        "canceled deleting PipelineRun(s) \"pipeline-run-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -185,7 +185,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelinerun(s) \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
+			want:        "Are you sure you want to delete PipelineRun(s) \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -194,7 +194,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipelinerun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -203,7 +203,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipelinerun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found; failed to delete pipelinerun \"nonexistent2\": pipelineruns.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found; failed to delete PipelineRun \"nonexistent2\": pipelineruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include pipelinerun names",
@@ -212,7 +212,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide pipelinerun name(s) or use --pipeline flag or --all flag to use delete",
+			want:        "must provide PipelineRun name(s) or use --pipeline flag or --all flag to use delete",
 		},
 		{
 			name:        "Remove pipelineruns of a pipeline",
@@ -221,7 +221,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" (y/n): All PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all PipelineRuns related to Pipeline \"pipeline\" (y/n): All PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -230,7 +230,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns in namespace \"ns\" (y/n): All PipelineRuns deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all PipelineRuns in namespace \"ns\" (y/n): All PipelineRuns deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -284,7 +284,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" keeping 2 pipelineruns (y/n): All but 2 PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all PipelineRuns related to Pipeline \"pipeline\" keeping 2 PipelineRuns (y/n): All but 2 PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Error from using argument with --keep",
@@ -503,7 +503,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("n"),
 			wantError:   true,
-			want:        "canceled deleting pipelinerun(s) \"pipeline-run-1\"",
+			want:        "canceled deleting PipelineRun(s) \"pipeline-run-1\"",
 		},
 		{
 			name:        "Without force delete flag, reply yes",
@@ -512,7 +512,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelinerun(s) \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
+			want:        "Are you sure you want to delete PipelineRun(s) \"pipeline-run-1\" (y/n): PipelineRuns deleted: \"pipeline-run-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -521,7 +521,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipelinerun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -530,7 +530,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete pipelinerun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found; failed to delete pipelinerun \"nonexistent2\": pipelineruns.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found; failed to delete PipelineRun \"nonexistent2\": pipelineruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include pipelinerun names",
@@ -539,7 +539,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "must provide pipelinerun name(s) or use --pipeline flag or --all flag to use delete",
+			want:        "must provide PipelineRun name(s) or use --pipeline flag or --all flag to use delete",
 		},
 		{
 			name:        "Remove pipelineruns of a pipeline",
@@ -548,7 +548,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" (y/n): All PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all PipelineRuns related to Pipeline \"pipeline\" (y/n): All PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -557,7 +557,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[3].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns in namespace \"ns\" (y/n): All PipelineRuns deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all PipelineRuns in namespace \"ns\" (y/n): All PipelineRuns deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -602,7 +602,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[5].pipelineClient,
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineruns related to pipeline \"pipeline\" keeping 2 pipelineruns (y/n): All but 2 PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+			want:        "Are you sure you want to delete all PipelineRuns related to Pipeline \"pipeline\" keeping 2 PipelineRuns (y/n): All but 2 PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Error from using argument with --keep",

--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -50,7 +50,7 @@ or
 	c := &cobra.Command{
 		Use:          "describe",
 		Aliases:      []string{"desc"},
-		Short:        "Describe a pipelinerun in a namespace",
+		Short:        "Describe a PipelineRun in a namespace",
 		Example:      eg,
 		SilenceUsage: true,
 		Annotations: map[string]string{
@@ -68,8 +68,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if !opts.Fzf {
@@ -105,9 +104,9 @@ or
 		},
 	}
 
-	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show description for last pipelinerun")
-	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultDescribeLimit, "lists number of pipelineruns when selecting a pipelinerun to describe")
-	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a pipelinerun to describe")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show description for last PipelineRun")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultDescribeLimit, "lists number of PipelineRuns when selecting a PipelineRun to describe")
+	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a PipelineRun to describe")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
 	f.AddFlags(c)
@@ -128,7 +127,8 @@ func askPipelineRunName(opts *options.DescribeOptions, p cli.Params) error {
 		return err
 	}
 	if len(prs) == 0 {
-		return fmt.Errorf("no pipelineruns found")
+		fmt.Fprint(os.Stdout, "No PipelineRuns found")
+		return nil
 	}
 
 	if opts.Fzf {

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -185,7 +185,7 @@ func TestListPipelineRuns(t *testing.T) {
 			name:      "limit pipelineruns negative case",
 			command:   commandV1alpha1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", -1)},
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name:      "filter pipelineruns by label with in query",
@@ -421,7 +421,7 @@ func TestListPipelineRuns_v1beta1(t *testing.T) {
 			name:      "limit pipelineruns negative case",
 			command:   commandV1beta1(t, prs, clock.Now(), ns, version, dc1),
 			args:      []string{"list", "-n", "namespace", "--limit", fmt.Sprintf("%d", -1)},
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name:      "filter pipelineruns by label with in query",

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -38,11 +38,11 @@ func logCommand(p cli.Params) *cobra.Command {
 
     tkn pipelinerun logs foo -n bar
 
-Show the logs of PipelineRun named 'microservice-1' for task 'build' only from namespace 'bar':
+Show the logs of PipelineRun named 'microservice-1' for Task 'build' only from namespace 'bar':
 
     tkn pr logs microservice-1 -t build -n bar
 
-Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (including init steps) from namespace 'foo':
+Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (including init steps) from namespace 'foo':
 
     tkn pr logs microservice-1 -a -n foo
    `
@@ -50,7 +50,7 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 	c := &cobra.Command{
 		Use:                   "logs",
 		DisableFlagsInUseLine: true,
-		Short:                 "Show the logs of PipelineRun",
+		Short:                 "Show the logs of a PipelineRun",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -80,11 +80,11 @@ Show the logs of PipelineRun named 'microservice-1' for all tasks and steps (inc
 	}
 
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
-	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last pipelinerun")
-	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a pipelinerun")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last PipelineRun")
+	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a PipelineRun")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
-	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned tasks only")
-	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of pipelineruns")
+	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned Tasks only")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of PipelineRuns")
 
 	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
 	return c
@@ -130,7 +130,8 @@ func askRunName(opts *options.LogOptions) error {
 	}
 
 	if len(prs) == 0 {
-		return fmt.Errorf("No pipelineruns found")
+		fmt.Fprint(os.Stdout, "No PipelineRuns found")
+		return nil
 	}
 
 	if len(prs) == 1 || opts.Last {

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -25,7 +25,7 @@ func Command(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "pipelinerun",
 		Aliases: []string{"pr", "pipelineruns"},
-		Short:   "Manage pipelineruns",
+		Short:   "Manage PipelineRuns",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-limit_pipelineruns_negative_case.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-limit_pipelineruns_negative_case.golden
@@ -1,0 +1,1 @@
+Error: limit was -1 but must be a positive number

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-no_mixing_pipelinename_and_label.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns-no_mixing_pipelinename_and_label.golden
@@ -1,1 +1,1 @@
-Error: specifying a pipeline and labels are not compatible
+Error: failed to list PipelineRuns from namespace namespace: specifying a Pipeline and labels are not compatible

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-limit_pipelineruns_negative_case.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-limit_pipelineruns_negative_case.golden
@@ -1,0 +1,1 @@
+Error: limit was -1 but must be a positive number

--- a/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-no_mixing_pipelinename_and_label.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestListPipelineRuns_v1beta1-no_mixing_pipelinename_and_label.golden
@@ -1,1 +1,1 @@
-Error: specifying a pipeline and labels are not compatible
+Error: failed to list PipelineRuns from namespace namespace: specifying a Pipeline and labels are not compatible

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -173,7 +173,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -182,7 +182,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -191,7 +191,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskruns flag, reply yes",
@@ -478,7 +478,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -487,7 +487,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -496,7 +496,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskruns flag, reply yes",

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -169,7 +169,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -178,7 +178,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete taskrun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete TaskRun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include taskrun names",
@@ -470,7 +470,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -479,7 +479,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete taskrun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete taskrun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete TaskRun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include taskrun names",

--- a/pkg/cmd/triggerbinding/delete_test.go
+++ b/pkg/cmd/triggerbinding/delete_test.go
@@ -119,7 +119,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete triggerbinding \"nonexistent\": triggerbindings.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete TriggerBinding \"nonexistent\": triggerbindings.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -127,7 +127,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete triggerbinding \"nonexistent\": triggerbindings.triggers.tekton.dev \"nonexistent\" not found; failed to delete triggerbinding \"nonexistent2\": triggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete TriggerBinding \"nonexistent\": triggerbindings.triggers.tekton.dev \"nonexistent\" not found; failed to delete TriggerBinding \"nonexistent2\": triggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",

--- a/pkg/cmd/triggertemplate/delete_test.go
+++ b/pkg/cmd/triggertemplate/delete_test.go
@@ -119,7 +119,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete triggertemplate \"nonexistent\": triggertemplates.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "failed to delete TriggerTemplate \"nonexistent\": triggertemplates.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -127,7 +127,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete triggertemplate \"nonexistent\": triggertemplates.triggers.tekton.dev \"nonexistent\" not found; failed to delete triggertemplate \"nonexistent2\": triggertemplates.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to delete TriggerTemplate \"nonexistent\": triggertemplates.triggers.tekton.dev \"nonexistent\" not found; failed to delete TriggerTemplate \"nonexistent2\": triggertemplates.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -53,7 +53,7 @@ func (d *Deleter) WithRelated(kind string, listFunc func(string) ([]string, erro
 func (d *Deleter) Delete(streams *cli.Stream, resourceNames []string) []string {
 	for _, name := range resourceNames {
 		if err := d.delete(name); err != nil {
-			d.appendError(streams, fmt.Errorf("failed to delete %s %q: %s", strings.ToLower(d.kind), name, err))
+			d.appendError(streams, fmt.Errorf("failed to delete %s %q: %s", d.kind, name, err))
 		} else {
 			d.successfulDeletes = append(d.successfulDeletes, name)
 		}


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `PipelineRun` instead of a variety of ways it is referenced throughout `tkn`.

This pull request only focuses on `tkn pipelinerun` commands, but there are other PipelineRun references throughout `tkn` that should be updated as well, but will be addressed in pull requests pertaining to the commands or helper packages where PipelineRun is referenced. 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead.

The final update introduced in this pr is an update to an error message from `deleter.go`, which updates the error `fmt.Errorf("failed to delete %s %q: %s", d.kind, name, err)` to not lowercase `d.kind`. As a result, this corrects the format of the error for every command in `tkn`.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Standardize the use of PipelineRun in user-facing messages for tkn pipelinerun commands
```
