### PR TITLE
Do not Sort TaskRuns or PipelineRuns if keep=0

### DIFF
--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -164,7 +164,12 @@ func allPipelineRunNames(cs *cli.Clients, keep int, ns string) ([]string, error)
 func keepPipelineRuns(pipelineRuns *v1beta1.PipelineRunList, keep int) []string {
 	var names []string
 	var counter = 0
-	prsort.SortByStartTime(pipelineRuns.Items)
+
+	// Do not sort PipelineRuns if keep=0 since ordering won't matter
+	if keep > 0 {
+		prsort.SortByStartTime(pipelineRuns.Items)
+	}
+
 	for _, run := range pipelineRuns.Items {
 		if keep > 0 && counter != keep {
 			counter++

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -165,7 +165,12 @@ func allTaskRunNames(cs *cli.Clients, keep int, ns string) ([]string, error) {
 func keepTaskRuns(taskRuns *v1beta1.TaskRunList, keep int) []string {
 	var names []string
 	var counter = 0
-	trsort.SortByStartTime(taskRuns.Items)
+
+	// Do not sort TaskRuns if keep=0 since ordering won't matter
+	if keep > 0 {
+		trsort.SortByStartTime(taskRuns.Items)
+	}
+
 	for _, tr := range taskRuns.Items {
 		if keep > 0 && counter != keep {
 			counter++


### PR DESCRIPTION
Closes #1155 

# Changes

If the `--keep` option for `tkn tr/pr delete` is 0, there is no need to sort runs before deletion since the order should not matter. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
