### PR TITLE
pkg/suggestions: print help and error out 🏢

### DIFF
--- a/pkg/suggestion/suggest.go
+++ b/pkg/suggestion/suggest.go
@@ -74,7 +74,11 @@ func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error
 		return fmt.Errorf(requireMsg, typedName, cmd.CommandPath())
 	}
 
-	return cmd.Help()
+	if typedName == "" {
+		return cmd.Help()
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s %s doesn't exists\n", cmd.Name(), typedName)
+	return cobra.ErrSubCommandRequired
 }
 
 // suggestsByPrefixOrLd suggests a command by levenshtein distance or by prefix.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In case of "suggestion", we want to print help and error out, as this
means the subcommand does not exists.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

Fixes #1114 
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes


```release-note
Invalid subcommands now return an error (exitCode > 0) even in case of proposed suggestions
```
