### PR TITLE
Added --component option to just output the version of the components like client|pipeline|triggers

### DIFF
--- a/docs/cmd/tkn_version.md
+++ b/docs/cmd/tkn_version.md
@@ -16,6 +16,7 @@ Prints version information
 
 ```
       --check               check if a newer version is available
+      --component string    provide a particular component name for its version (client|pipeline|triggers|dashboard)
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for version
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)

--- a/docs/man/man1/tkn-version.1
+++ b/docs/man/man1/tkn-version.1
@@ -24,6 +24,10 @@ Prints version information
     check if a newer version is available
 
 .PP
+\fB\-\-component\fP=""
+    provide a particular component name for its version (client|pipeline|triggers|dashboard)
+
+.PP
 \fB\-c\fP, \fB\-\-context\fP=""
     name of the kubeconfig context to use (default: kubectl config current\-context)
 

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -91,6 +91,23 @@ func TestVersionGood(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
+func TestComponentVersion(t *testing.T) {
+	v := clientVersion
+	defer func() { clientVersion = v }()
+
+	t.Run("test_client", func(t *testing.T) {})
+	clientVersion = "v1.2.3"
+
+	seedData, _ := test.SeedTestData(t, pipelinetest.Data{})
+
+	cs := pipelinetest.Clients{Kube: seedData.Kube}
+	p := &test.Params{Kube: cs.Kube}
+	version := Command(p)
+	got, _ := test.ExecuteCommand(version, "version", "--component", "client")
+	expected := "v1.2.3\n"
+	test.AssertOutput(t, expected, got)
+}
+
 func TestVersionBad(t *testing.T) {
 	v := clientVersion
 	defer func() { clientVersion = v }()


### PR DESCRIPTION
Fixes Issue [#1067](https://github.com/tektoncd/cli/issues/1067)


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
