### PR TITLE
Display Workspaces in the output of pipeline/pipelinerun describe command

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -81,6 +81,16 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{- end }}
 {{- end }}
 
+{{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
+{{- if eq (len .Pipeline.Spec.Workspaces) 0 }}
+ No workspaces
+{{- else }}
+ NAME	DESCRIPTION
+{{- range $workspace := .Pipeline.Spec.Workspaces }}
+ {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}
+{{- end }}
+{{- end }}
+
 {{decorate "tasks" ""}}{{decorate "underline bold" "Tasks\n"}}
 {{- $tl := len .Pipeline.Spec.Tasks }}{{ if eq $tl 0 }}
  No tasks

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -881,3 +881,82 @@ func TestPipelineDescribeV1beta1_with_results(t *testing.T) {
 	}
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestPipelineDescribeV1beta1_with_workspaces(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1beta1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1beta1.PipelineSpec{
+				Resources: []v1beta1.PipelineDeclaredResource{
+					{
+						Name: "name",
+						Type: v1alpha1.PipelineResourceTypeGit,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+				Results: []v1beta1.PipelineResult{
+					{
+						Name:        "result-1",
+						Description: "This is a description for result 1",
+					},
+					{
+						Name:        "result-2",
+						Description: "This is a description for result 2",
+					},
+					{
+						Name: "result-3",
+					},
+				},
+				Workspaces: []v1beta1.PipelineWorkspaceDeclaration{
+					{
+						Name:        "test",
+						Description: "test workspace",
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1P(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_task_conditions.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_task_conditions.golden
@@ -14,6 +14,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  NAME     TASKREF   RUNAFTER   TIMEOUT   CONDITIONS                              PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_with_spec_multiple_resource_param_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_with_spec_multiple_resource_param_run.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  NAME   TASKREF   RUNAFTER   TIMEOUT     CONDITIONS   PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_with_workspaces.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_with_workspaces.golden
@@ -19,7 +19,8 @@ Results
 
 Workspaces
 
- No workspaces
+ NAME   DESCRIPTION
+ test   test workspace
 
 Tasks
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_empty.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_empty.golden
@@ -13,6 +13,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  No tasks

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_v1alpha1_pipelineruns.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_v1alpha1_pipelineruns.golden
@@ -16,6 +16,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  NAME   TASKREF   RUNAFTER   TIMEOUT     CONDITIONS   PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_run.golden
@@ -13,6 +13,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  No tasks

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run.golden
@@ -23,6 +23,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  NAME   TASKREF   RUNAFTER   TIMEOUT     CONDITIONS   PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_resource_param_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_resource_param_run.golden
@@ -16,6 +16,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  NAME   TASKREF   RUNAFTER   TIMEOUT     CONDITIONS   PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_run.golden
@@ -14,6 +14,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Tasks
 
  NAME   TASKREF   RUNAFTER   TIMEOUT     CONDITIONS   PARAMS

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -1773,3 +1773,146 @@ func TestPipelineRunDescribe_zero_timeout(t *testing.T) {
 
 	golden.Assert(t, actual, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestPipelineRunDescribe_v1beta1_with_workspaces(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelinerunname := "pipeline-run"
+	taskRuns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "tr-1",
+				Labels:    map[string]string{"tekton.dev/task": "task-1"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task-1",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: v1beta1.PipelineRunReasonFailed.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now()},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(5 * time.Minute)},
+				},
+			},
+		},
+	}
+
+	prun := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pipelinerunname,
+				Namespace: "ns",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "res-1",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "test-res",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "p-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+				},
+				Workspaces: []v1beta1.WorkspaceBinding{
+					{
+						Name:     "test",
+						SubPath:  "test",
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+					{
+						Name: "configmap",
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "bar"},
+						},
+					},
+					{
+						Name: "secret",
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "foobar",
+						},
+					},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status:  corev1.ConditionTrue,
+							Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
+							Message: "Completed",
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now().Add(-10 * time.Minute)},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+					TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+						"tr-1": {
+							PipelineTaskName: "t-1",
+							Status:           &taskRuns[0].Status,
+						},
+					},
+					PipelineResults: []v1beta1.PipelineRunResult{
+						{
+							Name:  "result-1",
+							Value: "value-1",
+						},
+						{
+							Name:  "result-2",
+							Value: "value-2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1PR(prun[0], version),
+		cb.UnstructuredV1beta1TR(taskRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: namespaces, PipelineRuns: prun, TaskRuns: taskRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+
+	pipelinerun := Command(p)
+	got, err := test.ExecuteCommand(pipelinerun, "desc", "-n", "ns", "--last")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1.golden
@@ -23,6 +23,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED           DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_taskrun_with_no_status.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_taskrun_with_no_status.golden
@@ -23,6 +23,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
@@ -26,6 +26,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_custom_timeout.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_custom_timeout.golden
@@ -20,6 +20,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  No taskruns

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
@@ -27,6 +27,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutPRCondition.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutPRCondition.golden
@@ -23,6 +23,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutTRCondition.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutTRCondition.golden
@@ -27,6 +27,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_lastV1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_lastV1beta1.golden
@@ -23,6 +23,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED          DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_ordering.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_ordering.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref.golden
@@ -25,6 +25,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_only_taskrun.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1_with_workspaces.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1_with_workspaces.golden
@@ -25,7 +25,10 @@ Results
 
 Workspaces
 
- No workspaces
+ NAME        SUB PATH   WORKSPACE BINDING
+ test        test       EmptyDir (emptyDir=)
+ configmap   ---        ConfigMap (config=bar)
+ secret      ---        Secret (secret=foobar)
 
 Taskruns
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun.golden
@@ -25,6 +25,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_pipelineref.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_pipelineref.golden
@@ -20,6 +20,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  No taskruns

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_start_time.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_start_time.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  No taskruns

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_tr_start_time.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_tr_start_time.golden
@@ -22,6 +22,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  NAME   TASK NAME   STARTED   DURATION   STATUS

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_zero_timeout.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_zero_timeout.golden
@@ -19,6 +19,10 @@ Results
 
  No results
 
+Workspaces
+
+ No workspaces
+
 Taskruns
 
  No taskruns

--- a/pkg/pipelinerun/description/description.go
+++ b/pkg/pipelinerun/description/description.go
@@ -97,6 +97,21 @@ STARTED	DURATION	STATUS
 {{- end }}
 {{- end }}
 
+{{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
+
+{{- if eq (len .PipelineRun.Spec.Workspaces) 0 }}
+ No workspaces
+{{- else }}
+ NAME	SUB PATH	WORKSPACE BINDING
+{{- range $workspace := .PipelineRun.Spec.Workspaces }}
+{{- if not $workspace.SubPath }}
+ {{ decorate "bullet" $workspace.Name }}	{{ "---" }}	{{ formatWorkspace $workspace }}
+{{- else }}
+ {{ decorate "bullet" $workspace.Name }}	{{ $workspace.SubPath }}	{{ formatWorkspace $workspace }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{decorate "taskruns" ""}}{{decorate "underline bold" "Taskruns\n"}}
 {{- $l := len .TaskrunList }}{{ if eq $l 0 }}
  No taskruns
@@ -173,6 +188,7 @@ func PrintPipelineRunDescription(s *cli.Stream, prName string, p cli.Params) err
 		"formatDuration":            formatted.Duration,
 		"formatCondition":           formatted.Condition,
 		"formatResult":              formatted.Result,
+		"formatWorkspace":           formatted.Workspace,
 		"hasFailed":                 hasFailed,
 		"pipelineRefExists":         pipelineRefExists,
 		"pipelineResourceRefExists": pipelineResourceRefExists,

--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -670,6 +670,16 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{- end }}
 {{- end }}
 
+{{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
+{{- if eq (len .Pipeline.Spec.Workspaces) 0 }}
+ No workspaces
+{{- else }}
+ NAME	DESCRIPTION
+{{- range $workspace := .Pipeline.Spec.Workspaces }}
+ {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}
+{{- end }}
+{{- end }}
+
 {{decorate "tasks" ""}}{{decorate "underline bold" "Tasks\n"}}
 {{- $tl := len .Pipeline.Spec.Tasks }}{{ if eq $tl 0 }}
  No tasks
@@ -719,6 +729,7 @@ func GetPipelineDescribeOutput(t *testing.T, cs *framework.Clients, pname string
 		"formatDuration":       formatted.Duration,
 		"formatCondition":      formatted.Condition,
 		"formatTimeout":        formatted.Timeout,
+		"formatDesc":           formatted.FormatDesc,
 		"formatParam":          formatted.Param,
 		"decorate":             formatted.DecorateAttr,
 		"join":                 strings.Join,


### PR DESCRIPTION
# Changes

The workspaces declared in the pipeline/pipelinerun will be displayed in the output of their respective describe command.

- When we will do `tkn pipeline desc <pipeline-name>` workspace name and description will be displayed in the output
- When we will do `tkn pipelinerun desc <pipelinerun-name>` workspace name, subdir and workspace binding will be displayed as part of output

Closes #1048 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
- Display workspace name and description in the output of pipeline describe command
- Display workspace name, subdir and workspace binding in the output of pipelinerun describe command
```