### PR TITLE
Add Workspaces in Release pipeline instead of PipelineResources

### DIFF
--- a/tekton/get-version.yaml
+++ b/tekton/get-version.yaml
@@ -3,25 +3,27 @@ kind: Task
 metadata:
   name: get-versions
 spec:
-  resources:
-    inputs:
+  workspaces:
     - name: source
-      type: git
+      mountPath: /workspace/src/$(params.package)
+  params:
+    - name: package
+      description: base package where the source code lies
   steps:
-  - name: pull
-    image: goreleaser/goreleaser
-    workingDir: /workspace/source
-    script: |
-      git status && git fetch -p --all
-  - name: get-versions
-    # because it has git
-    image: goreleaser/goreleaser
-    workingDir: /workspace/source
-    script: |
-      echo -n $(git tag --points-at HEAD) > /tekton/results/version
-      echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\1/') > /tekton/results/major
-      echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\2/') > /tekton/results/minor
+    - name: pull
+      image: goreleaser/goreleaser
+      workingDir: $(workspaces.source.path)
+      script: |
+        git status && git fetch -p --all
+    - name: get-versions
+      # because it has git
+      image: goreleaser/goreleaser
+      workingDir: $(workspaces.source.path)
+      script: |
+        echo -n $(git tag --points-at HEAD) > /tekton/results/version
+        echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\1/') > /tekton/results/major
+        echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\2/') > /tekton/results/minor
   results:
-  - name: version
-  - name: major
-  - name: minor
+    - name: version
+    - name: major
+    - name: minor

--- a/tekton/goreleaser.yml
+++ b/tekton/goreleaser.yml
@@ -3,39 +3,37 @@ kind: Task
 metadata:
   name: goreleaser
 spec:
-  params:
-  - name: package
-    description: base package to build in
-  - name: github-token-secret
-    description: name of the secret holding the github-token
-    default: bot-token-github
-  - name: github-token-secret-key
-    description: name of the secret key holding the github-token
-    default: bot-token
-  - name: flags
-    description: flags to use for the test command
-    default: --timeout=30m
-  resources:
-    inputs:
+  workspaces:
     - name: source
-      type: git
-      targetPath: src/$(params.package)
+      mountPath: /workspace/src/$(params.package)
+  params:
+    - name: package
+      description: base package to build in
+    - name: github-token-secret
+      description: name of the secret holding the github-token
+      default: bot-token-github
+    - name: github-token-secret-key
+      description: name of the secret key holding the github-token
+      default: bot-token
+    - name: flags
+      description: flags to use for the test command
+      default: --timeout=30m
   steps:
-  - name: pull
-    image: goreleaser/goreleaser:v0.132
-    workingdir: /workspace/src/$(params.package)
-    script: |
-      git status; git fetch -p --all
-  - name: release
-    image: goreleaser/goreleaser
-    workingdir: /workspace/src/$(params.package)
-    script: |
-      goreleaser release $(params.flags)
-    env:
-    - name: GOPATH
-      value: /workspace
-    - name: GITHUB_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: $(params.github-token-secret)
-          key: $(params.github-token-secret-key)
+    - name: pull
+      image: goreleaser/goreleaser:v0.132
+      workingdir: $(workspaces.source.path)
+      script: |
+        git status; git fetch -p --all
+    - name: release
+      image: goreleaser/goreleaser
+      workingdir: $(workspaces.source.path)
+      script: |
+        goreleaser release $(params.flags)
+      env:
+        - name: GOPATH
+          value: /workspace
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github-token-secret)
+              key: $(params.github-token-secret-key)

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -3,35 +3,36 @@ kind: Task
 metadata:
   name: kaniko-build-and-push
 spec:
-  params:
-  - name: DOCKERFILE
-    description: Path to the Dockerfile to build.
-    default: ./Dockerfile
-  - name: CONTEXT
-    description: The build context used by Kaniko.
-    default: ./
-  - name: EXTRA_ARGS
-    type: array
-  - name: BUILDER_IMAGE
-    description: The image on which builds will run
-    default: gcr.io/kaniko-project/executor:v0.19.0
-  resources:
-    inputs:
+  workspaces:
     - name: source
