### PR TITLE
Consistent Error Messaging for Triggers Commands

### DIFF
--- a/pkg/cmd/clustertriggerbinding/describe.go
+++ b/pkg/cmd/clustertriggerbinding/describe.go
@@ -121,8 +121,7 @@ func printClusterTriggerBindingDescription(s *cli.Stream, p cli.Params, ctbName 
 
 	ctb, err := cs.Triggers.TriggersV1alpha1().ClusterTriggerBindings().Get(ctbName, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get clustertriggerbinding %s\n", ctbName)
-		return err
+		return fmt.Errorf("failed to get clustertriggerbinding %s: %v", ctbName, err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/clustertriggerbinding/list.go
+++ b/pkg/cmd/clustertriggerbinding/list.go
@@ -62,12 +62,12 @@ or
 
 			tbs, err := list(cs.Triggers, "")
 			if err != nil {
-				return fmt.Errorf(`failed to list clustertriggerbindings`)
+				return fmt.Errorf("failed to list clustertriggerbindings: %v", err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				return errors.New(`output option not set properly \n`)
+				return errors.New("output option not set properly")
 			}
 
 			stream := &cli.Stream{
@@ -89,7 +89,7 @@ or
 			}
 
 			if err = printFormatted(stream, tbs, p); err != nil {
-				return errors.New(`failed to print clustertriggerbindings \n`)
+				return fmt.Errorf("failed to print clustertriggerbindings: %v", err)
 			}
 			return nil
 

--- a/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_NonExistedName.golden
+++ b/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_NonExistedName.golden
@@ -1,2 +1,1 @@
-failed to get clustertriggerbinding bar
-Error: clustertriggerbindings.triggers.tekton.dev "bar" not found
+Error: failed to get clustertriggerbinding bar: clustertriggerbindings.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/eventlistener/describe.go
+++ b/pkg/cmd/eventlistener/describe.go
@@ -187,8 +187,7 @@ func printEventListenerDescription(s *cli.Stream, p cli.Params, elName string) e
 
 	el, err := cs.Triggers.TriggersV1alpha1().EventListeners(p.Namespace()).Get(elName, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get eventlistener %s\n", elName)
-		return err
+		return fmt.Errorf("failed to get eventlistener %s: %v", elName, err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/eventlistener/list.go
+++ b/pkg/cmd/eventlistener/list.go
@@ -62,7 +62,7 @@ or
 
 			els, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf(`failed to list eventlisteners from %s namespace \n`, p.Namespace())
+				return fmt.Errorf("failed to list eventlisteners from %s namespace: %v", p.Namespace(), err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_InvalidNamespace.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_InvalidNamespace.golden
@@ -1,2 +1,1 @@
-failed to get eventlistener bar
-Error: eventlisteners.triggers.tekton.dev "bar" not found
+Error: failed to get eventlistener bar: eventlisteners.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_NonExistedName.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_NonExistedName.golden
@@ -1,2 +1,1 @@
-failed to get eventlistener bar
-Error: eventlisteners.triggers.tekton.dev "bar" not found
+Error: failed to get eventlistener bar: eventlisteners.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggerbinding/describe.go
+++ b/pkg/cmd/triggerbinding/describe.go
@@ -122,8 +122,7 @@ func printTriggerBindingDescription(s *cli.Stream, p cli.Params, tbName string) 
 
 	tb, err := cs.Triggers.TriggersV1alpha1().TriggerBindings(p.Namespace()).Get(tbName, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get triggerbinding %s\n", tbName)
-		return err
+		return fmt.Errorf("failed to get triggerbinding %s from %s namespace: %v", tbName, p.Namespace(), err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/triggerbinding/list.go
+++ b/pkg/cmd/triggerbinding/list.go
@@ -62,7 +62,7 @@ or
 
 			tbs, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf("failed to list triggerbindings from %s namespace", p.Namespace())
+				return fmt.Errorf("failed to list triggerbindings from %s namespace: %v", p.Namespace(), err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")

--- a/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_Invalid_Namespace.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_Invalid_Namespace.golden
@@ -1,2 +1,1 @@
-failed to get triggerbinding bar
-Error: triggerbindings.triggers.tekton.dev "bar" not found
+Error: failed to get triggerbinding bar from invalid namespace: triggerbindings.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_NonExistedName.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_NonExistedName.golden
@@ -1,2 +1,1 @@
-failed to get triggerbinding bar
-Error: triggerbindings.triggers.tekton.dev "bar" not found
+Error: failed to get triggerbinding bar from ns namespace: triggerbindings.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggertemplate/describe.go
+++ b/pkg/cmd/triggertemplate/describe.go
@@ -142,8 +142,7 @@ func printTriggerTemplateDescription(s *cli.Stream, p cli.Params, ttname string)
 
 	tt, err := cs.Triggers.TriggersV1alpha1().TriggerTemplates(p.Namespace()).Get(ttname, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(s.Err, "failed to get triggertemplate %s\n", ttname)
-		return err
+		return fmt.Errorf("failed to get triggertemplate %s from %s namespace: %v", ttname, p.Namespace(), err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/triggertemplate/list.go
+++ b/pkg/cmd/triggertemplate/list.go
@@ -62,7 +62,7 @@ or
 
 			tts, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf("failed to list triggertemplates from %s namespace", p.Namespace())
+				return fmt.Errorf("failed to list triggertemplates from %s namespace: %v", p.Namespace(), err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_Invalid_Namespace.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_Invalid_Namespace.golden
@@ -1,2 +1,1 @@
-failed to get triggertemplate bar
-Error: triggertemplates.triggers.tekton.dev "bar" not found
+Error: failed to get triggertemplate bar from invalid namespace: triggertemplates.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_NonExistedName.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_NonExistedName.golden
@@ -1,2 +1,1 @@
-failed to get triggertemplate bar
-Error: triggertemplates.triggers.tekton.dev "bar" not found
+Error: failed to get triggertemplate bar from ns namespace: triggertemplates.triggers.tekton.dev "bar" not found


### PR DESCRIPTION
Closes #1099 

# Changes

This pull request provides a consistent error message for triggers list/describe commands when triggers is not installed on a cluster and when a resource cannot be found. Additionally, it removes single quotation mark strings that have a `\n` character as this will not apply a new line. 

The new error for when triggers is not installed is shown below:

```
$ tkn el ls

Error: failed to list eventlisteners from default namespace: the server could not find the 
requested resource (get eventlisteners.triggers.tekton.dev)
```

```
$ tkn el desc doesnotexist

Error: failed to get eventlistener doesnotexist: the server could not find the requested resource 
(get eventlisteners.triggers.tekton.dev doesnotexist)
```

While the error could still be improved as far as notifying a user triggers is not installed, I think it is more consistent with how pipeline commands handle this situation:

```
$ tkn p ls

Error: failed to list Pipelines from namespace default: no matches for tekton.dev/, Resource=pipelines
```

If further enhancements to the message should be made, I think it can be done as part of a larger overhaul to include pipeline commands. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Make error messaging consistent for triggers list/describe commands
```