### PR TITLE
Modify tkn version to accept namespace as ldflag and flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 
+ifneq ($(NAMESPACE),)
+	NAMESPACELDFLAG := -X github.com/tektoncd/cli/pkg/cmd/version.namespace=$(NAMESPACE)
+endif
+
 ifneq ($(SKIP_CHECK_FLAG),)
 	SKIPLDFLAG := -X github.com/tektoncd/cli/pkg/cmd/version.skipCheckFlag=$(SKIP_CHECK_FLAG)
 endif
@@ -12,9 +16,13 @@ ifneq ($(RELEASE_VERSION),)
 	VERSIONLDFLAG := -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(RELEASE_VERSION)
 endif
 
-FLAGS := $(VERSIONLDFLAG)$(SKIPLDFLAG)
+FLAGS := $(VERSIONLDFLAG)
 ifneq ($(SKIPLDFLAG),)
-	FLAGS := $(VERSIONLDFLAG) $(SKIPLDFLAG)
+	FLAGS := $(FLAGS) $(SKIPLDFLAG)
+endif
+
+ifneq ($(NAMESPACELDFLAG),)
+	FLAGS := $(FLAGS) $(NAMESPACELDFLAG)
 endif
 
 ifneq ($(FLAGS),)

--- a/docs/cmd/tkn_version.md
+++ b/docs/cmd/tkn_version.md
@@ -15,8 +15,9 @@ Prints version information
 ### Options
 
 ```
-  -c, --check   check if a newer version is available
-  -h, --help    help for version
+  -c, --check              check if a newer version is available
+  -h, --help               help for version
+  -n, --namespace string   namespace to check installed controller version
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-version.1
+++ b/docs/man/man1/tkn-version.1
@@ -27,6 +27,10 @@ Prints version information
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for version
 
+.PP
+\fB\-n\fP, \fB\-\-namespace\fP=""
+    namespace to check installed controller version
+
 
 .SH SEE ALSO
 .PP

--- a/pkg/cmd/version/testdata/TestVersionGood.golden
+++ b/pkg/cmd/version/testdata/TestVersionGood.golden
@@ -1,4 +1,4 @@
 Client version: v1.2.3
-Pipeline version: unknown
-Triggers version: unknown
-Dashboard version: unknown
+Pipeline version: unknown, pipeline controller may be installed in another namespace please use tkn version -n {namespace}
+Triggers version: unknown, triggers controller may be installed in another namespace please use tkn version -n {namespace}
+Dashboard version: unknown, dashboard controller may be installed in another namespace please use tkn version -n {namespace}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -37,20 +37,22 @@ func TestGetPipelineVersion(t *testing.T) {
 	}
 
 	testParams := []struct {
-		name       string
-		namespace  string
-		deployment *v1.Deployment
-		want       string
+		name                  string
+		namespace             string
+		userProvidedNamespace string
+		deployment            *v1.Deployment
+		want                  string
 	}{{
 		name:       "empty deployment items",
 		namespace:  "tekton-pipelines",
 		deployment: &v1.Deployment{},
 		want:       "",
 	}, {
-		name:       "controller in different namespace (old labels)",
-		namespace:  "test",
-		deployment: getDeploymentData("dep", "", oldDeploymentLabels, nil, map[string]string{"tekton.dev/release": "v0.10.0"}),
-		want:       "v0.10.0",
+		name:                  "controller in different namespace (old labels)",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            getDeploymentData("dep", "", oldDeploymentLabels, nil, map[string]string{"tekton.dev/release": "v0.10.0"}),
+		want:                  "v0.10.0",
 	}, {
 		name:       "deployment spec does not have labels and annotations specific to version (old labels)",
 		namespace:  "tekton-pipelines",
@@ -67,10 +69,11 @@ func TestGetPipelineVersion(t *testing.T) {
 		deployment: getDeploymentData("dep3", "", oldDeploymentLabels, map[string]string{"pipeline.tekton.dev/release": "v0.11.0"}, nil),
 		want:       "v0.11.0",
 	}, {
-		name:       "controller in different namespace (new labels)",
-		namespace:  "test",
-		deployment: getDeploymentData("dep4", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "master-test"}, nil),
-		want:       "master-test",
+		name:                  "controller in different namespace (new labels)",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            getDeploymentData("dep4", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "master-test"}, nil),
+		want:                  "master-test",
 	}, {
 		name:       "deployment spec have labels specific to master version (new labels)",
 		namespace:  "tekton-pipelines",
@@ -88,7 +91,7 @@ func TestGetPipelineVersion(t *testing.T) {
 			if _, err := cls.Kube.AppsV1().Deployments(tp.namespace).Create(tp.deployment); err != nil {
 				t.Errorf("failed to create deployment: %v", err)
 			}
-			version, _ := GetPipelineVersion(cls)
+			version, _ := GetPipelineVersion(cls, tp.userProvidedNamespace)
 			test.AssertOutput(t, tp.want, version)
 		})
 	}
@@ -130,30 +133,33 @@ func TestGetTriggerVersion(t *testing.T) {
 	}
 
 	testParams := []struct {
-		name       string
-		namespace  string
-		deployment *v1.Deployment
-		want       string
+		name                  string
+		namespace             string
+		userProvidedNamespace string
+		deployment            *v1.Deployment
+		want                  string
 	}{{
 		name:       "empty deployment items",
 		namespace:  "tekton-pipelines",
 		deployment: &v1.Deployment{},
 		want:       "",
 	}, {
-		name:       "controller in different namespace (old labels)",
-		namespace:  "test",
-		deployment: getDeploymentData("dep", "", oldDeploymentLabels, nil, nil),
-		want:       "",
+		name:                  "controller in different namespace (old labels)",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            getDeploymentData("dep", "", oldDeploymentLabels, nil, nil),
+		want:                  "",
 	}, {
 		name:       "deployment spec have labels specific to version (old labels)",
 		namespace:  "tekton-pipelines",
 		deployment: getDeploymentData("dep1", "", oldDeploymentLabels, map[string]string{"triggers.tekton.dev/release": "v0.3.1"}, nil),
 		want:       "v0.3.1",
 	}, {
-		name:       "controller in different namespace (new labels)",
-		namespace:  "test",
-		deployment: getDeploymentData("dep2", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.5.0"}, nil),
-		want:       "v0.5.0",
+		name:                  "controller in different namespace (new labels)",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            getDeploymentData("dep2", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.5.0"}, nil),
+		want:                  "v0.5.0",
 	}, {
 		name:       "deployment spec have labels specific to master version (new labels)",
 		namespace:  "tekton-pipelines",
@@ -171,7 +177,7 @@ func TestGetTriggerVersion(t *testing.T) {
 			if _, err := cls.Kube.AppsV1().Deployments(tp.namespace).Create(tp.deployment); err != nil {
 				t.Errorf("failed to create deployment: %v", err)
 			}
-			version, _ := GetTriggerVersion(cls)
+			version, _ := GetTriggerVersion(cls, tp.userProvidedNamespace)
 			test.AssertOutput(t, tp.want, version)
 		})
 	}
@@ -189,30 +195,33 @@ func TestGetDashboardVersion(t *testing.T) {
 	}
 
 	testParams := []struct {
-		name       string
-		namespace  string
-		deployment *v1.Deployment
-		want       string
+		name                  string
+		namespace             string
+		userProvidedNamespace string
+		deployment            *v1.Deployment
+		want                  string
 	}{{
 		name:       "empty deployment items",
 		namespace:  "tekton-pipelines",
 		deployment: &v1.Deployment{},
 		want:       "",
 	}, {
-		name:       "dashboard in different namespace (old labels)",
-		namespace:  "test",
-		deployment: getDeploymentData("dep", "", oldDeploymentLabels, nil, nil),
-		want:       "",
+		name:                  "dashboard in different namespace (old labels)",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            getDeploymentData("dep", "", oldDeploymentLabels, nil, nil),
+		want:                  "",
 	}, {
 		name:       "deployment spec have labels specific to version (old labels)",
 		namespace:  "tekton-pipelines",
 		deployment: getDeploymentData("dep1", "", map[string]string{"app": "tekton-dashboard", "version": "v0.6.0"}, oldDeploymentLabels, nil),
 		want:       "v0.6.0",
 	}, {
-		name:       "dashboard in different namespace (new labels)",
-		namespace:  "test",
-		deployment: getDeploymentData("dep2", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.7.0"}, nil),
-		want:       "v0.7.0",
+		name:                  "dashboard in different namespace (new labels)",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            getDeploymentData("dep2", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.7.0"}, nil),
+		want:                  "v0.7.0",
 	}, {
 		name:       "deployment spec have labels specific to master version (new labels)",
 		namespace:  "tekton-pipelines",
@@ -231,7 +240,7 @@ func TestGetDashboardVersion(t *testing.T) {
 			if _, err := cls.Kube.AppsV1().Deployments(tp.namespace).Create(tp.deployment); err != nil {
 				t.Errorf("failed to create deployment: %v", err)
 			}
-			version, _ := GetDashboardVersion(cls)
+			version, _ := GetDashboardVersion(cls, tp.userProvidedNamespace)
 			test.AssertOutput(t, tp.want, version)
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
**Issue:** Authenticated user(non-admin) cannot get the `tkn version` info because of permission issue as tkn version generally looks pipeline and triggers controller deployment across the cluster(all-namespaces) and non-admin user generally doesn't have permission to view on all namespaces.

So to satisfy admin and non-admin requirements to get the `tkn-version` come up with the below solution from WG meeting
1. Provide namespace as `ldflag` during `tkn` compilation
2. User can specify namespace as flag `tkn version -n {namespace}`
3. default namespace will be `tekton-pipelines` if no `ldflag` and `-n` flag specified

**Output:**
1. Specified namespace in `ldflag` is `tekton-pipelines1` and controllers are running in `tekton-pipelines`
```
$ GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.namespace=tekton-pipelines1"
$ tkn version
Client version: dev
Pipeline version: unknown, pipeline controller may be installed in another namespace please use tkn version -n {namespace}
Triggers version: unknown, triggers controller may be installed in another namespace please use tkn version -n {namespace}
Dashboard version: unknown, dashboard controller may be installed in another namespace please use tkn version -n {namespace}

```

2. Specified correct namespace where controllers are running using `flag`
```
$ tkn version -n tekton-pipelines
Client version: dev
Pipeline version: v0.14.2
Triggers version: devel
Dashboard version: v0.9.0

```
3. Built tkn binary from master code
By default `tkn version` looks Deployment in `tekton-pipeline` or `openshift-pipelines` namespace 
```
$ go build
$ tkn version
Client version: dev
Pipeline version: v0.14.2
Triggers version: devel
Dashboard version: v0.9.0
```

```
$ tkn version --help
Prints version information

Usage:
tkn version [flags]

Flags:
  -c, --check              check if a newer version is available
  -h, --help               help for version
  -n, --namespace string   namespace to check installed controller version

```
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