-      type: git
+      mountPath: /workspace/src/$(params.package)
+  params:
+    - name: package
+      description: base package where the source code lies
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+    - name: CONTEXT
+      description: The build context used by Kaniko.
+      default: ./
+    - name: EXTRA_ARGS
+      type: array
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run
+      default: gcr.io/kaniko-project/executor:v0.19.0
   steps:
-  - name: build-and-push
-    workingDir: /workspace/source
-    image: $(params.BUILDER_IMAGE)
-    # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
-    # https://github.com/tektoncd/pipeline/pull/706
-    env:
-    - name: DOCKER_CONFIG
-      value: /tekton/home/.docker
-    command:
-    - /kaniko/executor
-    - --dockerfile=$(params.DOCKERFILE)
-    - --context=$(params.CONTEXT)  # The user does not need to care the workspace and the source.
-    - $(params.EXTRA_ARGS)
-    securityContext:
-      runAsUser: 0
+    - name: build-and-push
+      workingDir: $(workspaces.source.path)
+      image: $(params.BUILDER_IMAGE)
+      # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+      # https://github.com/tektoncd/pipeline/pull/706
+      env:
+        - name: DOCKER_CONFIG
+          value: /tekton/home/.docker
+      command:
+        - /kaniko/executor
+        - --dockerfile=$(params.DOCKERFILE)
+        - --context=$(params.CONTEXT) # The user does not need to care the workspace and the source.
+        - $(params.EXTRA_ARGS)
+      securityContext:
+        runAsUser: 0

--- a/tekton/release-pipeline-run.yml
+++ b/tekton/release-pipeline-run.yml
@@ -1,24 +1,28 @@
 ---
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
+apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
-  name: tektoncd-cli-git
+  name: tektoncd-cli-pvc
 spec:
-  type: git
-  params:
-  - name: revision
-    value: v0.2.2
-  - name: url
-    value: https://github.com/tektoncd/cli
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  generateName: cli-release-pipeline-run
+  generateName: cli-release-pipeline-run-
 spec:
   pipelineRef:
     name: cli-release-pipeline
-  resources:
-    - name: source
-      resourceRef:
-        name: tektoncd-cli-git
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: tektoncd-cli-pvc
+  params:
+    - name: revision
+      value: v0.2.2
+    - name: url
+      value: https://github.com/tektoncd/cli

--- a/tekton/release-pipeline-run.yml
+++ b/tekton/release-pipeline-run.yml
@@ -1,15 +1,4 @@
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: tektoncd-cli-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 500Mi
----
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -19,8 +8,13 @@ spec:
     name: cli-release-pipeline
   workspaces:
     - name: shared-workspace
-      persistentvolumeclaim:
-        claimName: tektoncd-cli-pvc
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi
   params:
     - name: revision
       value: v0.2.2

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -4,25 +4,44 @@ kind: Pipeline
 metadata:
   name: cli-release-pipeline
 spec:
+  workspaces:
+    - name: shared-workspace
   params:
-  - name: package
-    description: package to release
-    default: github.com/tektoncd/cli
-  - name: github-token-secret
-    description: name of the secret holding the github-token
-    default: bot-token-github
-  - name: github-token-secret-key
-    description: name of the key for the secret holding the github-token
-    default: bot-token
-  resources:
-  - name: source
-    type: git
+    - name: url
+      description: git url to clone
+    - name: revision
+      description: revision branch to checkout
+    - name: package
+      description: package to release
+      default: github.com/tektoncd/cli
+    - name: github-token-secret
+      description: name of the secret holding the github-token
+      default: bot-token-github
+    - name: github-token-secret-key
+      description: name of the key for the secret holding the github-token
+      default: bot-token
   tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.url)
+        - name: revision
+          value: $(params.revision)
+        - name: deleteExisting
+          value: "true"
     - name: get-versions
-      resources:
-        inputs:
+      runAfter: [fetch-repository]
+      workspaces:
         - name: source
-          resource: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: $(params.package)
       taskRef:
         name: get-versions
     - name: lint
@@ -30,16 +49,15 @@ spec:
       taskRef:
         name: golangci-lint
       params:
-      - name: package
-        value: $(params.package)
-      - name: flags
-        value: "-v --timeout 10m"
-      - name: version
-        value: v1.24.0
-      resources:
-        inputs:
+        - name: package
+          value: $(params.package)
+        - name: flags
+          value: "-v --timeout 10m"
+        - name: version
+          value: v1.24.0
+      workspaces:
         - name: source
