### PR TITLE
Enables auto selection of task for `describe` command if only one task is present

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -65,7 +65,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
  No output resources
 {{- else }}
  NAME	TYPE
- 
+
 {{- range $or := .Task.Spec.Resources.Outputs }}
  {{decorate "bullet" $or.Name }}	{{ $or.Type }}
 {{- end }}
@@ -97,7 +97,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
  No steps
 {{- else }}
 {{- range $step := .Task.Spec.Steps }}
- {{ autoStepName $step.Name | decorate "bullet" }} 
+ {{ autoStepName $step.Name | decorate "bullet" }}
 {{- end }}
 {{- end }}
 
@@ -146,9 +146,17 @@ or
 			}
 
 			if len(args) == 0 {
-				err = askTaskName(opts, p)
+				taskNames, err := task.GetAllTaskNames(p)
 				if err != nil {
 					return err
+				}
+				if len(taskNames) == 1 {
+					opts.TaskName = taskNames[0]
+				} else {
+					err = askTaskName(opts, p)
+					if err != nil {
+						return err
+					}
 				}
 			} else {
 				opts.TaskName = args[0]

--- a/pkg/cmd/task/describe_test.go
+++ b/pkg/cmd/task/describe_test.go
@@ -82,6 +82,40 @@ func TestTaskDescribe_Empty(t *testing.T) {
 	test.AssertOutput(t, expected, out)
 }
 
+func TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent(t *testing.T) {
+	tasks := []*v1alpha1.Task{
+		tb.Task("task-1", tb.TaskNamespace("ns")),
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredT(tasks[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{Tasks: tasks, Namespaces: namespaces})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	task := Command(p)
+	out, err := test.ExecuteCommand(task, "desc")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
+}
+
 func TestTaskDescribe_OnlyName(t *testing.T) {
 	tasks := []*v1alpha1.Task{
 		tb.Task("task-1", tb.TaskNamespace("ns")),
@@ -400,6 +434,44 @@ func TestTaskDescribe_custom_output(t *testing.T) {
 	if got != expected {
 		t.Errorf("Result should be '%s' != '%s'", got, expected)
 	}
+}
+
+func TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent(t *testing.T) {
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "task-1",
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1T(tasks[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks, Namespaces: namespaces})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	task := Command(p)
+	out, err := test.ExecuteCommand(task, "desc")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
 }
 
 func TestTaskV1beta1Describe_Full(t *testing.T) {

--- a/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent.golden
@@ -1,0 +1,22 @@
+Name:        task-1
+Namespace:   ns
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Steps
+
+ No steps
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent.golden
@@ -1,0 +1,22 @@
+Name:        task-1
+Namespace:   ns
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Steps
+
+ No steps
+
+Taskruns
+
+ No taskruns


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* The `describe` command now auto selects the task if only one task is present

  E.g.  Command logs 
  
  ```
  $ ./tkn task describe
  
  Name:        echo-hello-world
  Namespace:   tekton

  📨 Input Resources

   No input resources

  📡 Output Resources

   No output resources

  ⚓ Params

   No params

  🦶 Steps

   ∙ echo

  🗂  Taskruns

   No taskruns

  ```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
