### PR TITLE
Disable colouring when the user set the variable NO_COLOR

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -124,6 +124,10 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 		p.SetNoColour(true)
 	}
 
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		p.SetNoColour(true)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
as advised by https://no-color.org/


Testing is complicated to have since we disable colouring when there is no tty
and there is never going to be a tty when running for CI so we can't run this properly.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [?] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] Run the code checkers with `make check`
- [-] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->
```release-note
NONE
```