### PR TITLE
Adds support for EventListener URL with List and Describe command

### DIFF
--- a/pkg/cmd/eventlistener/describe_test.go
+++ b/pkg/cmd/eventlistener/describe_test.go
@@ -274,6 +274,44 @@ func TestEventListenerDescribe_OutputYAMLWithMultipleBindingAndInterceptors(t *t
 	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
 }
 
+func TestEventListenerDescribe_WithOutputStatusURL(t *testing.T) {
+
+	els := []*v1alpha1.EventListener{
+		el.EventListener("el1", "ns",
+			el.EventListenerStatus(
+				el.EventListenerAddress("el-listener.default.svc.cluster.local"))),
+	}
+
+	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els})
+
+	p := &test.Params{Triggers: cs.Triggers, Kube: cs.Kube}
+
+	eventListener := Command(p)
+	out, err := test.ExecuteCommand(eventListener, "desc", "el1", "-o", "url", "-n", "ns")
+	if err != nil {
+		t.Errorf("Error")
+	}
+	test.AssertOutput(t, "http://el-listener.default.svc.cluster.local\n", out)
+}
+
+func TestEventListenerDescribe_OutputStatusURL_WithNoURL(t *testing.T) {
+	els := []*v1alpha1.EventListener{
+		el.EventListener("el1", "ns"),
+	}
+
+	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els})
+
+	p := &test.Params{Triggers: cs.Triggers, Kube: cs.Kube}
+
+	eventListener := Command(p)
+	out, err := test.ExecuteCommand(eventListener, "desc", "el1", "-o", "url", "-n", "ns")
+	if err == nil {
+		t.Errorf("Error")
+	}
+
+	test.AssertOutput(t, "Error: "+err.Error()+"\n", out)
+}
+
 func executeEventListenerCommand(t *testing.T, els []*v1alpha1.EventListener) {
 	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els, Namespaces: []*corev1.Namespace{{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/eventlistener/list.go
+++ b/pkg/cmd/eventlistener/list.go
@@ -115,15 +115,17 @@ func printFormatted(s *cli.Stream, els *v1alpha1.EventListenerList, p cli.Params
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "NAME\tAGE\tAVAILABLE")
+	fmt.Fprintln(w, "NAME\tAGE\tURL\tAVAILABLE")
 	for _, el := range els.Items {
+
 		status := corev1.ConditionStatus("---")
 		if len(el.Status.Conditions) > 0 && len(el.Status.Conditions[0].Status) > 0 {
 			status = el.Status.Conditions[0].Status
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 			el.Name,
 			formatted.Age(&el.CreationTimestamp, p.Time()),
+			formatted.FormatAddress(getURL(el)),
 			status,
 		)
 	}

--- a/pkg/cmd/eventlistener/list_test.go
+++ b/pkg/cmd/eventlistener/list_test.go
@@ -51,9 +51,12 @@ func TestListEventListener(t *testing.T) {
 	elStatusTrue := tb.EventListenerStatus(tb.EventListenerCondition("", "True", "", ""))
 	elStatusFalse := tb.EventListenerStatus(tb.EventListenerCondition("", "False", "", ""))
 	els := []*v1alpha1.EventListener{
-		tb.EventListener("tb1", "foo", cb.EventListenerCreationTime(now.Add(-2*time.Minute)), elStatusTrue),
-		tb.EventListener("tb2", "foo", cb.EventListenerCreationTime(now.Add(-30*time.Second)), elStatusTrue),
-		tb.EventListener("tb3", "foo", cb.EventListenerCreationTime(now.Add(-200*time.Hour)), elStatusTrue),
+		tb.EventListener("tb1", "foo", cb.EventListenerCreationTime(now.Add(-2*time.Minute)), tb.EventListenerStatus(
+			tb.EventListenerAddress("tb1-listener.default.svc.cluster.local")), elStatusTrue),
+		tb.EventListener("tb2", "foo", cb.EventListenerCreationTime(now.Add(-30*time.Second)), tb.EventListenerStatus(
+			tb.EventListenerAddress("tb2-listener.default.svc.cluster.local")), elStatusTrue),
+		tb.EventListener("tb3", "foo", cb.EventListenerCreationTime(now.Add(-200*time.Hour)), tb.EventListenerStatus(
+			tb.EventListenerAddress("tb3-listener.default.svc.cluster.local")), elStatusTrue),
 		tb.EventListener("tb4", "foo"),
 		tb.EventListener("tb5", "foo", cb.EventListenerCreationTime(now.Add(-10*time.Second)), elStatusFalse),
 	}

--- a/pkg/cmd/eventlistener/testdata/TestListEventListener-Multiple_EventListener.golden
+++ b/pkg/cmd/eventlistener/testdata/TestListEventListener-Multiple_EventListener.golden
@@ -1,6 +1,6 @@
-NAME   AGE              AVAILABLE
-tb1    2 minutes ago    True
-tb2    30 seconds ago   True
-tb3    1 week ago       True
-tb4    ---              ---
-tb5    10 seconds ago   False
+NAME   AGE              URL                                             AVAILABLE
+tb1    2 minutes ago    http://tb1-listener.default.svc.cluster.local   True
+tb2    30 seconds ago   http://tb2-listener.default.svc.cluster.local   True
+tb3    1 week ago       http://tb3-listener.default.svc.cluster.local   True
+tb4    ---              ---                                             ---
+tb5    10 seconds ago   ---                                             False

--- a/pkg/formatted/address.go
+++ b/pkg/formatted/address.go
@@ -1,0 +1,23 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+func FormatAddress(addressURL string) string {
+	if addressURL == "" {
+		return "---"
+	}
+
+	return addressURL
+}

--- a/pkg/formatted/address_test.go
+++ b/pkg/formatted/address_test.go
@@ -1,0 +1,37 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import (
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/test"
+)
+
+func TestFormatAddress(t *testing.T) {
+	addressURL := "http://el-listener.default.svc.cluster.local"
+
+	out := FormatAddress(addressURL)
+
+	test.AssertOutput(t, addressURL, out)
+}
+
+func TestFormatAddressWithEmptyString(t *testing.T) {
+	addressURL := ""
+
+	out := FormatAddress(addressURL)
+
+	test.AssertOutput(t, "---", out)
+}


### PR DESCRIPTION
Adds support for EventListener URL with List and Describe command …

   - `./tkn el list` will show URL of an eventlistener with name, age and status
   - `./tkn el desc <el-name> -o url` returns the URL of the eventlistener

Fixes: #1053

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
   Adds support for EventListener URL with List and Describe command
```