### PR TITLE
Modify --use-param-defaults flag for `pipeline start` command and add e2e test

### DIFF
--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
@@ -7,11 +7,6 @@ metadata:
     jemange: desfrites
   namespace: ns
 spec:
-  params:
-  - name: pipeline-param
-    value: somethingdifferent
-  - name: rev-param
-    value: revision
   pipelineRef:
     name: test-pipeline
   resources:

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
@@ -10,8 +10,6 @@ spec:
   params:
   - name: pipeline-param
     value: value1
-  - name: rev-param
-    value: revision
   pipelineRef:
     name: test-pipeline
   resources:

--- a/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
@@ -7,11 +7,6 @@ metadata:
     jemange: desfrites
   namespace: ns
 spec:
-  params:
-  - name: pipeline-param
-    value: somethingdifferent
-  - name: rev-param
-    value: revision
   pipelineRef:
     name: test-pipeline
   resources:

--- a/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
@@ -10,8 +10,6 @@ spec:
   params:
   - name: pipeline-param
     value: value1
-  - name: rev-param
-    value: revision
   pipelineRef:
     name: test-pipeline
   resources:

--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -649,7 +649,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
  NAME	TYPE	DESCRIPTION	DEFAULT VALUE
 {{- range $i, $p := .Pipeline.Spec.Params }}
 {{- if not $p.Default }}
- {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ $p.Description }}	{{ "" }}
+ {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ $p.Description }}	{{ "---" }}
 {{- else }}
 {{- if eq $p.Type "string" }}
  {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ $p.Description }}	{{ $p.Default.StringVal }}

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -138,12 +138,10 @@ func TestPipelinesE2E(t *testing.T) {
 						0: &builder.TaskRefData{
 							TaskName: "first-create-file",
 							TaskRef:  TaskName1,
-							RunAfter: nil,
 						},
 						1: &builder.TaskRefData{
 							TaskName: "then-check",
 							TaskRef:  TaskName2,
-							RunAfter: nil,
 						},
 					},
 					Runs: map[string]string{},
@@ -162,6 +160,8 @@ func TestPipelinesE2E(t *testing.T) {
 	t.Run("Start PipelineRun using pipeline start command with SA as 'pipeline' ", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineGitResourceName,
+			"-p=FILEPATH=docs",
+			"-p=FILENAME=README.md",
 			"--showlog")
 
 		time.Sleep(1 * time.Second)
@@ -319,6 +319,8 @@ Waiting for logs to be available...
 		tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineGitResourceName,
 			"--pod-template="+helper.GetResourcePath("/podtemplate/podtemplate.yaml"),
+			"--use-param-defaults",
+			"-p=FILENAME=README.md",
 			"--showlog")
 
 		time.Sleep(1 * time.Second)
@@ -433,6 +435,8 @@ func TestPipelinesNegativeE2E(t *testing.T) {
 	t.Run("Start Pipeline Run using pipeline start command with SA as 'pipelines' ", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineFaultGitResourceName,
+			"-p=FILEPATH=docs",
+			"-p=FILENAME=README.md",
 			"--showlog",
 			"true")
 

--- a/test/e2e/pipeline/start_test.go
+++ b/test/e2e/pipeline/start_test.go
@@ -59,6 +59,86 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 					return err
 				}
 
+				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs`)"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("(docs)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Value for param `FILENAME` of type `string`?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("README.md"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectEOF(); err != nil {
+					return err
+				}
+
+				c.Close()
+				return nil
+			}})
+	})
+
+	t.Run("Start PipelineRun using pipeline start interactively using --use-param-defaults and some of the params not having default ", func(t *testing.T) {
+		tkn.RunInteractiveTests(t, &cli.Prompt{
+			CmdArgs: []string{"pipeline", "start", "output-pipeline",
+				"--use-param-defaults"},
+			Procedure: func(c *expect.Console) error {
+				if _, err := c.ExpectString("Choose the git resource to use for source-repo:"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Value for param `FILENAME` of type `string`?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("README.md"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectEOF(); err != nil {
+					return err
+				}
+
+				c.Close()
+				return nil
+			}})
+	})
+
+	t.Run("Start PipelineRun using pipeline start interactively using --use-param-defaults and params provided with -p", func(t *testing.T) {
+		tkn.RunInteractiveTests(t, &cli.Prompt{
+			CmdArgs: []string{"pipeline", "start", "output-pipeline",
+				"--use-param-defaults",
+				"-p=FILENAME=README.md"},
+			Procedure: func(c *expect.Console) error {
+				if _, err := c.ExpectString("Choose the git resource to use for source-repo:"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
 				if _, err := c.ExpectEOF(); err != nil {
 					return err
 				}
@@ -72,11 +152,8 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 		tkn.RunInteractiveTests(t, &cli.Prompt{
 			CmdArgs: []string{"pipeline", "logs", "-f"},
 			Procedure: func(c *expect.Console) error {
-				if _, err := c.ExpectString("Select pipeline:"); err != nil {
-					return err
-				}
 
-				if _, err := c.ExpectString("output-pipeline"); err != nil {
+				if _, err := c.ExpectString("Select pipelinerun:"); err != nil {
 					return err
 				}
 
@@ -143,6 +220,26 @@ func TestPipelineInteractiveStartWithNewResourceE2E(t *testing.T) {
 					return err
 				}
 
+				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs`)"); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("(docs)"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectString("Value for param `FILENAME` of type `string`?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("README.md"); err != nil {
+					return err
+				}
+
 				if _, err := c.ExpectEOF(); err != nil {
 					return err
 				}
@@ -150,6 +247,7 @@ func TestPipelineInteractiveStartWithNewResourceE2E(t *testing.T) {
 				c.Close()
 				return nil
 			}})
+
 	})
 
 	t.Run("Validate interactive pipeline logs, with  follow mode (-f) ", func(t *testing.T) {

--- a/test/resources/pipeline.yaml
+++ b/test/resources/pipeline.yaml
@@ -24,6 +24,9 @@ spec:
     - name: workspace
       type: git
       targetPath: damnworkspace
+    params:
+      - name: FILEPATH
+      - name: FILENAME
   outputs:
     resources:
     - name: workspace
@@ -32,7 +35,7 @@ spec:
   - name: read-docs-old
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['-c', 'ls -la /workspace/damnworkspace/docs/README.md']  # tests that targetpath works
+    args: ['-c', 'ls -la /workspace/damnworkspace/$(inputs.params.FILEPATH)/$(inputs.params.FILENAME)']  # tests that targetpath works
   - name: write-new-stuff
     image: ubuntu
     command: ['bash']
@@ -66,10 +69,19 @@ spec:
   resources:
   - name: source-repo
     type: git
+  params:
+    - name: FILEPATH
+      default: "docs"
+    - name: FILENAME
   tasks:
   - name: first-create-file          # 1. create file
     taskRef:
       name: create-file
+    params:
+      - name: FILEPATH
+        value: $(params.FILEPATH)
+      - name: FILENAME
+        value: $(params.FILENAME)
     resources:
       inputs:
       - name: workspace


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Modified --use-param-defaults flag for `pipeline start` command
to not add `default params` to pipelinerun which should be automatically
added by the controller itself and prompt interactive mode if default is not
provided for some params in the pipeline and also added `e2e tests` for 
the `--use-param-defaults` option.

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

Fixes: #1065 


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Modify --use-param-defaults flag for pipeline start command to prompt interactive mode if default is not provided for some params.
```
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
