### PR TITLE
Fix pipelinerun logs error

### DIFF
--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -905,10 +905,10 @@ func TestLogs_nologs(t *testing.T) {
 	}
 	prlo := logOptsv1aplha1(prName, ns, cs, dc, fake.Streamer([]fake.Log{}), false, false)
 	output, err := fetchLogs(prlo)
-	if err == nil {
-		t.Errorf("Unexpected output: %v", output)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
-	test.AssertOutput(t, "pipelinerun has not started yet", err.Error())
+	test.AssertOutput(t, "PipelineRun is still running: Running\n", output)
 }
 
 func TestLog_run_failed_with_and_without_follow(t *testing.T) {
@@ -1027,7 +1027,7 @@ func TestLog_pipelinerun_still_running(t *testing.T) {
 				tb.PipelineRunStatusCondition(apis.Condition{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionTrue,
-					Message: "Running",
+					Message: "Completed",
 				}),
 			),
 		),
@@ -1948,10 +1948,10 @@ func TestLogs_nologs_v1beta1(t *testing.T) {
 	}
 	prlo := logOptsv1beta1(prName, ns, cs, dc, fake.Streamer([]fake.Log{}), false, false)
 	output, err := fetchLogs(prlo)
-	if err == nil {
-		t.Errorf("Unexpected output: %v", output)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
-	test.AssertOutput(t, "pipelinerun has not started yet", err.Error())
+	test.AssertOutput(t, "PipelineRun is still running: Running\n", output)
 }
 
 func TestLog_run_failed_with_and_without_follow_v1beta1(t *testing.T) {

--- a/pkg/log/pipeline_reader.go
+++ b/pkg/log/pipeline_reader.go
@@ -158,10 +158,14 @@ func (r *Reader) waitUntilAvailable(timeout time.Duration) error {
 			}
 		case <-time.After(timeout * time.Second):
 			watchRun.Stop()
-			if err = hasPipelineRunFailed(run.Status.Conditions); err != nil {
-				return fmt.Errorf("pipelinerun %s has failed", run.Name)
+			if isPipelineRunRunning(run.Status.Conditions) {
+				fmt.Fprintln(r.stream.Out, "PipelineRun is still running:", run.Status.Conditions[0].Message)
+				return nil
 			}
-			return fmt.Errorf("pipelinerun has not started yet")
+			if err = hasPipelineRunFailed(run.Status.Conditions); err != nil {
+				return fmt.Errorf("PipelineRun %s has failed: %s", run.Name, err.Error())
+			}
+			return fmt.Errorf("PipelineRun has not started yet")
 		}
 	}
 }
@@ -232,6 +236,13 @@ func hasPipelineRunFailed(prConditions duckv1beta1.Conditions) error {
 		return fmt.Errorf("pipelinerun has failed: %s", prConditions[0].Message)
 	}
 	return nil
+}
+
+func isPipelineRunRunning(prConditions duckv1beta1.Conditions) bool {
+	if len(prConditions) != 0 && prConditions[0].Status == corev1.ConditionUnknown {
+		return true
+	}
+	return false
 }
 
 func cast2pipelinerun(obj runtime.Object) (*v1beta1.PipelineRun, error) {


### PR DESCRIPTION
This will fix the error of pipelinerun log
which was showing pipelinerun not started
in case of pipelinerun is running

Fix #998

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix pipelinerun logs error in case of running pipeline
```
