### PR TITLE
pkg/suggestions: no help on subcommand errors

### DIFF
--- a/pkg/suggestion/suggest.go
+++ b/pkg/suggestion/suggest.go
@@ -77,8 +77,7 @@ func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error
 	if typedName == "" {
 		return cmd.Help()
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "%s %s doesn't exists\n", cmd.Name(), typedName)
-	return cobra.ErrSubCommandRequired
+	return fmt.Errorf("command %s %s doesn't exist. Run tkn help for available commands", cmd.Name(), typedName)
 }
 
 // suggestsByPrefixOrLd suggests a command by levenshtein distance or by prefix.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This only add the error message and suggestions of commands to type instead.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

```bash
$ ./bin/tkn
CLI for tekton pipelines

Usage:
tkn [flags]
  tkn [command]

Available Commands:
  clustertask           Manage ClusterTasks
  clustertriggerbinding Manage clustertriggerbindings
  condition             Manage conditions
  eventlistener         Manage eventlisteners
  pipeline              Manage pipelines
  pipelinerun           Manage PipelineRuns
  resource              Manage pipeline resources
  task                  Manage Tasks
  taskrun               Manage TaskRuns
  triggerbinding        Manage triggerbindings
  triggertemplate       Manage triggertemplates

Other Commands:
  completion            Prints shell completion scripts
  version               Prints version information

Flags:
  -h, --help   help for tkn

Use "tkn [command] --help" for more information about a command.
                                                                                                                                                                                             
$ ./bin/tkn ctl
Error: command tkn ctl doesn't exist. Run tkn help for available commands

                                                                                                                                                                                             
$ ./bin/tkn tsk
Error: unknown command "tsk" for "tkn"

Did you mean this?
        task

```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
