### PR TITLE
Fixing clustertask e2e tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -28,6 +28,7 @@ which need `-tags=e2e` to be enabled.
 go build -o tkn github.com/tektoncd/cli/cmd/tkn
 export TEST_CLIENT_BINARY=<path-to-tkn-binary-directory>/tkn ( eg: export TEST_CLIENT_BINARY=$PWD/tkn ) 
 ```
+Set environment variable `TEST_CLUSTERTASK_LIST_EMPTY` to any value if tests are run in an environment which contains `clustertasks`
 ### Running
 
 To run end to end tests, you will need to have a running Tekton

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -247,10 +247,10 @@ Waiting for logs to be available...
 
 	t.Run("Start TaskRun using tkn ct start with --use-taskrun option", func(t *testing.T) {
 		// Get last TaskRun for read-clustertask
-		lastTaskRun := builder.GetTaskRunListWithName(c, "read-clustertask", true).Items[0]
+		lastTaskRun := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0]
 
 		// Start TaskRun using --use-taskrun
-		tkn.MustSucceed(t, "ct", "start", "read-clustertask",
+		tkn.MustSucceed(t, "ct", "start", clusterTaskName,
 			"--use-taskrun",
 			lastTaskRun.Name,
 			"--showlog")
@@ -259,7 +259,7 @@ Waiting for logs to be available...
 		time.Sleep(1 * time.Second)
 
 		// Get name of most recent TaskRun and wait for it to succeed
-		taskRunUsingParticularTaskRun := builder.GetTaskRunListWithName(c, "read-clustertask", true).Items[0]
+		taskRunUsingParticularTaskRun := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0]
 		if err := wait.ForTaskRunState(c, taskRunUsingParticularTaskRun.Name, wait.TaskRunSucceed(taskRunUsingParticularTaskRun.Name), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -51,8 +51,8 @@ func TestClusterTaskInteractiveStartE2E(t *testing.T) {
 	kubectl := cli.NewKubectl(namespace)
 	tkn, err := cli.NewTknRunner(namespace)
 	assert.NilError(t, err)
-	// Set environment variable NO_CLUSTERTASK_FOUND_TEST to any value to skip "No ClusterTasks found" test
-	if os.Getenv("NO_CLUSTERTASK_FOUND_TEST") == "" {
+	// Set environment variable TEST_CLUSTERTASK_LIST_EMPTY to any value to skip "No ClusterTasks found" test
+	if os.Getenv("TEST_CLUSTERTASK_LIST_EMPTY") == "" {
 		t.Run("Get list of ClusterTasks when none present", func(t *testing.T) {
 			res := tkn.Run("clustertask", "list")
 			expected := "No ClusterTasks found\n"
@@ -74,7 +74,7 @@ func TestClusterTaskInteractiveStartE2E(t *testing.T) {
 
 	t.Run("Get list of ClusterTasks", func(t *testing.T) {
 		res := tkn.Run("clustertask", "list")
-		if os.Getenv("NO_CLUSTERTASK_FOUND_TEST") == "" {
+		if os.Getenv("TEST_CLUSTERTASK_LIST_EMPTY") == "" {
 			expected := builder.ListAllClusterTasksOutput(t, c, map[int]interface{}{
 				0: &builder.TaskData{
 					Name: clusterTaskName,

--- a/test/resources/read-file-clustertask.yaml
+++ b/test/resources/read-file-clustertask.yaml
@@ -15,7 +15,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: ClusterTask
 metadata:
-  name: read-clustertask
+  generateName: read-clustertask-
 spec:
   workspaces:
     - name: shared-workspace


### PR DESCRIPTION
The current clustertask e2e test assumes that the test will be run on a cluster which does not have any clustertasks

Fixing it to work with cluster which already has some clustertasks

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
