### PR TITLE
Throw error when deleting tr/pr with non-existing task/pipeline

### DIFF
--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -117,14 +117,16 @@ func deletePipelineRuns(s *cli.Stream, p cli.Params, prNames []string, opts *opt
 		d.DeleteRelated(s, []string{opts.ParentResourceName})
 	}
 	if !opts.DeleteAllNs {
-		switch {
-		case opts.Keep > 0:
-			// Should only occur in case of --pipeline and --keep being used together
-			fmt.Fprintf(s.Out, "All but %d PipelineRuns associated with Pipeline %q deleted in namespace %q\n", opts.Keep, opts.ParentResourceName, p.Namespace())
-		case opts.ParentResourceName != "":
-			fmt.Fprintf(s.Out, "All PipelineRuns associated with Pipeline %q deleted in namespace %q\n", opts.ParentResourceName, p.Namespace())
-		default:
-			d.PrintSuccesses(s)
+		if d.Errors() == nil {
+			switch {
+			case opts.Keep > 0:
+				// Should only occur in case of --pipeline and --keep being used together
+				fmt.Fprintf(s.Out, "All but %d PipelineRuns associated with Pipeline %q deleted in namespace %q\n", opts.Keep, opts.ParentResourceName, p.Namespace())
+			case opts.ParentResourceName != "":
+				fmt.Fprintf(s.Out, "All PipelineRuns associated with Pipeline %q deleted in namespace %q\n", opts.ParentResourceName, p.Namespace())
+			default:
+				d.PrintSuccesses(s)
+			}
 		}
 	} else if opts.DeleteAllNs {
 		if d.Errors() == nil {

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -277,6 +277,15 @@ func TestPipelineRunDelete(t *testing.T) {
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 		{
+			name:        "Error from deleting PipelineRun with non-existing Pipeline",
+			command:     []string{"delete", "pipelinerun", "-p", "non-existing-pipeline"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "no PipelineRuns associated with Pipeline \"non-existing-pipeline\"",
+		},
+		{
 			name:        "Remove pipelineruns of a pipeline using --keep",
 			command:     []string{"rm", "--pipeline", "pipeline", "-n", "ns", "--keep", "2"},
 			dynamic:     seeds[5].dynamicClient,
@@ -593,6 +602,15 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
+		},
+		{
+			name:        "Error from deleting PipelineRun with non-existing Pipeline",
+			command:     []string{"delete", "pipelinerun", "-p", "non-existing-pipeline"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "no PipelineRuns associated with Pipeline \"non-existing-pipeline\"",
 		},
 		{
 			name:        "Remove pipelineruns of a pipeline using --keep",

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -118,14 +118,16 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 	}
 
 	if !opts.DeleteAllNs {
-		switch {
-		case opts.Keep > 0:
-			// Should only occur in case of --task flag and --keep being used together
-			fmt.Fprintf(s.Out, "All but %d TaskRuns associated with Task %q deleted in namespace %q\n", opts.Keep, opts.ParentResourceName, p.Namespace())
-		case opts.ParentResourceName != "":
-			fmt.Fprintf(s.Out, "All TaskRuns associated with Task %q deleted in namespace %q\n", opts.ParentResourceName, p.Namespace())
-		default:
-			d.PrintSuccesses(s)
+		if d.Errors() == nil {
+			switch {
+			case opts.Keep > 0:
+				// Should only occur in case of --task flag and --keep being used together
+				fmt.Fprintf(s.Out, "All but %d TaskRuns associated with Task %q deleted in namespace %q\n", opts.Keep, opts.ParentResourceName, p.Namespace())
+			case opts.ParentResourceName != "":
+				fmt.Fprintf(s.Out, "All TaskRuns associated with Task %q deleted in namespace %q\n", opts.ParentResourceName, p.Namespace())
+			default:
+				d.PrintSuccesses(s)
+			}
 		}
 	} else if opts.DeleteAllNs {
 		if d.Errors() == nil {

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -252,6 +252,15 @@ func TestTaskRunDelete(t *testing.T) {
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 		{
+			name:        "Error from deleting TaskRun with non-existing Task",
+			command:     []string{"delete", "taskrun", "-t", "non-existing-task"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "no TaskRuns associated with Task \"non-existing-task\"",
+		},
+		{
 			name:        "Remove taskruns of a task with --keep",
 			command:     []string{"rm", "--task", "random", "-n", "ns", "--keep", "2"},
 			dynamic:     seeds[5].dynamicClient,
@@ -542,6 +551,15 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
+		},
+		{
+			name:        "Error from deleting TaskRun with non-existing Task",
+			command:     []string{"delete", "taskrun", "-t", "non-existing-task"},
+			dynamic:     seeds[4].dynamicClient,
+			input:       seeds[4].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "no TaskRuns associated with Task \"non-existing-task\"",
 		},
 		{
 			name:        "Remove taskruns of a task with --keep",

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -78,13 +78,18 @@ func (d *Deleter) deleteRelatedList(streams *cli.Stream, resourceName string) {
 		err = fmt.Errorf("failed to list %ss: %s", strings.ToLower(d.relatedKind), err)
 		d.appendError(streams, err)
 	} else {
-		for _, subresource := range related {
-			if err := d.deleteRelated(subresource); err != nil {
-				err = fmt.Errorf("failed to delete %s %q: %s", d.relatedKind, subresource, err)
-				d.appendError(streams, err)
-			} else {
-				d.successfulRelatedDeletes = append(d.successfulRelatedDeletes, subresource)
+		if len(related) > 0 {
+			for _, subresource := range related {
+				if err := d.deleteRelated(subresource); err != nil {
+					err = fmt.Errorf("failed to delete %s %q: %s", d.relatedKind, subresource, err)
+					d.appendError(streams, err)
+				} else {
+					d.successfulRelatedDeletes = append(d.successfulRelatedDeletes, subresource)
+				}
 			}
+		} else {
+			err = fmt.Errorf("no %ss associated with %s %q", d.relatedKind, d.kind, resourceName)
+			d.appendError(streams, err)
 		}
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes #1116 

FIx the display when deleting tr/pr with non-existing task/pipeline by throwing error instead.

Add two test cases:
- Error from deleting TaskRun with non-existing Task
- Error from deleting PipelineRun with non-existing Pipeline

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
