### PR TITLE
Display Results in the output of ClusterTask describe command

### DIFF
--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -90,6 +90,16 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .ClusterTask.Name }}
 {{- end }}
 {{- end }}
 
+{{decorate "results" ""}}{{decorate "underline bold" "Results\n"}}
+{{- if eq (len .ClusterTask.Spec.Results) 0 }}
+ No results
+{{- else }}
+ NAME	DESCRIPTION
+{{- range $result := .ClusterTask.Spec.Results }}
+ {{ decorate "bullet" $result.Name }}	{{ formatDesc $result.Description }}
+{{- end }}
+{{- end }}
+
 {{decorate "steps" ""}}{{decorate "underline bold" "Steps\n"}}
 
 {{- if eq (len .ClusterTask.Spec.Steps) 0 }}

--- a/pkg/cmd/clustertask/describe_test.go
+++ b/pkg/cmd/clustertask/describe_test.go
@@ -360,3 +360,59 @@ func TestClusterTaskV1beta1_custom_output(t *testing.T) {
 		t.Errorf("Result should be '%s' != '%s'", got, expected)
 	}
 }
+
+func TestClusterTaskDescribe_With_Results(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	clustertasks := []*v1beta1.ClusterTask{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "clustertask-1",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a clustertest description",
+				Steps: []v1beta1.Step{
+					{
+						Container: corev1.Container{
+							Name:  "hello",
+							Image: "busybox",
+						},
+					},
+				},
+				Results: []v1beta1.TaskResult{
+					{
+						Name:        "result-1",
+						Description: "This is a description for result 1",
+					},
+					{
+						Name:        "result-2",
+						Description: "This is a description for result 2",
+					},
+					{
+						Name: "result-3",
+					},
+				},
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1CT(clustertasks[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{ClusterTasks: clustertasks})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"clustertask", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Dynamic: dynamic}
+	clustertask := Command(p)
+	out, err := test.ExecuteCommand(clustertask, "desc", "clustertask-1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_With_Results.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_With_Results.golden
@@ -1,0 +1,29 @@
+Name:          clustertask-1
+Description:   a clustertest description
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ NAME       DESCRIPTION
+ result-1   This is a descripti...
+ result-2   This is a descripti...
+ result-3   
+
+Steps
+
+ hello
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
@@ -16,6 +16,10 @@ Params
  NAME    TYPE     DESCRIPTION   DEFAULT VALUE
  myarg   string                 ---
 
+Results
+
+ No results
+
 Steps
 
  hello

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_with_name_only.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_with_name_only.golden
@@ -12,6 +12,10 @@ Params
 
  No params
 
+Results
+
+ No results
+
 Steps
 
  No steps

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_full_clustertask_multiple_taskruns.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_full_clustertask_multiple_taskruns.golden
@@ -17,6 +17,10 @@ Params
  myarg   string   param type is string   default
  print   array    param type is array    [booms booms booms]
 
+Results
+
+ No results
+
 Steps
 
  hello


### PR DESCRIPTION
# Changes

The results declared in the clustertask will be displayed in the output of clustertask describe command. When we will do `tkn ct desc <ctname>` result name and description will be displayed in the output

Closes #1102 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Display results in the output of clustertask describe command
```