### PR TITLE
Add Check for Timeout Status for PipelineRun and TaskRun Cancel

### DIFF
--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/pipelinerun"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,6 +29,7 @@ var (
 	succeeded   = formatted.ColorStatus("Succeeded")
 	failed      = formatted.ColorStatus("Failed")
 	prCancelled = formatted.ColorStatus("Cancelled") + "(PipelineRunCancelled)"
+	prTimeout   = formatted.ColorStatus("Failed") + "(" + v1beta1.PipelineRunReasonTimedOut.String() + ")"
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
@@ -73,7 +75,7 @@ func cancelPipelineRun(p cli.Params, s *cli.Stream, prName string) error {
 	}
 
 	prCond := formatted.Condition(pr.Status.Conditions)
-	if prCond == succeeded || prCond == failed || prCond == prCancelled {
+	if prCond == succeeded || prCond == failed || prCond == prCancelled || prCond == prTimeout {
 		return fmt.Errorf("failed to cancel PipelineRun %s: PipelineRun has already finished execution", prName)
 	}
 

--- a/pkg/cmd/pipelinerun/cancel_test.go
+++ b/pkg/cmd/pipelinerun/cancel_test.go
@@ -727,3 +727,88 @@ func Test_finished_pipelinerun_cancel_v1beta1(t *testing.T) {
 	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
 	tu.AssertOutput(t, expected, got)
 }
+
+func Test_finished_pipelinerun_timeout_v1beta1(t *testing.T) {
+	ns := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	prName := "test-pipeline-run-123"
+
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "rev-param",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: v1beta1.PipelineRunReasonTimedOut.String(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{PipelineRuns: prs, Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"pipeline", "pipelinerun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredV1beta1PR(prs[0], versionB1),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	p := &tu.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc}
+
+	pRun := Command(p)
+	got, _ := tu.ExecuteCommand(pRun, "cancel", prName, "-n", "ns")
+
+	expected := "Error: failed to cancel PipelineRun " + prName + ": PipelineRun has already finished execution\n"
+	tu.AssertOutput(t, expected, got)
+}

--- a/pkg/cmd/taskrun/cancel.go
+++ b/pkg/cmd/taskrun/cancel.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/taskrun"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,6 +29,7 @@ var (
 	succeeded        = formatted.ColorStatus("Succeeded")
 	failed           = formatted.ColorStatus("Failed")
 	taskrunCancelled = formatted.ColorStatus("Cancelled") + "(TaskRunCancelled)"
+	taskrunTimeout   = formatted.ColorStatus("Failed") + "(" + v1beta1.TaskRunReasonTimedOut.String() + ")"
 )
 
 func cancelCommand(p cli.Params) *cobra.Command {
@@ -71,7 +73,7 @@ func cancelTaskRun(p cli.Params, s *cli.Stream, trName string) error {
 	}
 
 	taskrunCond := formatted.Condition(tr.Status.Conditions)
-	if taskrunCond == succeeded || taskrunCond == failed || taskrunCond == taskrunCancelled {
+	if taskrunCond == succeeded || taskrunCond == failed || taskrunCond == taskrunCancelled || taskrunCond == taskrunTimeout {
 		return fmt.Errorf("failed to cancel TaskRun %s: TaskRun has already finished execution", trName)
 	}
 


### PR DESCRIPTION
Closes #1118 

Adding PipelineRunTimeout and TaskRunTimeout to check to prevent cancelling PipelineRun/TaskRun that have finished executing. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

For pull requests with a release note:

```release-note
Add check for tkn pr/tr cancel to prevent cancelling a timed out PipelineRun/TaskRun
```