### PR TITLE
Copy Over PipelineRun and TaskRun Spec for --last and use run Options

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -219,10 +219,8 @@ func startClusterTask(opt startOptions, args []string) error {
 		if err != nil {
 			return err
 		}
-		tr.Spec.Resources = trLast.Spec.Resources
-		tr.Spec.Params = trLast.Spec.Params
-		tr.Spec.ServiceAccountName = trLast.Spec.ServiceAccountName
-		tr.Spec.Workspaces = trLast.Spec.Workspaces
+		// Copy over spec from last TaskRun to use same values for this TaskRun
+		tr.Spec = trLast.Spec
 	}
 
 	if tr.Spec.Resources == nil {

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_--last.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_--last.golden
@@ -31,6 +31,7 @@ spec:
   taskRef:
     kind: ClusterTask
     name: clustertask-1
+  timeout: 1h0m0s
   workspaces:
   - emptyDir: {}
     name: test

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -253,13 +253,8 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 		} else if opt.PrefixName == "" {
 			pr.ObjectMeta.GenerateName = usepr.ObjectMeta.Name + "-"
 		}
-		pr.Spec.Resources = usepr.Spec.Resources
-		pr.Spec.Params = usepr.Spec.Params
-		// If the usepr is a "new" PR, let's populate those fields too
-		pr.Spec.ServiceAccountName = usepr.Spec.ServiceAccountName
-		pr.Spec.ServiceAccountNames = usepr.Spec.ServiceAccountNames
-		pr.Spec.Workspaces = usepr.Spec.Workspaces
-		pr.Spec.Timeout = usepr.Spec.Timeout
+		// Copy over spec from last or previous PipelineRun to use same values for this PipelineRun
+		pr.Spec = usepr.Spec
 	}
 
 	if err := mergeRes(pr, opt.Resources); err != nil {

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -250,13 +250,8 @@ func useTaskRunFrom(opt startOptions, tr *v1beta1.TaskRun, cs *cli.Clients, tnam
 	} else if opt.PrefixName == "" {
 		tr.ObjectMeta.GenerateName = trUsed.ObjectMeta.Name + "-"
 	}
-
-	tr.Spec.Resources = trUsed.Spec.Resources
-	tr.Spec.Params = trUsed.Spec.Params
-	tr.Spec.ServiceAccountName = trUsed.Spec.ServiceAccountName
-	tr.Spec.Workspaces = trUsed.Spec.Workspaces
-	tr.Spec.Timeout = trUsed.Spec.Timeout
-
+	// Copy over spec from last or previous TaskRun to use same values for this TaskRun
+	tr.Spec = trUsed.Spec
 	return nil
 }
 

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -17,9 +17,11 @@ package task
 
 import (
 	"testing"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
+	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/cli/test/builder"
 	"github.com/tektoncd/cli/test/cli"
 	"github.com/tektoncd/cli/test/framework"
@@ -226,6 +228,32 @@ Waiting for logs to be available...
 		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
+		}
+	})
+
+	t.Run("Start TaskRun using tkn task start with --last option", func(t *testing.T) {
+		// Get last TaskRun for read-task
+		lastTaskRun := builder.GetTaskRunListWithName(c, "read-task", true).Items[0]
+
+		// Start TaskRun using --last
+		tkn.MustSucceed(t, "task", "start", "read-task",
+			"--last",
+			"--showlog")
+
+		// Sleep to make make sure TaskRun is created/running
+		time.Sleep(1 * time.Second)
+
+		// Get name of most recent TaskRun and wait for it to succeed
+		taskRunUsingLast := builder.GetTaskRunListWithName(c, "read-task", true).Items[0]
+		if err := wait.ForTaskRunState(c, taskRunUsingLast.Name, wait.TaskRunSucceed(taskRunUsingLast.Name), "TaskRunSucceeded"); err != nil {
+			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
+		}
+
+		// Expect that previous TaskRun spec will match most recent TaskRun spec
+		expected := lastTaskRun.Spec
+		got := taskRunUsingLast.Spec
+		if d := cmp.Diff(got, expected); d != "" {
+			t.Fatalf("-got, +want: %v", d)
 		}
 	})
 }


### PR DESCRIPTION
Closes #1133 

# Changes

In order to avoid the issue of needing to add properties for `--last` and `--use-taskrun`/`--use-pipelinerun` options, the entire Spec of the previous TaskRun or PipelineRun should be copied over to the new run object. This will prevent future issues like #1133 and #862.

This may also address #1119, but will not close the issue until there is further verification. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Fix --last and --use-taskrun/--use-pipelinerun commands so that all properties are used as part of new run
```

