### PR TITLE
Support VolumeClaimTemplates with --workspace for tkn start Commands

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -274,7 +274,7 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 	}
 	pr.Spec.Params = param
 
-	workspaces, err := workspaces.Merge(pr.Spec.Workspaces, opt.Workspaces)
+	workspaces, err := workspaces.Merge(pr.Spec.Workspaces, opt.Workspaces, opt.cliparams)
 	if err != nil {
 		return err
 	}
@@ -736,8 +736,8 @@ func NameArg(args []string, p cli.Params, file string) (*v1beta1.Pipeline, error
 	return pipelineFile, nil
 }
 
-func parsePipeline(taskLocation string, p cli.Params) (*v1beta1.Pipeline, error) {
-	b, err := file.LoadFileContent(p, taskLocation, file.IsYamlFile(), fmt.Errorf("invalid file format for %s: .yaml or .yml file extension and format required", taskLocation))
+func parsePipeline(pipelineLocation string, p cli.Params) (*v1beta1.Pipeline, error) {
+	b, err := file.LoadFileContent(p, pipelineLocation, file.IsYamlFile(), fmt.Errorf("invalid file format for %s: .yaml or .yml file extension and format required", pipelineLocation))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -335,7 +335,7 @@ func startTask(opt startOptions, args []string) error {
 	}
 	tr.ObjectMeta.Labels = labels
 
-	workspaces, err := workspaces.Merge(tr.Spec.Workspaces, opt.Workspaces)
+	workspaces, err := workspaces.Merge(tr.Spec.Workspaces, opt.Workspaces, opt.cliparams)
 	if err != nil {
 		return err
 	}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -41,12 +41,16 @@ func LoadFileContent(p cli.Params, target string, validate TypeValidator, errorM
 	}
 
 	var content []byte
-	cs, err := p.Clients()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tekton client")
+	var cs *cli.Clients
+	var err error
+	if p != nil {
+		cs, err = p.Clients()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create tekton client")
+		}
 	}
 
-	if strings.HasPrefix(target, "http") {
+	if strings.HasPrefix(target, "http") && cs != nil {
 		content, err = getRemoteContent(cs, target)
 	} else {
 		content, err = ioutil.ReadFile(target)

--- a/pkg/workspaces/testdata/pvc-typo.yaml
+++ b/pkg/workspaces/testdata/pvc-typo.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vctname
+spec:
+  storageClassNam: "storageclassname"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi

--- a/pkg/workspaces/testdata/pvc.yaml
+++ b/pkg/workspaces/testdata/pvc.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vctname
+spec:
+  storageClassName: "storageclassname"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi

--- a/pkg/workspaces/workspaces_test.go
+++ b/pkg/workspaces/workspaces_test.go
@@ -17,10 +17,13 @@ package workspaces
 import (
 	"testing"
 
+	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMerge(t *testing.T) {
@@ -41,49 +44,49 @@ func TestMerge(t *testing.T) {
 	}
 
 	optWS := []string{}
-	outWS, err := Merge(ws, optWS)
+	outWS, err := Merge(ws, optWS, nil)
 	if err != nil {
-		t.Errorf("Not expected error:" + err.Error())
+		t.Errorf("Not expected error: " + err.Error())
 	}
 	test.AssertOutput(t, ws, outWS)
 
 	optWS = []string{"test"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 	test.AssertOutput(t, "Name not found for workspace", err.Error())
 
 	optWS = []string{"name"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 	test.AssertOutput(t, "Name not found for workspace", err.Error())
 
 	optWS = []string{"name=test,configsecret=wrong"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 	test.AssertOutput(t, invalidWorkspace+optWS[0], err.Error())
 
 	optWS = []string{"name=emptydir-data-hp,emptyDir=s3"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 	test.AssertOutput(t, invalidWorkspace+optWS[0], err.Error())
 
 	optWS = []string{"name=recipe-store,config=sensitive-recipe-storage,item=brownies"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 	test.AssertOutput(t, "invalid key value", err.Error())
 
 	optWS = []string{"name=recipe-store,secret=secret-name,item=brownies"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -91,7 +94,7 @@ func TestMerge(t *testing.T) {
 
 	optWS = []string{"name=recipe-store,config=sensitive-recipe-storage," +
 		"secret=secret-name,item=brownies=recipe.txt"}
-	_, err = Merge(ws, optWS)
+	_, err = Merge(ws, optWS, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -102,13 +105,29 @@ func TestMerge(t *testing.T) {
 		"name=emptydir-data-hp,emptyDir=HugePages",
 		"name=emptydir-data-mem,emptyDir=Memory",
 		"name=emptydir-data,emptyDir=",
-		"name=shared-data-path,claimName=pvc3,subPath=dir"}
-	outWS, err = Merge(ws, optWS)
+		"name=shared-data-path,claimName=pvc3,subPath=dir",
+	}
+	outWS, err = Merge(ws, optWS, nil)
 	if err != nil {
-		t.Errorf("Not expected error:" + err.Error())
+		t.Errorf("Not expected error: " + err.Error())
 	}
 	test.AssertOutput(t, 7, len(outWS))
 
+	var p cli.Params
+	optWS = []string{"name=volumeclaimtemplatews,volumeClaimTemplateFile=./testdata/pvc.yaml"}
+	outWS, err = Merge(ws, optWS, p)
+	if err != nil {
+		t.Errorf("Not expected error: " + err.Error())
+	}
+
+	optWS = []string{"name=volumeclaimtemplatews,volumeClaimTemplateFile=./testdata/pvc-typo.yaml"}
+	_, err = Merge(ws, optWS, p)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+	test.AssertOutput(t, "error unmarshaling JSON: while decoding JSON: json: unknown field \"storageClassNam\"", err.Error())
+
+	storageClassName := "storageclassname"
 	expectedWS := []v1beta1.WorkspaceBinding{
 		{Name: "foo", ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "bar"}}},
 		{Name: "emptydir-data", EmptyDir: &corev1.EmptyDirVolumeSource{}},
@@ -137,6 +156,29 @@ func TestMerge(t *testing.T) {
 			SubPath:               "dir",
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc3"},
 		},
+		{
+			Name: "volumeclaimtemplatews",
+			VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolumeClaim",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vctname",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: &storageClassName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("50Mi"),
+						},
+					},
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+				},
+			},
+		},
 	}
 
 	for i := range outWS {
@@ -155,6 +197,8 @@ func TestMerge(t *testing.T) {
 			test.AssertOutput(t, expectedWS[5], outWS[i])
 		case "shared-data-path":
 			test.AssertOutput(t, expectedWS[6], outWS[i])
+		case "volumeclaimtemplatews":
+			test.AssertOutput(t, expectedWS[7], outWS[i])
 		}
 	}
 }

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -210,4 +211,13 @@ func (e TknRunner) RunInteractiveTestsDummy(t *testing.T, ops *Prompt) *expect.C
 	assert.NilError(t, cmd.Wait())
 
 	return c
+}
+
+// TODO: Re-write this to just get the version of Tekton components through tkn version
+// as described in https://github.com/tektoncd/cli/issues/1067
+func (e TknRunner) CheckVersion(component string, version string) bool {
+	cmd := append([]string{e.path}, "version")
+	result := icmd.RunCmd(icmd.Cmd{Command: cmd, Timeout: timeout})
+
+	return strings.Contains(result.Stdout(), component+" version: "+version)
 }

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -173,8 +173,7 @@ func TestPipelinesE2E(t *testing.T) {
 	t.Run("Start PipelineRun using pipeline start command with SA as 'pipeline' ", func(t *testing.T) {
 		res := tkn.Run("pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineGitResourceName,
-			"--showlog",
-			"true")
+			"--showlog")
 
 		time.Sleep(1 * time.Second)
 
@@ -268,6 +267,37 @@ Waiting for logs to be available...
 				c.Close()
 				return nil
 			}})
+	})
+
+	t.Logf("Creating Pipeline volume-from-template in namespace: %s", namespace)
+	e2e.Assert(t, kubectl.Create(e2e.ResourcePath("pipeline-with-workspace.yaml")), icmd.Success)
+
+	t.Run("Start PipelineRun with --workspace and volumeClaimTemplate", func(t *testing.T) {
+		if tkn.CheckVersion("Pipeline", "v0.10.2") {
+			t.Skip("Skip test as pipeline v0.10.2 doesn't support volumeClaimTemplates")
+		}
+
+		res := tkn.Run("pipeline", "start", "pipeline-with-workspace",
+			"--workspace=name=ws,volumeClaimTemplateFile="+e2e.ResourcePath("pvc.yaml"),
+			"--showlog")
+
+		time.Sleep(1 * time.Second)
+
+		pipelineRunGeneratedName := e2e.GetPipelineRunListWithName(c, "pipeline-with-workspace").Items[0].Name
+		vars["Element"] = pipelineRunGeneratedName
+		expected := e2e.ProcessString(`(PipelineRun started: {{.Element}}
+Waiting for logs to be available...
+.*)`, vars)
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Err:      icmd.None,
+		})
+		assert.Assert(t, is.Regexp(expected, res.Stdout()))
+
+		timeout := 5 * time.Minute
+		if err := e2e.WaitForPipelineRunState(c, pipelineRunGeneratedName, timeout, e2e.PipelineRunSucceed(pipelineRunGeneratedName), "PipelineRunSucceeded"); err != nil {
+			t.Errorf("Error waiting for PipelineRun to Succeed: %s", err)
+		}
 	})
 }
 

