### PR TITLE
Modify tkn version output to hide components version if they are not installed

### DIFF
--- a/pkg/cmd/version/testdata/TestGetVersions-deployment_only_with_pipeline_installed.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-deployment_only_with_pipeline_installed.golden
@@ -1,0 +1,2 @@
+Client version: dev
+Pipeline version: v0.10.0

--- a/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline,_triggers_and_dashboard_installed.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline,_triggers_and_dashboard_installed.golden
@@ -1,0 +1,4 @@
+Client version: dev
+Pipeline version: v0.10.0
+Triggers version: v0.5.0
+Dashboard version: v0.7.0

--- a/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline_and_dashboard_installed.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline_and_dashboard_installed.golden
@@ -1,0 +1,3 @@
+Client version: dev
+Pipeline version: v0.10.0
+Dashboard version: v0.7.0

--- a/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline_and_triggers_installed.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline_and_triggers_installed.golden
@@ -1,0 +1,3 @@
+Client version: dev
+Pipeline version: v0.10.0
+Triggers version: v0.5.0

--- a/pkg/cmd/version/testdata/TestGetVersions-empty_deployment_items.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-empty_deployment_items.golden
@@ -1,2 +1,2 @@
-Client version: v1.2.3
+Client version: dev
 Pipeline version: unknown, pipeline controller may be installed in another namespace please use tkn version -n {namespace}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -67,17 +67,13 @@ func Command(p cli.Params) *cobra.Command {
 
 				fmt.Fprintf(cmd.OutOrStdout(), "Pipeline version: %s\n", pipelineVersion)
 				triggersVersion, _ := version.GetTriggerVersion(cs, namespace)
-				if triggersVersion == "" {
-					triggersVersion = "unknown, " +
-						"triggers controller may be installed in another namespace please use tkn version -n {namespace}"
+				if triggersVersion != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "Triggers version: %s\n", triggersVersion)
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "Triggers version: %s\n", triggersVersion)
 				dashboardVersion, _ := version.GetDashboardVersion(cs, namespace)
-				if dashboardVersion == "" {
-					dashboardVersion = "unknown, " +
-						"dashboard controller may be installed in another namespace please use tkn version -n {namespace}"
+				if dashboardVersion != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "Dashboard version: %s\n", dashboardVersion)
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "Dashboard version: %s\n", dashboardVersion)
 			}
 
 			if !check || clientVersion == devVersion {

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,9 @@ import (
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestVersionGood(t *testing.T) {
@@ -149,4 +153,105 @@ func testingHTTPClient(handler http.Handler) (*http.Client, func()) {
 	}
 
 	return cli, s.Close
+}
+
+func TestGetVersions(t *testing.T) {
+	pipelineDeploymentLabels := map[string]string{
+		"app.kubernetes.io/part-of":   "tekton-pipelines",
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/name":      "controller",
+	}
+	triggersDeploymentLabels := map[string]string{
+		"app.kubernetes.io/part-of":   "tekton-triggers",
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/name":      "controller",
+	}
+	dashboardDeploymentLabels := map[string]string{
+		"app.kubernetes.io/part-of":   "tekton-dashboard",
+		"app.kubernetes.io/component": "dashboard",
+		"app.kubernetes.io/name":      "dashboard",
+	}
+	pipelineDeployment := getDeploymentData("pipeline-dep", "", pipelineDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.10.0"}, nil)
+	triggersDeployment := getDeploymentData("triggers-dep", "", triggersDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.5.0"}, nil)
+	dashboardDeployment := getDeploymentData("dashboard-dep", "", dashboardDeploymentLabels, map[string]string{"app.kubernetes.io/version": "v0.7.0"}, nil)
+
+	testParams := []struct {
+		name                  string
+		namespace             string
+		userProvidedNamespace string
+		deployment            []*v1.Deployment
+		goldenFile            bool
+	}{{
+		name:       "empty deployment items",
+		namespace:  "tekton-pipelines",
+		deployment: []*v1.Deployment{},
+		goldenFile: true,
+	}, {
+		name:                  "deployment only with pipeline installed",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            []*v1.Deployment{pipelineDeployment},
+		goldenFile:            true,
+	}, {
+		name:                  "deployment with pipeline and triggers installed",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            []*v1.Deployment{pipelineDeployment, triggersDeployment},
+		goldenFile:            true,
+	}, {
+		name:                  "deployment with pipeline and dashboard installed",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            []*v1.Deployment{pipelineDeployment, dashboardDeployment},
+		goldenFile:            true,
+	}, {
+		name:                  "deployment with pipeline, triggers and dashboard installed",
+		namespace:             "test",
+		userProvidedNamespace: "test",
+		deployment:            []*v1.Deployment{pipelineDeployment, triggersDeployment, dashboardDeployment},
+		goldenFile:            true,
+	}}
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			seedData, _ := test.SeedTestData(t, pipelinetest.Data{})
+			cs := pipelinetest.Clients{Kube: seedData.Kube}
+			p := &test.Params{Kube: cs.Kube}
+			version := Command(p)
+			cls, err := p.Clients()
+			if err != nil {
+				t.Errorf("failed to get client: %v", err)
+			}
+			// To add multiple deployments in a particular namespace
+			for _, v := range tp.deployment {
+				if _, err := cls.Kube.AppsV1().Deployments(tp.namespace).Create(v); err != nil {
+					t.Errorf("failed to create deployment: %v", err)
+				}
+			}
+			got, _ := test.ExecuteCommand(version, "version", "-n", "test")
+			golden.Assert(t, got, strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
+		})
+	}
+}
+
+func getDeploymentData(name, image string, deploymentLabels, podTemplateLabels, annotations map[string]string) *v1.Deployment {
+	return &v1.Deployment{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: deploymentLabels,
+		},
+		Spec: v1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      podTemplateLabels,
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: image,
+					}},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Modified tkn version output to hide Triggers and Dashboard version if they are not installed.

Closes: #1143 

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
 ```release-note
`tkn version` output is modified to hide components version if they are not installed
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

   

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
