### PR TITLE
ClusterTask start interactive mode

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -40,6 +40,7 @@ like cat,foo,bar
   -s, --serviceaccount string    pass the serviceaccount name
       --showlog                  show logs right after starting the ClusterTask
       --timeout string           timeout for TaskRun
+  -w, --workspace stringArray    pass one or more workspaces to map to the corresponding physical volumes as name=name,claimName=pvcName or name=name,emptyDir=
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -63,6 +63,10 @@ Start ClusterTasks
 \fB\-\-timeout\fP=""
     timeout for TaskRun
 
+.PP
+\fB\-w\fP, \fB\-\-workspace\fP=[]
+    pass one or more workspaces to map to the corresponding physical volumes as name=name,claimName=pvcName or name=name,emptyDir=
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -18,14 +18,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
 	ctactions "github.com/tektoncd/cli/pkg/clustertask"
+	"github.com/tektoncd/cli/pkg/cmd/pipelineresource"
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/flags"
 	"github.com/tektoncd/cli/pkg/labels"
@@ -33,6 +37,8 @@ import (
 	"github.com/tektoncd/cli/pkg/params"
 	"github.com/tektoncd/cli/pkg/task"
 	tractions "github.com/tektoncd/cli/pkg/taskrun"
+	"github.com/tektoncd/cli/pkg/workspaces"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
@@ -58,11 +64,14 @@ type startOptions struct {
 	TimeOut            string
 	DryRun             bool
 	Output             string
+	Workspaces         []string
+	clustertask        *v1beta1.ClusterTask
+	askOpts            survey.AskOpt
 	TektonOptions      flags.TektonOptions
 }
 
 // NameArg validates that the first argument is a valid clustertask name
-func NameArg(args []string, p cli.Params) error {
+func NameArg(args []string, p cli.Params, opt *startOptions) error {
 	if len(args) == 0 {
 		return errNoClusterTask
 	}
@@ -77,7 +86,7 @@ func NameArg(args []string, p cli.Params) error {
 	if err != nil {
 		return fmt.Errorf(errInvalidClusterTask, name)
 	}
-
+	opt.clustertask = ct
 	if ct.Spec.Params != nil {
 		params.FilterParamsByType(ct.Spec.Params)
 	}
@@ -88,6 +97,14 @@ func NameArg(args []string, p cli.Params) error {
 func startCommand(p cli.Params) *cobra.Command {
 	opt := startOptions{
 		cliparams: p,
+		askOpts: func(opt *survey.AskOptions) error {
+			opt.Stdio = terminal.Stdio{
+				In:  os.Stdin,
+				Out: os.Stdout,
+				Err: os.Stderr,
+			}
+			return nil
+		},
 	}
 
 	eg := `Start ClusterTask foo by creating a TaskRun named "foo-run-xyz123" in namespace 'bar':
@@ -120,7 +137,7 @@ like cat,foo,bar
 			if err := flags.InitParams(p, cmd); err != nil {
 				return err
 			}
-			return NameArg(args, p)
+			return NameArg(args, p, &opt)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opt.stream = &cli.Stream{
@@ -140,6 +157,7 @@ like cat,foo,bar
 	flags.AddShellCompletion(c.Flags().Lookup("serviceaccount"), "__kubectl_get_serviceaccount")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the ClusterTask using last TaskRun values")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
+	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass one or more workspaces to map to the corresponding physical volumes as name=name,claimName=pvcName or name=name,emptyDir=")
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the ClusterTask")
 	c.Flags().StringVar(&opt.TimeOut, "timeout", "", "timeout for TaskRun")
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview TaskRun without running it")
@@ -170,6 +188,10 @@ func startClusterTask(opt startOptions, args []string) error {
 			Name: ctname,
 			Kind: v1beta1.ClusterTaskKind, //Specify TaskRun is for a ClusterTask kind
 		},
+	}
+
+	if err := opt.getInputs(); err != nil {
+		return err
 	}
 
 	if opt.TimeOut != "" {
@@ -214,6 +236,12 @@ func startClusterTask(opt startOptions, args []string) error {
 		return err
 	}
 	tr.ObjectMeta.Labels = labels
+
+	workspaces, err := workspaces.Merge(tr.Spec.Workspaces, opt.Workspaces, opt.cliparams)
+	if err != nil {
+		return err
+	}
+	tr.Spec.Workspaces = workspaces
 
 	param, err := params.MergeParam(tr.Spec.Params, opt.Params)
 	if err != nil {
@@ -354,4 +382,83 @@ func convertedTrVersion(c *cli.Clients, tr *v1beta1.TaskRun) (interface{}, error
 	}
 
 	return tr, nil
+}
+
+func (opt *startOptions) getInputs() error {
+	intOpts := options.InteractiveOpts{
+		Stream:    opt.stream,
+		CliParams: opt.cliparams,
+		AskOpts:   opt.askOpts,
+		Ns:        opt.cliparams.Namespace(),
+	}
+
+	if opt.clustertask.Spec.Resources != nil && !opt.Last {
+		if len(opt.InputResources) == 0 {
+			if err := intOpts.ClusterTaskInputResources(opt.clustertask, createPipelineResource); err != nil {
+				return err
+			}
+			opt.InputResources = append(opt.InputResources, intOpts.InputResources...)
+		}
+		if len(opt.OutputResources) == 0 {
+			if err := intOpts.ClusterTaskOutputResources(opt.clustertask, createPipelineResource); err != nil {
+				return err
+			}
+			opt.OutputResources = append(opt.OutputResources, intOpts.OutputResources...)
+		}
+	}
+
+	params.FilterParamsByType(opt.clustertask.Spec.Params)
+	if len(opt.Params) == 0 && !opt.Last {
+		if err := intOpts.ClusterTaskParams(opt.clustertask); err != nil {
+			return err
+		}
+		opt.Params = append(opt.Params, intOpts.Params...)
+	}
+
+	if len(opt.Workspaces) == 0 && !opt.Last {
+		if err := intOpts.ClusterTaskWorkspaces(opt.clustertask); err != nil {
+			return err
+		}
+		opt.Workspaces = append(opt.Workspaces, intOpts.Workspaces...)
+	}
+
+	return nil
+}
+
+func createPipelineResource(resType v1alpha1.PipelineResourceType, askOpt survey.AskOpt, p cli.Params, s *cli.Stream) (*v1alpha1.PipelineResource, error) {
+	res := pipelineresource.Resource{
+		AskOpts: askOpt,
+		Params:  p,
+		PipelineResource: v1alpha1.PipelineResource{
+			ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace()},
+			Spec:       v1alpha1.PipelineResourceSpec{Type: resType},
+		}}
+
+	if err := res.AskMeta(); err != nil {
+		return nil, err
+	}
+
+	resourceTypeParams := map[v1alpha1.PipelineResourceType]func() error{
+		v1alpha1.PipelineResourceTypeGit:         res.AskGitParams,
+		v1alpha1.PipelineResourceTypeStorage:     res.AskStorageParams,
+		v1alpha1.PipelineResourceTypeImage:       res.AskImageParams,
+		v1alpha1.PipelineResourceTypeCluster:     res.AskClusterParams,
+		v1alpha1.PipelineResourceTypePullRequest: res.AskPullRequestParams,
+		v1alpha1.PipelineResourceTypeCloudEvent:  res.AskCloudEventParams,
+	}
+	if res.PipelineResource.Spec.Type != "" {
+		if err := resourceTypeParams[res.PipelineResource.Spec.Type](); err != nil {
+			return nil, err
+		}
+	}
+	cs, err := p.Clients()
+	if err != nil {
+		return nil, err
+	}
+	newRes, err := cs.Resource.TektonV1alpha1().PipelineResources(p.Namespace()).Create(&res.PipelineResource)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(s.Out, "New %s resource \"%s\" has been created\n", newRes.Spec.Type, newRes.Name)
+	return newRes, nil
 }

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_no_output.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_no_output.golden
@@ -7,6 +7,9 @@ metadata:
     key: value
 spec:
   inputs:
+    params:
+    - name: myarg
+      value: value1
     resources:
     - name: my-repo
       resourceRef:

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_output=json.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_output=json.golden
@@ -22,6 +22,12 @@
 						"name": "git"
 					}
 				}
+			],
+			"params": [
+				{
+					"name": "myarg",
+					"value": "value1"
+				}
 			]
 		},
 		"outputs": {

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start_v1beta1-Dry_run_with_--timeout_v1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start_v1beta1-Dry_run_with_--timeout_v1beta1.golden
@@ -6,6 +6,9 @@ metadata:
   labels:
     key: value
 spec:
+  params:
+  - name: myarg
+    value: value1
   resources:
     inputs:
     - name: my-repo

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start_v1beta1-Dry_run_with_no_output.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start_v1beta1-Dry_run_with_no_output.golden
@@ -6,6 +6,9 @@ metadata:
   labels:
     key: value
 spec:
+  params:
+  - name: myarg
+    value: value1
   resources:
     inputs:
     - name: my-repo

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start_v1beta1-Dry_run_with_no_output_v1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start_v1beta1-Dry_run_with_no_output_v1beta1.golden
@@ -6,6 +6,9 @@ metadata:
   labels:
     key: value
 spec:
+  params:
+  - name: myarg
+    value: value1
   resources:
     inputs:
     - name: my-repo

--- a/pkg/options/start.go
+++ b/pkg/options/start.go
@@ -351,10 +351,233 @@ func (intOpts *InteractiveOpts) TaskWorkspaces(task *v1beta1.Task) error {
 	return nil
 }
 
+func (intOpts *InteractiveOpts) ClusterTaskInputResources(clustertask *v1beta1.ClusterTask, f func(v1alpha1.PipelineResourceType, survey.AskOpt, cli.Params, *cli.Stream) (*v1alpha1.PipelineResource, error)) error {
+	cs, err := intOpts.CliParams.Clients()
+	if err != nil {
+		return err
+	}
+
+	resources, err := intOpts.pipelineResourcesByFormat(cs.Resource)
+	if err != nil {
+		return err
+	}
+	for _, res := range clustertask.Spec.Resources.Inputs {
+		options := resourceByType(resources, string(res.Type))
+		// directly create resource
+		if len(options) == 0 {
+			fmt.Fprintf(intOpts.Stream.Out, "no PipelineResource of type \"%s\" found in namespace: %s\n", string(res.Type), intOpts.Ns)
+			fmt.Fprintf(intOpts.Stream.Out, "Please create a new \"%s\" resource for PipelineResource \"%s\"\n", string(res.Type), res.Name)
+			newres, err := f(res.Type, intOpts.AskOpts, intOpts.CliParams, intOpts.Stream)
+			if err != nil {
+				return err
+			}
+			if newres.Status != nil {
+				fmt.Printf("resource status %s\n\n", newres.Status)
+			}
+			intOpts.InputResources = append(intOpts.InputResources, res.Name+"="+newres.Name)
+			continue
+		}
+
+		// shows create option in the resource list
+		resCreateOpt := fmt.Sprintf("create new \"%s\" resource", res.Type)
+		options = append(options, resCreateOpt)
+		var ans string
+		var qs = []*survey.Question{
+			{
+				Name: "pipelineresource",
+				Prompt: &survey.Select{
+					Message: fmt.Sprintf("Choose the %s resource to use for %s:", res.Type, res.Name),
+					Options: options,
+				},
+			},
+		}
+
+		if err := survey.Ask(qs, &ans, intOpts.AskOpts); err != nil {
+			return err
+		}
+
+		if ans == resCreateOpt {
+			newres, err := f(res.Type, intOpts.AskOpts, intOpts.CliParams, intOpts.Stream)
+			if err != nil {
+				return err
+			}
+			intOpts.InputResources = append(intOpts.InputResources, res.Name+"="+newres.Name)
+			continue
+		}
+		name := strings.TrimSpace(strings.Split(ans, " ")[0])
+		intOpts.InputResources = append(intOpts.InputResources, res.Name+"="+name)
+	}
+	return nil
+}
+
+func (intOpts *InteractiveOpts) ClusterTaskOutputResources(clustertask *v1beta1.ClusterTask, f func(v1alpha1.PipelineResourceType, survey.AskOpt, cli.Params, *cli.Stream) (*v1alpha1.PipelineResource, error)) error {
+	cs, err := intOpts.CliParams.Clients()
+	if err != nil {
+		return err
+	}
+
+	resources, err := intOpts.pipelineResourcesByFormat(cs.Resource)
+	if err != nil {
+		return err
+	}
+
+	for _, res := range clustertask.Spec.Resources.Outputs {
+		options := resourceByType(resources, string(res.Type))
+		// directly create resource
+		if len(options) == 0 {
+			fmt.Fprintf(intOpts.Stream.Out, "no PipelineResource of type \"%s\" found in namespace: %s\n", string(res.Type), intOpts.Ns)
+			fmt.Fprintf(intOpts.Stream.Out, "Please create a new \"%s\" resource for PipelineResource \"%s\"\n", string(res.Type), res.Name)
+			newres, err := f(res.Type, intOpts.AskOpts, intOpts.CliParams, intOpts.Stream)
+			if err != nil {
+				return err
+			}
+			if newres.Status != nil {
+				fmt.Printf("resource status %s\n\n", newres.Status)
+			}
+			intOpts.OutputResources = append(intOpts.OutputResources, res.Name+"="+newres.Name)
+			continue
+		}
+
+		// shows create option in the resource list
+		resCreateOpt := fmt.Sprintf("create new \"%s\" resource", res.Type)
+		options = append(options, resCreateOpt)
+		var ans string
+		var qs = []*survey.Question{
+			{
+				Name: "pipelineresource",
+				Prompt: &survey.Select{
+					Message: fmt.Sprintf("Choose the %s resource to use for %s:", res.Type, res.Name),
+					Options: options,
+				},
+			},
+		}
+
+		if err := survey.Ask(qs, &ans, intOpts.AskOpts); err != nil {
+			return err
+		}
+
+		if ans == resCreateOpt {
+			newres, err := f(res.Type, intOpts.AskOpts, intOpts.CliParams, intOpts.Stream)
+			if err != nil {
+				return err
+			}
+			intOpts.OutputResources = append(intOpts.OutputResources, res.Name+"="+newres.Name)
+			continue
+		}
+		name := strings.TrimSpace(strings.Split(ans, " ")[0])
+		intOpts.OutputResources = append(intOpts.OutputResources, res.Name+"="+name)
+	}
+	return nil
+}
+
+func (intOpts *InteractiveOpts) ClusterTaskParams(clustertask *v1beta1.ClusterTask) error {
+	for _, param := range clustertask.Spec.Params {
+		var ans, ques, defaultValue string
+		ques = fmt.Sprintf("Value for param `%s` of type `%s`?", param.Name, param.Type)
+		input := &survey.Input{}
+		if param.Default != nil {
+			if param.Type == "string" {
+				defaultValue = param.Default.StringVal
+			} else {
+				defaultValue = strings.Join(param.Default.ArrayVal, ",")
+			}
+			ques += fmt.Sprintf(" (Default is `%s`)", defaultValue)
+			input.Default = defaultValue
+		}
+		input.Message = ques
+
+		var qs = []*survey.Question{
+			{
+				Name:   "pipeline param",
+				Prompt: input,
+			},
+		}
+
+		if err := survey.Ask(qs, &ans, intOpts.AskOpts); err != nil {
+			return err
+		}
+
+		intOpts.Params = append(intOpts.Params, param.Name+"="+ans)
+	}
+	return nil
+}
+
+func (intOpts *InteractiveOpts) ClusterTaskWorkspaces(clustertask *v1beta1.ClusterTask) error {
+	for _, ws := range clustertask.Spec.Workspaces {
+		fmt.Fprintf(intOpts.Stream.Out, "Please give specifications for the workspace: %s \n", ws.Name)
+		name, err := askParam("Name for the workspace:", intOpts.AskOpts)
+		if err != nil {
+			return err
+		}
+		workspace := "name=" + name
+		subPath, err := askParam("Value of the Sub Path:", intOpts.AskOpts, " ")
+		if err != nil {
+			return err
+		}
+		if subPath != " " {
+			workspace = workspace + ",subPath=" + subPath
+		}
+
+		var kind string
+		var qs = []*survey.Question{
+			{
+				Name: "workspace param",
+				Prompt: &survey.Select{
+					Message: " Type of the Workspace:",
+					Options: []string{"config", "emptyDir", "secret", "pvc"},
+					Default: "emptyDir",
+				},
+			},
+		}
+		if err := survey.Ask(qs, &kind, intOpts.AskOpts); err != nil {
+			return err
+		}
+		switch kind {
+		case "pvc":
+			claimName, err := askParam("Value of Claim Name:", intOpts.AskOpts)
+			if err != nil {
+				return err
+			}
+			workspace = workspace + ",claimName=" + claimName
+		case "emptyDir":
+			kind, err := askParam("Type of EmtpyDir:", intOpts.AskOpts, "")
+			if err != nil {
+				return err
+			}
+			workspace = workspace + ",emptyDir=" + kind
+		case "config":
+			config, err := askParam("Name of the configmap:", intOpts.AskOpts)
+			if err != nil {
+				return err
+			}
+			workspace = workspace + ",config=" + config
+			items, err := getItems(intOpts.AskOpts)
+			if err != nil {
+				return err
+			}
+			workspace += items
+		case "secret":
+			secret, err := askParam("Name of the secret:", intOpts.AskOpts)
+			if err != nil {
+				return err
+			}
+			workspace = workspace + ",secret=" + secret
+			items, err := getItems(intOpts.AskOpts)
+			if err != nil {
+				return err
+			}
+			workspace += items
+		}
+		intOpts.Workspaces = append(intOpts.Workspaces, workspace)
+
+	}
+	return nil
+}
+
 func getItems(askOpts survey.AskOpt) (string, error) {
 	var items string
 	for {
-		it, err := askParam("Item Value :", askOpts, " ")
+		it, err := askParam("Item Value:", askOpts, " ")
 		if err != nil {
 			return "", err
 		}

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -1,0 +1,114 @@
+// +build e2e
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustertask
+
+import (
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/Netflix/go-expect"
+	"github.com/tektoncd/cli/test/builder"
+	"github.com/tektoncd/cli/test/cli"
+	"github.com/tektoncd/cli/test/framework"
+	"github.com/tektoncd/cli/test/helper"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/icmd"
+	knativetest "knative.dev/pkg/test"
+)
+
+const (
+	tePipelineGitResourceName = "skaffold-git"
+)
+
+func TestClusterTaskInteractiveStartE2E(t *testing.T) {
+	t.Parallel()
+	c, namespace := framework.Setup(t)
+	knativetest.CleanupOnInterrupt(func() { framework.TearDown(t, c, namespace) }, t.Logf)
+	defer framework.TearDown(t, c, namespace)
+
+	kubectl := cli.NewKubectl(namespace)
+	tkn, err := cli.NewTknRunner(namespace)
+	assert.NilError(t, err)
+
+	t.Logf("Creating clustertask read-task")
+	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("read-file-clustertask.yaml"))
+
+	t.Logf("Creating git pipeline resource in namespace: %s", namespace)
+	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("git-resource.yaml"))
+
+	t.Run("Get list of ClusterTasks", func(t *testing.T) {
+		res := tkn.Run("clustertask", "list")
+		expected := builder.ListAllClusterTasksOutput(t, c, map[int]interface{}{
+			0: &builder.TaskData{
+				Name: "read-task",
+			},
+		})
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Err:      icmd.None,
+			Out:      expected,
+		})
+	})
+
+	t.Run("Start ClusterTask with flags", func(t *testing.T) {
+		res := tkn.MustSucceed(t, "clustertask", "start", "read-task",
+			"-i=source="+tePipelineGitResourceName,
+			"-p=FILENAME=docs/README.md",
+			"-w=name=shared-workspace,emptyDir=",
+			"--showlog",
+			"true")
+
+		vars := make(map[string]interface{})
+		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[0].Name
+		vars["Taskrun"] = taskRunGeneratedName
+		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
+Waiting for logs to be available...
+.*)`, vars)
+		assert.Assert(t, is.Regexp(expected, res.Stdout()))
+	})
+
+	t.Run("Start ClusterTask interactively", func(t *testing.T) {
+		tkn.RunInteractiveTests(t, &cli.Prompt{
+			CmdArgs: []string{"clustertask", "start", "read-task", "-w=name=shared-workspace,emptyDir="},
+			Procedure: func(c *expect.Console) error {
+				if _, err := c.ExpectString("Choose the git resource to use for source:"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
+				if _, err := c.ExpectString("Value for param `FILENAME` of type `string`?"); err != nil {
+					return err
+				}
+				if _, err := c.SendLine("docs/README.md"); err != nil {
+					return err
+				}
+				if _, err := c.ExpectEOF(); err != nil {
+					return err
+				}
+
+				c.Close()
+				return nil
+			}})
+	})
+}

--- a/test/framework/clients.go
+++ b/test/framework/clients.go
@@ -30,6 +30,7 @@ type Clients struct {
 
 	PipelineClient         v1alpha1.PipelineInterface
 	TaskClient             v1alpha1.TaskInterface
+	ClusterTaskClient      v1alpha1.ClusterTaskInterface
 	TaskRunClient          v1alpha1.TaskRunInterface
 	PipelineRunClient      v1alpha1.PipelineRunInterface
 	PipelineResourceClient resourcev1alpha1.PipelineResourceInterface
@@ -65,6 +66,7 @@ func NewClients(configPath, clusterName, namespace string) *Clients {
 	}
 	c.PipelineClient = cs.TektonV1alpha1().Pipelines(namespace)
 	c.TaskClient = cs.TektonV1alpha1().Tasks(namespace)
+	c.ClusterTaskClient = cs.TektonV1alpha1().ClusterTasks()
 	c.TaskRunClient = cs.TektonV1alpha1().TaskRuns(namespace)
 	c.PipelineRunClient = cs.TektonV1alpha1().PipelineRuns(namespace)
 	c.PipelineResourceClient = rcs.TektonV1alpha1().PipelineResources(namespace)

--- a/test/resources/read-file-clustertask.yaml
+++ b/test/resources/read-file-clustertask.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1alpha1
+kind: ClusterTask
+metadata:
+  name: read-task
+spec:
+  workspaces:
+    - name: shared-workspace
+  inputs:
+    params:
+      - name: FILENAME
+    resources:
+      - name: source
+        type: git
+  steps:
+    - name: read-file-content
+      image: ubuntu
+      script: "cat $(inputs.resources.source.path)/$(inputs.params.FILENAME)"


### PR DESCRIPTION
# Changes

This adds interactive mode to start a clustertask similar to task and pipeline start command to maintain consistency and also added `--workspace` flag as Workspaces needs to be used at the time of interactive start.

Closes #1013 
Closes #958 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```release-note
Add interactive start to ClusterTask start and also added `--workspace` flag for the interactive start
```
