### PR TITLE
Add Triggers Installation for e2e Tests

### DIFF
--- a/test/builder/sort.go
+++ b/test/builder/sort.go
@@ -20,15 +20,19 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
-func SortByStartTime(trs []v1alpha1.TaskRun) {
-	sort.Sort(byStartTime(trs))
+func SortByStartTimeTaskRun(trs []v1alpha1.TaskRun) {
+	sort.Sort(byStartTimeTR(trs))
 }
 
-type byStartTime []v1alpha1.TaskRun
+func SortByStartTimePipelineRun(prs []v1alpha1.PipelineRun) {
+	sort.Sort(byStartTimePR(prs))
+}
 
-func (trs byStartTime) Len() int      { return len(trs) }
-func (trs byStartTime) Swap(i, j int) { trs[i], trs[j] = trs[j], trs[i] }
-func (trs byStartTime) Less(i, j int) bool {
+type byStartTimeTR []v1alpha1.TaskRun
+
+func (trs byStartTimeTR) Len() int      { return len(trs) }
+func (trs byStartTimeTR) Swap(i, j int) { trs[i], trs[j] = trs[j], trs[i] }
+func (trs byStartTimeTR) Less(i, j int) bool {
 	if trs[j].Status.StartTime == nil {
 		return false
 	}
@@ -36,4 +40,18 @@ func (trs byStartTime) Less(i, j int) bool {
 		return true
 	}
 	return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
+}
+
+type byStartTimePR []v1alpha1.PipelineRun
+
+func (prs byStartTimePR) Len() int      { return len(prs) }
+func (prs byStartTimePR) Swap(i, j int) { prs[i], prs[j] = prs[j], prs[i] }
+func (prs byStartTimePR) Less(i, j int) bool {
+	if prs[j].Status.StartTime == nil {
+		return false
+	}
+	if prs[i].Status.StartTime == nil {
+		return true
+	}
+	return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
 }

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -85,7 +85,7 @@ func TestClusterTaskInteractiveStartE2E(t *testing.T) {
 			"true")
 
 		vars := make(map[string]interface{})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
 		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
@@ -128,7 +128,7 @@ Waiting for logs to be available...
 
 	t.Run("Start ClusterTask with --pod-template", func(t *testing.T) {
 		if tkn.CheckVersion("Pipeline", "v0.10.2") {
-			t.Skip("Skip test as pipeline v0.10.2 doesn't support certain PodTemplate properties")
+			t.Skip("Skip test as pipeline v0.10 doesn't support certain PodTemplate properties")
 		}
 
 		tkn.MustSucceed(t, "clustertask", "start", "read-task",
@@ -138,7 +138,7 @@ Waiting for logs to be available...
 			"--showlog",
 			"--pod-template="+helper.GetResourcePath("/podtemplate/podtemplate.yaml"))
 
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -165,7 +165,7 @@ func TestPipelinesE2E(t *testing.T) {
 
 		time.Sleep(1 * time.Second)
 
-		pipelineGeneratedName = builder.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
+		pipelineGeneratedName = builder.GetPipelineRunListWithName(c, tePipelineName, true).Items[0].Name
 		vars["Element"] = pipelineGeneratedName
 		expected := helper.ProcessString(`(PipelineRun started: {{.Element}}
 Waiting for logs to be available...
@@ -266,7 +266,7 @@ Waiting for logs to be available...
 
 		time.Sleep(1 * time.Second)
 
-		pipelineRunGeneratedName := builder.GetPipelineRunListWithName(c, "pipeline-with-workspace").Items[0].Name
+		pipelineRunGeneratedName := builder.GetPipelineRunListWithName(c, "pipeline-with-workspace", true).Items[0].Name
 		vars["Element"] = pipelineRunGeneratedName
 		expected := helper.ProcessString(`(PipelineRun started: {{.Element}}
 Waiting for logs to be available...
@@ -285,7 +285,7 @@ Waiting for logs to be available...
 
 	t.Run("Start PipelineRun with --pod-template", func(t *testing.T) {
 		if tkn.CheckVersion("Pipeline", "v0.10.2") {
-			t.Skip("Skip test as pipeline v0.10.2 doesn't support certain PodTemplate properties")
+			t.Skip("Skip test as pipeline v0.10 doesn't support certain PodTemplate properties")
 		}
 
 		tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
@@ -295,7 +295,7 @@ Waiting for logs to be available...
 
 		time.Sleep(1 * time.Second)
 
-		pipelineRunGeneratedName := builder.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
+		pipelineRunGeneratedName := builder.GetPipelineRunListWithName(c, tePipelineName, true).Items[0].Name
 		timeout := 5 * time.Minute
 		// Should fail since runAsNonRoot=true
 		if err := wait.ForPipelineRunState(c, pipelineRunGeneratedName, timeout, wait.PipelineRunFailed(pipelineRunGeneratedName), "PipelineRunFailed"); err != nil {
@@ -408,7 +408,7 @@ func TestPipelinesNegativeE2E(t *testing.T) {
 			"--showlog",
 			"true")
 
-		pipelineGeneratedName = builder.GetPipelineRunListWithName(c, tePipelineName).Items[0].Name
+		pipelineGeneratedName = builder.GetPipelineRunListWithName(c, tePipelineName, true).Items[0].Name
 		vars["Element"] = pipelineGeneratedName
 		expected := helper.ProcessString(`(PipelineRun started: {{.Element}}
 Waiting for logs to be available...

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -74,7 +74,7 @@ func TestTaskStartE2E(t *testing.T) {
 			"--showlog")
 
 		vars := make(map[string]interface{})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
 		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
@@ -121,10 +121,10 @@ Waiting for logs to be available...
 	})
 
 	t.Run("Get list of TaskRuns from namespace  "+namespace, func(t *testing.T) {
-
-		taskRun1GeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[0].Name
-		taskRun2GeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[1].Name
-		taskRun3GeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[2].Name
+		taskRuns := builder.GetTaskRunListWithName(c, "read-task", false)
+		taskRun1GeneratedName := taskRuns.Items[0].Name
+		taskRun2GeneratedName := taskRuns.Items[1].Name
+		taskRun3GeneratedName := taskRuns.Items[2].Name
 
 		if err := wait.ForTaskRunState(c, taskRun1GeneratedName, wait.TaskRunSucceed(taskRun1GeneratedName), "TaskRunSucceed"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
@@ -187,7 +187,7 @@ Waiting for logs to be available...
 
 	t.Run("Start TaskRun with --workspace and volumeClaimTemplate", func(t *testing.T) {
 		if tkn.CheckVersion("Pipeline", "v0.10.2") {
-			t.Skip("Skip test as pipeline v0.10.2 doesn't support volumeClaimTemplates")
+			t.Skip("Skip test as pipeline v0.10 doesn't support volumeClaimTemplates")
 		}
 
 		res := tkn.MustSucceed(t, "task", "start", "task-with-workspace",
@@ -195,7 +195,7 @@ Waiting for logs to be available...
 			"--workspace=name=read-allowed,volumeClaimTemplateFile="+helper.GetResourcePath("pvc.yaml"))
 
 		vars := make(map[string]interface{})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "task-with-workspace").Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "task-with-workspace", true).Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
 		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
@@ -213,7 +213,7 @@ Waiting for logs to be available...
 
 	t.Run("Start TaskRun with --pod-template", func(t *testing.T) {
 		if tkn.CheckVersion("Pipeline", "v0.10.2") {
-			t.Skip("Skip test as pipeline v0.10.2 doesn't support certain PodTemplate properties")
+			t.Skip("Skip test as pipeline v0.10 doesn't support certain PodTemplate properties")
 		}
 
 		tkn.MustSucceed(t, "task", "start", "read-task",
@@ -223,7 +223,7 @@ Waiting for logs to be available...
 			"--showlog",
 			"--pod-template="+helper.GetResourcePath("/podtemplate/podtemplate.yaml"))
 
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task").Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}

--- a/test/resources/eventlistener.yaml
+++ b/test/resources/eventlistener.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: listener
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  triggers:
+    - name: foo-trig
+      bindings:
+        - ref: pipeline-binding
+        - ref: message-binding
+      template:
+        name: pipeline-template


### PR DESCRIPTION
Closes #1107
Closes #1115 

Installing triggers on clusters used for e2e tests to allow for development of e2e tests using triggers resources.

Also fixes #1115 by adding option to sort TaskRuns/PipelineRuns in tests by start times to get correct runs associated with tests.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```