### PR TITLE
Add New Line for No ClusterTasks found Output

### DIFF
--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	emptyMsg = "No ClusterTasks found"
+	emptyMsg = "No ClusterTasks found\n"
 	header   = "NAME\tDESCRIPTION\tAGE"
 	body     = "%s\t%s\t%s\n"
 )

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -45,6 +45,16 @@ func TestClusterTaskInteractiveStartE2E(t *testing.T) {
 	tkn, err := cli.NewTknRunner(namespace)
 	assert.NilError(t, err)
 
+	t.Run("Get list of ClusterTasks when none present", func(t *testing.T) {
+		res := tkn.Run("clustertask", "list")
+		expected := "No ClusterTasks found\n"
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Err:      icmd.None,
+			Out:      expected,
+		})
+	})
+
 	t.Logf("Creating clustertask read-task")
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("read-file-clustertask.yaml"))
 


### PR DESCRIPTION
Closes #1100 

# Changes

Adding back new line to `No ClusterTasks found` message for `tkn ct ls`. Also adding e2e to try and add another check to prevent future break of message output.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

<!--
Does your PR contain User facing changes?

```release-note
Add back new line to No ClusterTasks found message with tkn clustertask ls
```

