### PR TITLE
Display results in the output of task/taskrun describe command

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -91,6 +91,17 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
 {{- end }}
 {{- end }}
 
+{{decorate "results" ""}}{{decorate "underline bold" "Results\n"}}
+
+{{- if eq (len .Task.Spec.Results) 0 }}
+ No results
+{{- else }}
+ NAME	DESCRIPTION
+{{- range $result := .Task.Spec.Results }}
+ {{ decorate "bullet" $result.Name }}	{{ formatDesc $result.Description }}
+{{- end }}
+{{- end }}
+
 {{decorate "steps" ""}}{{decorate "underline bold" "Steps\n"}}
 
 {{- if eq (len .Task.Spec.Steps) 0 }}

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
@@ -23,6 +23,10 @@ Params
  print     string   params with sting t...   somethingdifferent
  output    array                             [booms booms booms]
 
+Results
+
+ No results
+
 Steps
 
  hello

--- a/pkg/cmd/task/testdata/TestTaskDescribe_OnlyName.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_OnlyName.golden
@@ -13,6 +13,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameDiffNameSpace.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameDiffNameSpace.golden
@@ -13,6 +13,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameParams.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameParams.golden
@@ -16,6 +16,10 @@ Params
  myprint   string   testing very long d...   ---
  myarray   array                             ---
 
+Results
+
+ No results
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_Results.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_Results.golden
@@ -1,0 +1,30 @@
+Name:          task-1
+Namespace:     ns
+Description:   a test description
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ NAME       DESCRIPTION
+ result-1   This is a descripti...
+ result-2   This is a descripti...
+ result-3   
+
+Steps
+
+ hello
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent.golden
@@ -13,6 +13,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent.golden
@@ -13,6 +13,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
@@ -23,6 +23,10 @@ Params
  print     string                 somethingdifferent
  output    array                  [booms booms booms]
 
+Results
+
+ No results
+
 Steps
 
  hello

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Results.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Results.golden
@@ -1,14 +1,13 @@
 Name:        tr-1
 Namespace:   ns
+Task Ref:    task-1
+Labels:
+ tekton.dev/task=task-1
 
 Status
 
-STARTED         DURATION    STATUS
-8 minutes ago   3 minutes   Failed
-
-Message
-
-Testing tr failed
+STARTED          DURATION    STATUS
+10 minutes ago   5 minutes   Failed
 
 Input Resources
 
@@ -24,7 +23,9 @@ Params
 
 Results
 
- No results
+ NAME       VALUE
+ result-1   value-1
+ result-2   value-2
 
 Steps
 

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
@@ -22,6 +22,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
@@ -22,6 +22,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
@@ -24,6 +24,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_last.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_last.golden
@@ -26,6 +26,10 @@ Params
  input    param
  input2   param2
 
+Results
+
+ No results
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_lastV1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_lastV1beta1.golden
@@ -21,6 +21,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
@@ -26,6 +26,10 @@ Params
  input    param
  input2   param2
 
+Results
+
+ No results
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
@@ -26,6 +26,10 @@ Params
  input    param
  input2   param2
 
+Results
+
+ No results
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
@@ -26,6 +26,10 @@ Params
  input    param
  input2   param2
 
+Results
+
+ No results
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
@@ -26,6 +26,10 @@ Params
  input    param
  input2   param2
 
+Results
+
+ No results
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
@@ -26,6 +26,10 @@ Params
  input    param
  input2   param2
 
+Results
+
+ No results
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
@@ -19,6 +19,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
 No steps

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -68,6 +68,8 @@ func DecorateAttr(attrString, message string) string {
 		return "🗂  "
 	case "sidecars":
 		return "🚗 "
+	case "results":
+		return "📝 "
 	}
 
 	attr := color.Reset

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -80,13 +80,13 @@ func TestDecoration(t *testing.T) {
 	funcMap := template.FuncMap{
 		"decorate": DecorateAttr,
 	}
-	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
+	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
 	processed := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(aTemplate))
 	buf := new(bytes.Buffer)
 
 	if err := processed.Execute(buf, nil); err != nil {
 		t.Error("Could not process the template.")
 	}
-	test.AssertOutput(t, "∙ Foo ✔ ️📦 ⚓ 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
+	test.AssertOutput(t, "∙ Foo ✔ ️📦 ⚓ 📝 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
 
 }

--- a/pkg/formatted/results.go
+++ b/pkg/formatted/results.go
@@ -1,0 +1,23 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import "strings"
+
+// Result will format a given result value
+func Result(value string) string {
+	// remove trailing new-line from value
+	return strings.TrimSuffix(value, "\n")
+}

--- a/pkg/formatted/results_test.go
+++ b/pkg/formatted/results_test.go
@@ -1,0 +1,50 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import "testing"
+
+func TestResult(t *testing.T) {
+	tt := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "Empty value in the result",
+			value: "",
+			want:  "",
+		},
+		{
+			name:  "Proper value in the result",
+			value: "sha: 2r17r2176r7\n",
+			want:  "sha: 2r17r2176r7",
+		},
+		{
+			name:  "Empty line in the result",
+			value: "\n",
+			want:  "",
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			got := Result(test.value)
+			if got != test.want {
+				t.Fatalf("Result failed: got %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/taskrun/description/description.go
+++ b/pkg/taskrun/description/description.go
@@ -115,6 +115,17 @@ STARTED 	DURATION 	STATUS
 {{- end }}
 {{- end }}
 
+{{decorate "results" ""}}{{decorate "underline bold" "Results\n"}}
+
+{{- if eq (len .TaskRun.Status.TaskRunResults) 0 }}
+ No results
+{{- else }}
+ NAME	VALUE
+{{- range $result := .TaskRun.Status.TaskRunResults }}
+ {{decorate "bullet" $result.Name }}	{{ formatResult $result.Value }}
+{{- end }}
+{{- end }}
+
 {{decorate "steps" ""}}{{decorate "underline bold" "Steps"}}
 {{$sortedSteps := sortStepStates .TaskRun.Status.Steps }}
 {{- $l := len $sortedSteps }}{{ if eq $l 0 }}
@@ -205,6 +216,7 @@ func PrintTaskRunDescription(s *cli.Stream, trName string, p cli.Params) error {
 		"formatAge":             formatted.Age,
 		"formatDuration":        formatted.Duration,
 		"formatCondition":       formatted.Condition,
+		"formatResult":          formatted.Result,
 		"hasFailed":             hasFailed,
 		"taskRefExists":         taskRefExists,
 		"taskResourceRefExists": taskResourceRefExists,


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The results declared in the task will be displayed in the output of task/taskrun describe command
* Result name and description will be displayed in the output of `tkn task describe` command
* Result name and value will be displayed in the output of `tkn taskrun describe` command

Fixes: #1046 

Signed-off-by: Chetan Banavikalmutt <cbanavik@redhat.com>
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```
Display results in the output of task/taskrun describe command
```
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
