### PR TITLE
Refactor status formatting

### DIFF
--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -78,6 +78,42 @@ func TestCondition(t *testing.T) {
 			want: "Cancelled(TaskRunCancelled)",
 		},
 		{
+			name: "PipelineRunTimeout status reason",
+			condition: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+				Reason: "PipelineRunTimeout",
+			}},
+			want: "Failed(PipelineRunTimeout)",
+		},
+		{
+			name: "TaskRunTimeout status reason",
+			condition: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+				Reason: "TaskRunTimeout",
+			}},
+			want: "Failed(TaskRunTimeout)",
+		},
+		{
+			name: "PipelineRunStopping status reason",
+			condition: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionUnknown,
+				Reason: "PipelineRunStopping",
+			}},
+			want: "Failed(PipelineRunStopping)",
+		},
+		{
+			name: "ConfigError status reason",
+			condition: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionUnknown,
+				Reason: "CreateContainerConfigError",
+			}},
+			want: "Pending(CreateContainerConfigError)",
+		},
+		{
 			name: "Reason equal Status",
 			condition: []apis.Condition{{
 				Type:   apis.ConditionSucceeded,


### PR DESCRIPTION
This will refactor the status formating to
handle new status added in API

From API, these are coming as ConditionUnknown
so it shows as Running in CLI

Fixes #1083 #1086

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
   Improve the status of resources show in CLI
```