### PR TITLE
Display workspaces in tkn task/clustertask/taskrun describe command

### DIFF
--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -100,6 +100,16 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .ClusterTask.Name }}
 {{- end }}
 {{- end }}
 
+{{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
+{{- if eq (len .ClusterTask.Spec.Workspaces) 0 }}
+ No workspaces
+{{- else }}
+ NAME	DESCRIPTION
+{{- range $workspace := .ClusterTask.Spec.Workspaces }}
+ {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}
+{{- end }}
+{{- end }}
+
 {{decorate "steps" ""}}{{decorate "underline bold" "Steps\n"}}
 
 {{- if eq (len .ClusterTask.Spec.Steps) 0 }}

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_With_Results.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_With_Results.golden
@@ -20,6 +20,10 @@ Results
  result-2   This is a descripti...
  result-3   
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  hello

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_With_Workspaces.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_With_Workspaces.golden
@@ -1,4 +1,5 @@
-Name:   clustertask-justname
+Name:          clustertask-1
+Description:   a clustertest description
 
 Input Resources
 
@@ -18,11 +19,12 @@ Results
 
 Workspaces
 
- No workspaces
+ NAME   DESCRIPTION
+ test   test workspace
 
 Steps
 
- No steps
+ hello
 
 Taskruns
 

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
@@ -20,6 +20,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  hello

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_full_clustertask_multiple_taskruns.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_full_clustertask_multiple_taskruns.golden
@@ -21,6 +21,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  hello

--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -102,6 +102,17 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
 {{- end }}
 {{- end }}
 
+{{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
+
+{{- if eq (len .Task.Spec.Workspaces) 0 }}
+ No workspaces
+{{- else }}
+ NAME	DESCRIPTION
+{{- range $workspace := .Task.Spec.Workspaces }}
+ {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}
+{{- end }}
+{{- end }}
+
 {{decorate "steps" ""}}{{decorate "underline bold" "Steps\n"}}
 
 {{- if eq (len .Task.Spec.Steps) 0 }}

--- a/pkg/cmd/task/describe_test.go
+++ b/pkg/cmd/task/describe_test.go
@@ -745,3 +745,61 @@ func TestTaskDescribe_With_Results(t *testing.T) {
 	}
 	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestTaskDescribe_With_Workspaces(t *testing.T) {
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "task-1",
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test description",
+				Steps: []v1beta1.Step{
+					{
+						Container: corev1.Container{
+							Name:  "hello",
+							Image: "busybox",
+						},
+					},
+				},
+				Workspaces: []v1beta1.WorkspaceDeclaration{
+					{
+						Name:        "test",
+						Description: "test workspace",
+						MountPath:   "/workspace/test/file",
+						ReadOnly:    true,
+					},
+				},
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1T(tasks[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks, Namespaces: namespaces})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	task := Command(p)
+	out, err := test.ExecuteCommand(task, "desc", "task-1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
@@ -27,6 +27,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  hello

--- a/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameDiffNameSpace.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameDiffNameSpace.golden
@@ -17,6 +17,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameParams.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_OnlyNameParams.golden
@@ -20,6 +20,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_Results.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_Results.golden
@@ -21,6 +21,10 @@ Results
  result-2   This is a descripti...
  result-3   
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  hello

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_Workspaces.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_Workspaces.golden
@@ -1,5 +1,6 @@
-Name:        task-1
-Namespace:   ns
+Name:          task-1
+Namespace:     ns
+Description:   a test description
 
 Input Resources
 
@@ -19,11 +20,12 @@ Results
 
 Workspaces
 
- No workspaces
+ NAME   DESCRIPTION
+ test   test workspace
 
 Steps
 
- No steps
+ hello
 
 Taskruns
 

--- a/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent.golden
@@ -17,6 +17,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_WithoutNameIfOnlyOneV1beta1TaskPresent.golden
@@ -17,6 +17,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  No steps

--- a/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
@@ -27,6 +27,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  hello

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -1065,3 +1065,93 @@ func TestTaskRunDescribe_zero_timeout(t *testing.T) {
 
 	golden.Assert(t, actual, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestTaskRunDescribe_With_Workspaces(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	taskRuns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "tr-1",
+				Labels:    map[string]string{"tekton.dev/task": "task-1"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task-1",
+				},
+				Workspaces: []v1beta1.WorkspaceBinding{
+					{
+						Name:     "test",
+						SubPath:  "test",
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+					{
+						Name: "configmap",
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "bar"},
+						},
+					},
+					{
+						Name: "secret",
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "foobar",
+						},
+					},
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: v1beta1.TaskRunReasonFailed.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now().Add(-10 * time.Minute)},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+					TaskRunResults: []v1alpha1.TaskRunResult{
+						{
+							Name:  "result-1",
+							Value: "value-1",
+						},
+						{
+							Name:  "result-2",
+							Value: "value-2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1TR(taskRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: namespaces, TaskRuns: taskRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	taskrun := Command(p)
+	got, err := test.ExecuteCommand(taskrun, "desc", "tr-1")
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Workspaces.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Workspaces.golden
@@ -29,7 +29,10 @@ Results
 
 Workspaces
 
- No workspaces
+ NAME        SUB PATH      WORKSPACE BINDING
+ test        test          EmptyDir (emptyDir=)
+ configmap   ---           ConfigMap (config=bar)
+ secret      ---           Secret (secret=foobar)
 
 Steps
 

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
@@ -26,6 +26,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
@@ -26,6 +26,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
@@ -28,6 +28,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_last.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_last.golden
@@ -30,6 +30,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_lastV1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_lastV1beta1.golden
@@ -25,6 +25,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
@@ -30,6 +30,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_taskref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_taskref.golden
@@ -26,6 +26,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
@@ -30,6 +30,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
@@ -30,6 +30,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
@@ -30,6 +30,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
@@ -30,6 +30,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
  NAME    STATUS

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_zero_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_zero_timeout.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
@@ -23,6 +23,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Steps
 
 No steps

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -70,6 +70,8 @@ func DecorateAttr(attrString, message string) string {
 		return "🚗 "
 	case "results":
 		return "📝 "
+	case "workspaces":
+		return "📂 "
 	}
 
 	attr := color.Reset

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -80,13 +80,13 @@ func TestDecoration(t *testing.T) {
 	funcMap := template.FuncMap{
 		"decorate": DecorateAttr,
 	}
-	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
+	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "workspaces" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
 	processed := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(aTemplate))
 	buf := new(bytes.Buffer)
 
 	if err := processed.Execute(buf, nil); err != nil {
 		t.Error("Could not process the template.")
 	}
-	test.AssertOutput(t, "∙ Foo ✔ ️📦 ⚓ 📝 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
+	test.AssertOutput(t, "∙ Foo ✔ ️📦 ⚓ 📝 📂 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
 
 }

--- a/pkg/formatted/workspace.go
+++ b/pkg/formatted/workspace.go
@@ -1,0 +1,91 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Workspace(ws v1beta1.WorkspaceBinding) string {
+	if ws.VolumeClaimTemplate != nil {
+		return "VolumeClaimTemplate"
+	}
+	if ws.PersistentVolumeClaim != nil {
+		claimName := ws.PersistentVolumeClaim.ClaimName
+		return fmt.Sprintf("PersistentVolumeClaim (claimName=%s)", claimName)
+	}
+	if ws.EmptyDir != nil {
+		dirType := getWorkspaceEmptyDir(ws.EmptyDir)
+		return fmt.Sprintf("EmptyDir (emptyDir=%s)", dirType)
+	}
+	if ws.ConfigMap != nil {
+		cm := getWorkspaceConfig(ws.ConfigMap)
+		return fmt.Sprintf("ConfigMap (%s)", cm)
+	}
+	if ws.Secret != nil {
+		secret := getWorkspaceSecret(ws.Secret)
+		return fmt.Sprintf("Secret (%s)", secret)
+	}
+	return ""
+}
+
+func getWorkspaceEmptyDir(ed *corev1.EmptyDirVolumeSource) string {
+	sM := ed.Medium
+	var dirType string
+	if sM == corev1.StorageMediumDefault {
+		dirType = ""
+	}
+	if sM == corev1.StorageMediumMemory {
+		dirType = "Memory"
+	}
+	if sM == corev1.StorageMediumHugePages {
+		dirType = "HugePages"
+	}
+	return dirType
+}
+
+func getWorkspaceConfig(cm *corev1.ConfigMapVolumeSource) string {
+	cmName := cm.LocalObjectReference.Name
+	cmItems := cm.Items
+	str := fmt.Sprintf("config=%s", cmName)
+	if len(cmItems) != 0 {
+		str = fmt.Sprintf("%s%s", str, getItems(cmItems))
+	}
+	return str
+}
+
+func getWorkspaceSecret(secret *corev1.SecretVolumeSource) string {
+	secretName := secret.SecretName
+	secretItems := secret.Items
+	str := fmt.Sprintf("secret=%s", secretName)
+	if len(secretItems) != 0 {
+		str = fmt.Sprintf("%s%s", str, getItems(secretItems))
+	}
+	return str
+}
+
+func getItems(items []corev1.KeyToPath) string {
+	str := ""
+	for i := range items {
+		kp := items[i]
+		key := kp.Key
+		value := kp.Path
+		str = fmt.Sprintf("%s,item=%s=%s", str, key, value)
+	}
+	return str
+}

--- a/pkg/formatted/workspace_test.go
+++ b/pkg/formatted/workspace_test.go
@@ -1,0 +1,62 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestWorkspace(t *testing.T) {
+	workspaceSpec := []v1beta1.WorkspaceBinding{
+		{
+			Name:     "emptydir-default",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+		{
+			Name: "emptydir-memory",
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+		{
+			Name: "configmap",
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "bar"},
+			},
+		},
+		{
+			Name: "secret",
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "foobar",
+			},
+		},
+	}
+	defaultEmptyWorkspaceStr := Workspace(workspaceSpec[0]) // EmptyDir workspace with default storage medium
+	assert.Equal(t, defaultEmptyWorkspaceStr, "EmptyDir (emptyDir=)")
+
+	memoryEmptyWorkspaceStr := Workspace(workspaceSpec[1]) // EmptyDir workspace with Memory storage medium
+	assert.Equal(t, memoryEmptyWorkspaceStr, "EmptyDir (emptyDir=Memory)")
+
+	configMapWorkspaceStr := Workspace(workspaceSpec[2]) // ConfigMap workspace
+	assert.Equal(t, configMapWorkspaceStr, "ConfigMap (config=bar)")
+
+	secretWorkspaceStr := Workspace(workspaceSpec[3]) // Secret Workspace
+	assert.Equal(t, secretWorkspaceStr, "Secret (secret=foobar)")
+}

--- a/pkg/taskrun/description/description.go
+++ b/pkg/taskrun/description/description.go
@@ -126,6 +126,21 @@ STARTED 	DURATION 	STATUS
 {{- end }}
 {{- end }}
 
+{{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
+
+{{- if eq (len .TaskRun.Spec.Workspaces) 0 }}
+ No workspaces
+{{- else }}
+ NAME	SUB PATH		WORKSPACE BINDING
+{{- range $workspace := .TaskRun.Spec.Workspaces }}
+{{- if not $workspace.SubPath }}
+ {{ decorate "bullet" $workspace.Name }}	{{ "---" }}		{{ formatWorkspace $workspace }}
+{{- else }}
+ {{ decorate "bullet" $workspace.Name }}	{{ $workspace.SubPath }} 		{{ formatWorkspace $workspace }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{decorate "steps" ""}}{{decorate "underline bold" "Steps"}}
 {{$sortedSteps := sortStepStates .TaskRun.Status.Steps }}
 {{- $l := len $sortedSteps }}{{ if eq $l 0 }}
@@ -217,6 +232,7 @@ func PrintTaskRunDescription(s *cli.Stream, trName string, p cli.Params) error {
 		"formatDuration":        formatted.Duration,
 		"formatCondition":       formatted.Condition,
 		"formatResult":          formatted.Result,
+		"formatWorkspace":       formatted.Workspace,
 		"hasFailed":             hasFailed,
 		"taskRefExists":         taskRefExists,
 		"taskResourceRefExists": taskResourceRefExists,


### PR DESCRIPTION
# Changes

The workspaces declared in the clustertask/task/taskrun will be displayed in the output of their respective describe command.
- When we will do `tkn clustertask desc <ctname>` workspace name and description will be displayed in the output
- When we will do `tkn task desc <task-name>` workspace name and description will be displayed in the output
- When we will do `tkn taskrun desc <taskrun-name.`  `workspace name`, `subdir` and `workspace binding` will be displayed as part of output

Closes #1045 

sample TaskRun describe output is as follows :- 
```bash
$ tkn taskrun describe custom-volume-5tc6p
Name:        custom-volume-5tc6p
Namespace:   default
Timeout:     1h0m0s
Labels:
 app.kubernetes.io/managed-by=tekton-pipelines

🌡️  Status

STARTED       DURATION    STATUS
5 hours ago   1 minute    Succeeded

📨 Input Resources

 No input resources

📡 Output Resources

 No output resources

⚓ Params

 No params

📝 Results

 No results

📂 Workspaces

 NAME        SUB PATH        WORKSPACE BINDING
 ∙ custom    my-subdir       PersistentVolumeClaim (claimName=my-pvc)
 ∙ custom2   ---             PersistentVolumeClaim (claimName=my-pvc)
 ∙ custom3   testing         EmptyDir (emptyDir=)
 ∙ custom4   ---             ConfigMap (config=my-configmap,item=message=my-message.txt)
 ∙ custom5   ---             Secret (secret=my-secret)

🦶 Steps

 NAME              STATUS
 ∙ write           Completed
 ∙ read            Completed
 ∙ write2          Completed
 ∙ read2           Completed
 ∙ write3          Completed
 ∙ read3           Completed
 ∙ readconfigmap   Completed
 ∙ readsecret      Completed

🚗 Sidecars

No sidecars
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
- Display workspace name and description in the output of task/clustertask describe command
- Display workspace name, subdir and workspace binding in the output of taskrun describe command
```