### PR TITLE
panic when there are no TR/PR present in the namespace while using (--last) option with (describe)

### DIFF
--- a/pkg/cmd/pipelinerun/describe.go
+++ b/pkg/cmd/pipelinerun/describe.go
@@ -84,6 +84,10 @@ or
 					if err != nil {
 						return err
 					}
+					if len(prs) == 0 {
+						fmt.Fprintf(s.Out, "No PipelineRuns present in namespace %s\n", opts.Params.Namespace())
+						return nil
+					}
 					opts.PipelineRunName = strings.Fields(prs[0])[0]
 				}
 			} else {

--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -84,6 +84,10 @@ or
 					if err != nil {
 						return err
 					}
+					if len(trs) == 0 {
+						fmt.Fprintf(s.Out, "No TaskRuns present in namespace %s\n", opts.Params.Namespace())
+						return nil
+					}
 					opts.TaskrunName = strings.Fields(trs[0])[0]
 				}
 			} else {


### PR DESCRIPTION
Fixes [1068](https://github.com/tektoncd/cli/issues/1068)
tkn TR/PR describe --last command resulted in panic when there are no TR/PR present in the namespace.
Fixed it to give an error message when no TR/PR is present in the namespace.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