--- a/test/resources/pipeline-with-workspace.yaml
+++ b/test/resources/pipeline-with-workspace.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline-with-workspace
+spec:
+  tasks:
+    - name: reader
+      taskSpec:
+        steps:
+          - name: list-files
+            image: ubuntu
+            script: ls $(workspaces.myws.path)
+        workspaces:
+          - name: myws
+      workspaces:
+        - name: myws
+          workspace: ws
+  workspaces:
+    - name: ws

--- a/test/resources/pvc.yaml
+++ b/test/resources/pvc.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to create PersistentVolumeClaim from VolumeClaimTemplate
+
+metadata:
+  name: pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/resources/task-with-workspace.yaml
+++ b/test/resources/task-with-workspace.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-with-workspace
+spec:
+  steps:
+  - name: list-files
+    image: ubuntu
+    script: ls $(workspaces.write-allowed.path)
+  workspaces:
+  - name: read-allowed


### PR DESCRIPTION
Closes #1006 

This pull request adds the ability to create PersistentVolumeClaims based off a volumeClaimTemplate for PipelineRun/TaskRun workspaces.

The proposed UX will be as follows:

```
tkn p start pipeline-with-workspace --workspace name=ws,volumeClaimTemplateFile=/path/to/pvc.yaml
```

If `volumeClaimTemplateFile` is specified, other `--workspace` options are ignored. An example file for a volumeClaimTemplate is shown below:

```yaml
metadata:
  name: pvc
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 1Gi
```

In the future, it might be helpful to also support some override options to allow users to specify values via `tkn` at run time instead of via a file definition. 

Only YAML files will be supported initially.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

 ```release-note
Allow users to specify a volumeClaimTemplate for PipelineRuns/TaskRuns via the --workspace option with tkn pipeline/task start
 ```

