### PR TITLE
Fix the display of 0 Value for Timeout with tkn tr/pr describe

### DIFF
--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_zero_timeout.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_zero_timeout.golden
@@ -1,0 +1,24 @@
+Name:           pipeline-run-zero-timeout
+Namespace:      ns
+Pipeline Ref:   pipeline-zero-timeout
+
+Status
+
+STARTED   DURATION   STATUS
+---       ---        ---
+
+Resources
+
+ No resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_zero_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_zero_timeout.golden
@@ -1,0 +1,31 @@
+Name:        tr-zero-timeout
+Namespace:   ns
+
+Status
+
+STARTED    DURATION    STATUS
+---        ---         ---
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Steps
+
+No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/pipelinerun/description/description.go
+++ b/pkg/pipelinerun/description/description.go
@@ -38,7 +38,7 @@ const templ = `{{decorate "bold" "Name"}}:	{{ .PipelineRun.Name }}
 {{- end }}
 
 {{- $timeout := getTimeout .PipelineRun -}}
-{{- if ne $timeout "" }}
+{{- if and (ne $timeout "") (ne $timeout "0s") }}
 {{decorate "bold" "Timeout"}}:	{{ .PipelineRun.Spec.Timeout.Duration.String }}
 {{- end }}
 {{- $l := len .PipelineRun.Labels }}{{ if eq $l 0 }}

--- a/pkg/taskrun/description/description.go
+++ b/pkg/taskrun/description/description.go
@@ -39,7 +39,7 @@ const templ = `{{decorate "bold" "Name"}}:	{{ .TaskRun.Name }}
 {{- end }}
 
 {{- $timeout := getTimeout .TaskRun -}}
-{{- if ne $timeout "" }}
+{{- if and (ne $timeout "") (ne $timeout "0s") }}
 {{decorate "bold" "Timeout"}}:	{{ .TaskRun.Spec.Timeout.Duration.String }}
 {{- end }}
 {{- $l := len .TaskRun.Labels }}{{ if eq $l 0 }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes #1106.

The pull request fixes the display of 0 Value for Timeout with `tkn tr/pr describe` by removing the description of timeout when the value of timeout is zero.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
