### PR TITLE
Add deadcode to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,4 @@ linters:
   - gocritic
   - golint
   - misspell
+  - deadcode


### PR DESCRIPTION
Closes #1074 

Adding `deadcode` to golangci-lint to help prevent ununsed code.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```