### PR TITLE
Enable auto-select support in ClusterTask/TaskRun if only one is present

### DIFF
--- a/pkg/clustertask/clustertask.go
+++ b/pkg/clustertask/clustertask.go
@@ -30,6 +30,24 @@ import (
 
 var clustertaskGroupResource = schema.GroupVersionResource{Group: "tekton.dev", Resource: "clustertasks"}
 
+func GetAllClusterTaskNames(p cli.Params) ([]string, error) {
+	cs, err := p.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	clustertasks, err := List(cs, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []string{}
+	for _, item := range clustertasks.Items {
+		ret = append(ret, item.ObjectMeta.Name)
+	}
+	return ret, nil
+}
+
 func List(c *cli.Clients, opts metav1.ListOptions) (*v1beta1.ClusterTaskList, error) {
 	unstructuredCT, err := actions.List(clustertaskGroupResource, c, "", opts)
 	if err != nil {

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -86,7 +86,7 @@ func deleteClusterTasks(opts *options.DeleteOptions, s *cli.Stream, p cli.Params
 	})
 	switch {
 	case opts.DeleteAll:
-		cts, err := allClusterTaskNames(cs)
+		cts, err := clustertask.GetAllClusterTaskNames(p)
 		if err != nil {
 			return err
 		}
@@ -110,18 +110,6 @@ func deleteClusterTasks(opts *options.DeleteOptions, s *cli.Stream, p cli.Params
 		}
 	}
 	return d.Errors()
-}
-
-func allClusterTaskNames(cs *cli.Clients) ([]string, error) {
-	clusterTasks, err := clustertask.List(cs, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	var names []string
-	for _, ct := range clusterTasks.Items {
-		names = append(names, ct.Name)
-	}
-	return names, nil
 }
 
 func taskRunLister(cs *cli.Clients, p cli.Params) func(string) ([]string, error) {

--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -165,9 +165,17 @@ or
 			}
 
 			if len(args) == 0 {
-				err = askClusterTaskName(opts, p)
+				clusterTaskNames, err := clustertask.GetAllClusterTaskNames(p)
 				if err != nil {
 					return err
+				}
+				if len(clusterTaskNames) == 1 {
+					opts.ClusterTaskName = clusterTaskNames[0]
+				} else {
+					err = askClusterTaskName(opts, clusterTaskNames)
+					if err != nil {
+						return err
+					}
 				}
 			} else {
 				opts.ClusterTaskName = args[0]
@@ -261,20 +269,11 @@ func sortResourcesByTypeAndName(tres []v1beta1.TaskResource) []v1beta1.TaskResou
 	return tres
 }
 
-func askClusterTaskName(opts *options.DescribeOptions, p cli.Params) error {
-	cs, err := p.Clients()
-	if err != nil {
-		return err
-	}
-	clusterTaskNames, err := allClusterTaskNames(cs)
-	if err != nil {
-		return err
-	}
+func askClusterTaskName(opts *options.DescribeOptions, clusterTaskNames []string) error {
 	if len(clusterTaskNames) == 0 {
 		return fmt.Errorf("no ClusterTasks found")
 	}
-
-	err = opts.Ask(options.ResourceNameClusterTask, clusterTaskNames)
+	err := opts.Ask(options.ResourceNameClusterTask, clusterTaskNames)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_WithoutNameIfOnlyOneClusterTaskPresent.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_WithoutNameIfOnlyOneClusterTaskPresent.golden
@@ -1,0 +1,29 @@
+Name:   task-1
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Steps
+
+ No steps
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_WithoutNameIfOnlyOneV1beta1ClusterTaskPresent.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskDescribe_WithoutNameIfOnlyOneV1beta1ClusterTaskPresent.golden
@@ -1,0 +1,29 @@
+Name:   task-1
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Steps
+
+ No steps
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/taskrun/describe.go
+++ b/pkg/cmd/taskrun/describe.go
@@ -73,13 +73,21 @@ or
 			}
 
 			if len(args) == 0 {
+				lOpts := metav1.ListOptions{}
 				if !opts.Last {
-					err = askTaskRunName(opts, p)
+					trs, err := trlist.GetAllTaskRuns(p, lOpts, opts.Limit)
 					if err != nil {
 						return err
 					}
+					if len(trs) == 1 {
+						opts.TaskrunName = strings.Fields(trs[0])[0]
+					} else {
+						err = askTaskRunName(opts, trs)
+						if err != nil {
+							return err
+						}
+					}
 				} else {
-					lOpts := metav1.ListOptions{}
 					trs, err := trlist.GetAllTaskRuns(p, lOpts, 1)
 					if err != nil {
 						return err
@@ -113,18 +121,12 @@ or
 	return c
 }
 
-func askTaskRunName(opts *options.DescribeOptions, p cli.Params) error {
-	lOpts := metav1.ListOptions{}
-
+func askTaskRunName(opts *options.DescribeOptions, trs []string) error {
 	err := opts.ValidateOpts()
 	if err != nil {
 		return err
 	}
 
-	trs, err := trlist.GetAllTaskRuns(opts.Params, lOpts, opts.Limit)
-	if err != nil {
-		return err
-	}
 	if len(trs) == 0 {
 		return fmt.Errorf("no TaskRuns found")
 	}

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneTaskRunPresent.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneTaskRunPresent.golden
@@ -1,0 +1,38 @@
+Name:        tr-1
+Namespace:   ns
+Task Ref:    t1
+Labels:
+ tekton.dev/task=t1
+
+Status
+
+STARTED          DURATION    STATUS
+20 minutes ago   5 minutes   Succeeded
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Steps
+
+No steps
+
+Sidecars
+
+No sidecars

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneV1beta1TaskRunPresent.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneV1beta1TaskRunPresent.golden
@@ -1,0 +1,38 @@
+Name:        tr-1
+Namespace:   ns
+Task Ref:    task-1
+Labels:
+ tekton.dev/task=task-1
+
+Status
+
+STARTED          DURATION    STATUS
+10 minutes ago   5 minutes   Failed
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Steps
+
+No steps
+
+Sidecars
+
+No sidecars


### PR DESCRIPTION
# Changes

- When only one `clustertask` is present then instead of prompting to user to select the `clustertask` at the time of running the `clustertask describe` command then `clustertask` will be autoselected and the output will be displayed.
- When only one `taskrun` is present then instead of prompting to user to select the `taskrun` at the time of running the `taskrun describe` command then `taskrun` will be autoselected and the output will be displayed.
- Also extracted `allClusterTaskNames` function from `pkg/cmd/clustertask/delete.go` to `pkg/clustertask/clustertask.go` in order to maintain the code consistency and also added unit tests for it.

Closes #1112 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
- Enable auto-select support in ClusterTask describe command if only one is present
- Enable auto-select support in TaskRun describe command if only one is present
```