### PR TITLE
adds finally logs in pipelinerun

### DIFF
--- a/pkg/log/pipeline_reader.go
+++ b/pkg/log/pipeline_reader.go
@@ -214,8 +214,10 @@ func (r *Reader) getOrderedTasks(pr *v1beta1.PipelineRun) ([]trh.Run, error) {
 			return nil, err
 		}
 		tasks = pl.Spec.Tasks
+		tasks = append(tasks, pl.Spec.Finally...)
 	case pr.Spec.PipelineSpec != nil:
 		tasks = pr.Spec.PipelineSpec.Tasks
+		tasks = append(tasks, pr.Spec.PipelineSpec.Finally...)
 	default:
 		return nil, fmt.Errorf("pipelinerun %s did not provide PipelineRef or PipelineSpec", pr.Name)
 	}

--- a/pkg/pipelinerun/tracker_test.go
+++ b/pkg/pipelinerun/tracker_test.go
@@ -21,6 +21,7 @@ import (
 	trh "github.com/tektoncd/cli/pkg/taskrun"
 	"github.com/tektoncd/cli/pkg/test"
 	clitest "github.com/tektoncd/cli/pkg/test"
+	cb "github.com/tektoncd/cli/pkg/test/builder"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -155,7 +156,7 @@ func startPipelineRun(t *testing.T, data pipelinetest.Data, prStatus ...v1alpha1
 	// to keep pushing the taskrun over the period(simulate watch)
 	watcher := watch.NewFake()
 	cs.Pipeline.PrependWatchReactor("pipelineruns", k8stest.DefaultWatchReactor(watcher, nil))
-
+	cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"task", "taskrun", "pipeline", "pipelinerun"})
 	go func() {
 		for _, status := range prStatus {
 			time.Sleep(time.Second * 2)

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -19,7 +19,10 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"testing"
 	"text/template"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Process(t *template.Template, vars interface{}) string {
@@ -48,4 +51,23 @@ func ResourcePath(elem ...string) string {
 	tmp := dir()
 	path := append([]string{tmp}, elem...)
 	return filepath.Join(path...)
+}
+
+func AssertOutput(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	diff := cmp.Diff(actual, expected)
+	if diff == "" {
+		return
+	}
+
+	t.Errorf(`
+Unexpected output:
+%s
+
+Expected
+%s
+
+Actual
+%s
+`, diff, expected, actual)
 }

--- a/test/e2e/pipelinerun/pipelinerun_test.go
+++ b/test/e2e/pipelinerun/pipelinerun_test.go
@@ -1,0 +1,55 @@
+// +build e2e
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/cli/test/e2e"
+	"gotest.tools/v3/icmd"
+	knativetest "knative.dev/pkg/test"
+)
+
+func TestPipelineRunLogE2E(t *testing.T) {
+	t.Parallel()
+	c, namespace := e2e.Setup(t)
+	knativetest.CleanupOnInterrupt(func() { e2e.TearDown(t, c, namespace) }, t.Logf)
+	defer e2e.TearDown(t, c, namespace)
+
+	kubectl := e2e.NewKubectl(namespace)
+	tkn, err := e2e.NewTknRunner(namespace)
+	if err != nil {
+		t.Fatalf("Error creating tknRunner %+v", err)
+	}
+
+	if tkn.CheckVersion("Pipeline", "v0.10.2") {
+		t.Skip("Skip test as pipeline v0.10.2 doesn't support finally")
+	}
+
+	t.Logf("Creating pipelinerun in namespace: %s", namespace)
+	e2e.Assert(t, kubectl.Create(e2e.ResourcePath("pipelinerun-with-finally.yaml")), icmd.Success)
+
+	t.Run("Pipelinerun logs with finally  "+namespace, func(t *testing.T) {
+		res := tkn.Run("pipelinerun", "logs", "exit-handler", "-f")
+		s := []string{
+			"[print-msg : main] printing a message\n",
+			"[echo-on-exit : main] finally\n",
+		}
+		expected := strings.Join(s, "\n") + "\n"
+		e2e.AssertOutput(t, expected, res.Stdout())
+	})
+}

--- a/test/resources/pipelinerun-with-finally.yaml
+++ b/test/resources/pipelinerun-with-finally.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: exit-handler
+spec:
+  pipelineSpec:
+    finally:
+      - name: echo-on-exit
+        taskSpec:
+          steps:
+            - args:
+                - echo "finally"
+              command:
+                - sh
+                - -c
+              image: library/bash:4.4.23
+              name: main
+    tasks:
+      - name: print-msg
+        taskSpec:
+          steps:
+            - args:
+                - echo "printing a message"
+              command:
+                - sh
+                - -c
+              image: library/bash:4.4.23
+              name: main


### PR DESCRIPTION
closes #1054

this adds finally logs in pipelinerun logs command in follow and
non follow mode

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