-          resource: source
+          workspace: shared-workspace
     - name: unit-tests
       runAfter: [lint]
       taskRef:
@@ -51,10 +69,9 @@ spec:
           value: 1.13.8
         - name: flags
           value: -v -mod=vendor
-      resources:
-        inputs:
-          - name: source
-            resource: source
+      workspaces:
+        - name: source
+          workspace: shared-workspace
     - name: build
       runAfter: [lint]
       taskRef:
@@ -66,43 +83,42 @@ spec:
           value: 1.13.8
         - name: flags
           value: -v -mod=vendor
-      resources:
-        inputs:
-          - name: source
-            resource: source
+      workspaces:
+        - name: source
+          workspace: shared-workspace
     - name: publish
       runAfter: [build, unit-tests]
       taskRef:
         name: kaniko-build-and-push
       params:
-      - name: DOCKERFILE
-        value: contrib/tkn-image/Dockerfile
-      - name: EXTRA_ARGS
-        value:
-        - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:latest
-        - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:$(tasks.get-versions.results.version)
-        - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:v$(tasks.get-versions.results.major)
-        - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:v$(tasks.get-versions.results.major).$(tasks.get-versions.results.minor)
-        - --destination=gcr.io/tekton-releases/tkn:latest
-        - --destination=gcr.io/tekton-releases/tkn:$(tasks.get-versions.results.version)
-        - --destination=gcr.io/tekton-releases/tkn:v$(tasks.get-versions.results.major)
-        - --destination=gcr.io/tekton-releases/tkn:v$(tasks.get-versions.results.major).$(tasks.get-versions.results.minor)
-      resources:
-        inputs:
+        - name: DOCKERFILE
+          value: contrib/tkn-image/Dockerfile
+        - name: package
+          value: $(params.package)
+        - name: EXTRA_ARGS
+          value:
+            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:latest
+            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:$(tasks.get-versions.results.version)
+            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:v$(tasks.get-versions.results.major)
+            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:v$(tasks.get-versions.results.major).$(tasks.get-versions.results.minor)
+            - --destination=gcr.io/tekton-releases/tkn:latest
+            - --destination=gcr.io/tekton-releases/tkn:$(tasks.get-versions.results.version)
+            - --destination=gcr.io/tekton-releases/tkn:v$(tasks.get-versions.results.major)
+            - --destination=gcr.io/tekton-releases/tkn:v$(tasks.get-versions.results.major).$(tasks.get-versions.results.minor)
+      workspaces:
         - name: source
-          resource: source
+          workspace: shared-workspace
     - name: release
       runAfter: [build, unit-tests]
       taskRef:
         name: goreleaser
       params:
-      - name: package
-        value: $(params.package)
-      - name: github-token-secret
-        value: $(params.github-token-secret)
-      - name: github-token-secret-key
-        value: $(params.github-token-secret-key)
-      resources:
-        inputs:
+        - name: package
+          value: $(params.package)
+        - name: github-token-secret
+          value: $(params.github-token-secret)
+        - name: github-token-secret-key
+          value: $(params.github-token-secret-key)
+      workspaces:
         - name: source
-          resource: source
+          workspace: shared-workspace

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -137,20 +137,6 @@ kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/release-pipeline.yml
 
 sleep 2
 
-# Until tkn supports tkn create with parameters we do like this,
-cat <<EOF | kubectl -n ${TARGET_NAMESPACE} apply -f-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: tektoncd-cli-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 500Mi
-EOF
-
 # Start the pipeline, We can't use tkn start because until #272 and #262 are imp/fixed
 cat <<EOF | kubectl -n ${TARGET_NAMESPACE} create -f-
 apiVersion: tekton.dev/v1beta1
@@ -162,8 +148,13 @@ spec:
     name: cli-release-pipeline
   workspaces:
     - name: shared-workspace
-      persistentvolumeclaim:
-        claimName: tektoncd-cli-pvc
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi
   params:
     - name: revision
       value: ${RELEASE_VERSION}


### PR DESCRIPTION
# Changes

Currently release pipeline is using PipelineResources so instead of that we are replacing them with workspaces and also adding the git-clone task.

Closes #1019 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._