### PR TITLE
Fix golangci-lint 1.31 gocritic Issues

### DIFF
--- a/cmd/docs/man_docs.go
+++ b/cmd/docs/man_docs.go
@@ -65,7 +65,7 @@ func GenManTreeFromOpts(cmd *cobra.Command, opts GenManTreeOptions) error {
 	if opts.CommandSeparator != "" {
 		separator = opts.CommandSeparator
 	}
-	basename := strings.Replace(cmd.CommandPath(), " ", separator, -1)
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", separator)
 	filename := filepath.Join(opts.Path, basename+"."+section)
 	f, err := os.Create(filename)
 	if err != nil {
@@ -112,7 +112,7 @@ func GenMan(cmd *cobra.Command, header *GenManHeader, w io.Writer) error {
 
 func fillHeader(header *GenManHeader, name string) error {
 	if header.Title == "" {
-		header.Title = strings.ToUpper(strings.Replace(name, " ", "\\-", -1))
+		header.Title = strings.ToUpper(strings.ReplaceAll(name, " ", "\\-"))
 	}
 	if header.Section == "" {
 		header.Section = "1"
@@ -189,7 +189,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 	cmd.InitDefaultHelpFlag()
 
 	// something like `rootcmd-subcmd1-subcmd2`
-	dashCommandName := strings.Replace(cmd.CommandPath(), " ", "-", -1)
+	dashCommandName := strings.ReplaceAll(cmd.CommandPath(), " ", "-")
 
 	buf := new(bytes.Buffer)
 
@@ -204,7 +204,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 		seealsos := make([]string, 0)
 		if cmd.HasParent() {
 			parentPath := cmd.Parent().CommandPath()
-			dashParentPath := strings.Replace(parentPath, " ", "-", -1)
+			dashParentPath := strings.ReplaceAll(parentPath, " ", "-")
 			seealso := fmt.Sprintf("**%s(%s)**", dashParentPath, header.Section)
 			seealsos = append(seealsos, seealso)
 			cmd.VisitParents(func(c *cobra.Command) {

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -89,7 +89,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			parent := cmd.Parent()
 			pname := parent.CommandPath()
 			link := pname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
@@ -107,7 +107,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			}
 			cname := name + " " + child.Name()
 			link := cname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short))
 		}
 		buf.WriteString("\n")
@@ -143,7 +143,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 		}
 	}
 
-	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
 	filename := filepath.Join(dir, basename)
 	f, err := os.Create(filename)
 	if err != nil {

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -195,7 +195,7 @@ func startClusterTask(opt startOptions, args []string) error {
 	tr.Spec = v1beta1.TaskRunSpec{
 		TaskRef: &v1beta1.TaskRef{
 			Name: ctname,
-			Kind: v1beta1.ClusterTaskKind, //Specify TaskRun is for a ClusterTask kind
+			Kind: v1beta1.ClusterTaskKind, // Specify TaskRun is for a ClusterTask kind
 		},
 	}
 
@@ -213,7 +213,7 @@ func startClusterTask(opt startOptions, args []string) error {
 
 	tr.ObjectMeta.GenerateName = ctname + "-run-"
 
-	//TaskRuns are namespaced so using same LastRun method as Task
+	// TaskRuns are namespaced so using same LastRun method as Task
 	if opt.Last {
 		trLast, err := task.LastRun(cs, ctname, opt.cliparams.Namespace(), "ClusterTask")
 		if err != nil {

--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -220,10 +220,10 @@ func Test_ClusterTask_Start(t *testing.T) {
 	)
 	cs := pipelinetest.Clients{Pipeline: seedData0.Pipeline, Kube: seedData0.Kube}
 	cs.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"taskrun", "clustertask", "task"})
-	//seeds[0]
+	// seeds[0]
 	seeds = append(seeds, clients{pipelineClient: cs, dynamicClient: dc0})
 
-	//seeds[1] - Same data as seeds[0] but creates a new TaskRun
+	// seeds[1] - Same data as seeds[0] but creates a new TaskRun
 	seedData1, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns, TaskRuns: taskruns, ClusterTasks: clustertasks})
 	objs1 := []runtime.Object{clustertasks[0], taskruns[0]}
 	tdc1 := newDynamicClientOpt(versionA1, "taskrun-2", objs1...)
@@ -233,7 +233,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 	)
 	cs1 := pipelinetest.Clients{Pipeline: seedData1.Pipeline, Kube: seedData1.Kube}
 	cs1.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun", "clustertask"})
-	//seeds[1] - No TaskRun with ClusterTask
+	// seeds[1] - No TaskRun with ClusterTask
 	seeds = append(seeds, clients{pipelineClient: cs1, dynamicClient: dc1})
 
 	objs2 := []runtime.Object{clustertasks[0]}
@@ -247,10 +247,10 @@ func Test_ClusterTask_Start(t *testing.T) {
 		Kube:     seedData2.Kube,
 	}
 	cs2.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun", "clustertask"})
-	//seeds[2]
+	// seeds[2]
 	seeds = append(seeds, clients{pipelineClient: cs2, dynamicClient: dc2})
 
-	//seeds[3] - For Dry Run tests with v1alpha1
+	// seeds[3] - For Dry Run tests with v1alpha1
 	tdc3 := testDynamic.Options{}
 	dc3, _ := tdc3.Client(
 		cb.UnstructuredCT(clustertasks[0], versionA1),
@@ -258,10 +258,10 @@ func Test_ClusterTask_Start(t *testing.T) {
 	)
 	cs3, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks, Namespaces: ns})
 	cs3.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun", "clustertask"})
-	//seeds[3]
+	// seeds[3]
 	seeds = append(seeds, clients{pipelineClient: cs3, dynamicClient: dc3})
 
-	//seeds[4] - For Dry Run tests with v1beta1
+	// seeds[4] - For Dry Run tests with v1beta1
 	tdc4 := testDynamic.Options{}
 	dc4, _ := tdc4.Client(
 		cb.UnstructuredCT(clustertasks[0], versionB1),
@@ -269,10 +269,10 @@ func Test_ClusterTask_Start(t *testing.T) {
 	)
 	cs4, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks, Namespaces: ns})
 	cs4.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun", "clustertask"})
-	//seeds[4]
+	// seeds[4]
 	seeds = append(seeds, clients{pipelineClient: cs4, dynamicClient: dc4})
 
-	//seeds[5] - Same data as seeds[0] but creates a new TaskRun
+	// seeds[5] - Same data as seeds[0] but creates a new TaskRun
 	seedData5, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns, TaskRuns: taskruns, ClusterTasks: clustertasks})
 	objs5 := []runtime.Object{clustertasks[0], taskruns[0]}
 	tdc5 := newDynamicClientOpt(versionA1, "taskrun-5", objs5...)
@@ -282,7 +282,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 	)
 	cs5 := pipelinetest.Clients{Pipeline: seedData5.Pipeline, Kube: seedData5.Kube}
 	cs5.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"task", "taskrun", "clustertask"})
-	//seeds[5] - No TaskRun with ClusterTask
+	// seeds[5] - No TaskRun with ClusterTask
 	seeds = append(seeds, clients{pipelineClient: cs5, dynamicClient: dc5})
 
 	seedData6, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns, TaskRuns: taskruns, ClusterTasks: clustertasks})
@@ -294,7 +294,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 	)
 	cs6 := pipelinetest.Clients{Pipeline: seedData6.Pipeline, Kube: seedData6.Kube}
 	cs6.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"taskrun", "clustertask", "task"})
-	//seeds[6] - For Workspaces Tests
+	// seeds[6] - For Workspaces Tests
 	seeds = append(seeds, clients{pipelineClient: cs6, dynamicClient: dc6})
 
 	testParams := []struct {
@@ -932,10 +932,10 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 	)
 	cs := pipelinev1beta1test.Clients{Pipeline: seedData0.Pipeline, Kube: seedData0.Kube}
 	cs.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"taskrun", "clustertask", "task"})
-	//seeds[0]
+	// seeds[0]
 	seeds = append(seeds, clients{pipelineClient: cs, dynamicClient: dc0})
 
-	//seeds[1] - Same data as seeds[0] but creates a new TaskRun
+	// seeds[1] - Same data as seeds[0] but creates a new TaskRun
 	seedData1, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns, TaskRuns: taskruns, ClusterTasks: clustertasks})
 	objs1 := []runtime.Object{clustertasks[0], taskruns[0]}
 	tdc1 := newDynamicClientOpt(versionB1, "taskrun-2", objs1...)
@@ -945,7 +945,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 	)
 	cs1 := pipelinev1beta1test.Clients{Pipeline: seedData1.Pipeline, Kube: seedData1.Kube}
 	cs1.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun", "clustertask"})
-	//seeds[1] - No TaskRun with ClusterTask
+	// seeds[1] - No TaskRun with ClusterTask
 	seeds = append(seeds, clients{pipelineClient: cs1, dynamicClient: dc1})
 
 	objs2 := []runtime.Object{clustertasks[0]}
@@ -956,10 +956,10 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 	)
 	cs2 := pipelinev1beta1test.Clients{Pipeline: seedData2.Pipeline, Kube: seedData2.Kube}
 	cs2.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun", "clustertask"})
-	//seeds[2]
+	// seeds[2]
 	seeds = append(seeds, clients{pipelineClient: cs2, dynamicClient: dc2})
 
-	//seeds[3] - For Dry Run tests with v1alpha1
+	// seeds[3] - For Dry Run tests with v1alpha1
 	tdc3 := testDynamic.Options{}
 	dc3, _ := tdc3.Client(
 		cb.UnstructuredV1beta1CT(clustertasks[0], versionB1),
@@ -967,10 +967,10 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 	)
 	cs3, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{ClusterTasks: clustertasks, Namespaces: ns})
 	cs3.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun", "clustertask"})
-	//seeds[3]
+	// seeds[3]
 	seeds = append(seeds, clients{pipelineClient: cs3, dynamicClient: dc3})
 
-	//seeds[4] - For Dry Run tests with v1beta1
+	// seeds[4] - For Dry Run tests with v1beta1
 	tdc4 := testDynamic.Options{}
 	dc4, _ := tdc4.Client(
 		cb.UnstructuredV1beta1CT(clustertasks[0], versionB1),
@@ -978,7 +978,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 	)
 	cs4, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{ClusterTasks: clustertasks, Namespaces: ns})
 	cs4.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"task", "taskrun", "clustertask"})
-	//seeds[4]
+	// seeds[4]
 	seeds = append(seeds, clients{pipelineClient: cs4, dynamicClient: dc4})
 
 	seedData5, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns, TaskRuns: taskruns, ClusterTasks: clustertasks})
@@ -990,7 +990,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 	)
 	cs5 := pipelinev1beta1test.Clients{Pipeline: seedData5.Pipeline, Kube: seedData5.Kube}
 	cs5.Pipeline.Resources = cb.APIResourceList(versionB1, []string{"taskrun", "clustertask", "task"})
-	//seeds[5]
+	// seeds[5]
 	seeds = append(seeds, clients{pipelineClient: cs, dynamicClient: dc5})
 
 	testParams := []struct {

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -3067,7 +3067,6 @@ func Test_start_pipeline_last(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: ns,
 	})
@@ -3271,7 +3270,6 @@ func Test_start_pipeline_last_v1beta1(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Namespaces: ns,
 	})
@@ -3368,7 +3366,6 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: ns,
 	})
@@ -3552,7 +3549,6 @@ func Test_start_pipeline_last_without_res_param_v1beta1(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Namespaces: ns,
 	})
@@ -3648,7 +3644,6 @@ func Test_start_pipeline_last_merge(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: ns,
 	})
@@ -3854,7 +3849,6 @@ func Test_start_pipeline_last_merge_v1beta1(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Namespaces: ns,
 	})
@@ -3964,7 +3958,6 @@ func Test_start_pipeline_use_pipelinerun(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedTestData(t, pipelinetest.Data{
 		Namespaces: ns,
 	})
@@ -4137,7 +4130,6 @@ func Test_start_pipeline_use_pipelinerun_v1beta1(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		Namespaces: ns,
 	})

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -411,7 +411,7 @@ func (res *Resource) AskPullRequestParams() error {
 		res.PipelineResource.Spec.Params = append(res.PipelineResource.Spec.Params, urlParam)
 	}
 
-	//ask for the secrets
+	// ask for the secrets
 	qsOpts := []string{"Yes", "No"}
 	qs := "Do you want to set secrets ?"
 

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
-//Command instantiates the pipelinerun command
+// Command instantiates the pipelinerun command
 func Command(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "pipelinerun",

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -781,7 +781,6 @@ func Test_start_task_last(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns, Tasks: tasks, TaskRuns: taskruns})
 	objs := []runtime.Object{tasks[0], taskruns[0]}
 	_, tdc := newPipelineClient(versionA1, objs...)
@@ -975,7 +974,6 @@ func Test_start_task_last_v1beta1(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns, Tasks: tasks, TaskRuns: taskruns})
 	objs := []runtime.Object{tasks[0], taskruns[0]}
 	_, tdc := newPipelineClient(versionB1, objs...)
@@ -1088,7 +1086,6 @@ func Test_start_use_taskrun(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: ns, Tasks: tasks, TaskRuns: taskruns})
 
 	objs := []runtime.Object{tasks[0], taskruns[0], taskruns[1]}
@@ -1227,7 +1224,6 @@ func Test_start_use_taskrun_v1beta1(t *testing.T) {
 		},
 	}
 
-	//Add namespaces to kube client
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: ns, Tasks: tasks, TaskRuns: taskruns})
 
 	objs := []runtime.Object{tasks[0], taskruns[0], taskruns[1]}

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -1478,7 +1478,7 @@ func TestLog_taskrun_last_v1beta1(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	//cs.Pipeline.Resources = cb.APIResourceList("v1alpha1", []string{"taskrun"})
+
 	p := test.Params{
 		Kube:    cs.Kube,
 		Tekton:  cs.Pipeline,
@@ -1789,7 +1789,7 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 		trs[0].Status.PodName = trPod
 		watcher.Modify(trs[0])
 	}()
-	//time.Sleep(time.Second * 2)
+
 	output, err := fetchLogs(trlo)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -1913,7 +1913,7 @@ func TestLog_taskrun_follow_mode_update_pod_name_v1beta1(t *testing.T) {
 		trs[0].Status.PodName = trPod
 		watcher.Modify(trs[0])
 	}()
-	//time.Sleep(time.Second * 2)
+
 	output, err := fetchLogs(trlo)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -145,7 +145,7 @@ func (r *rainbow) Fprintf(label string, w io.Writer, format string, args ...inte
 	crainbow.Fprintf(w, format, args...)
 }
 
-//Color formatter to print the colored output on streams
+// Color formatter to print the colored output on streams
 type Color struct {
 	Rainbow *rainbow
 
@@ -153,7 +153,7 @@ type Color struct {
 	blue *color.Color
 }
 
-//NewColor returns a new instance color formatter
+// NewColor returns a new instance color formatter
 func NewColor() *Color {
 	return &Color{
 		Rainbow: newRainbow(),
@@ -163,12 +163,12 @@ func NewColor() *Color {
 	}
 }
 
-//PrintRed prints the formatted content to given destination in red color
+// PrintRed prints the formatted content to given destination in red color
 func (c *Color) PrintRed(w io.Writer, format string, args ...interface{}) {
 	c.red.Fprintf(w, format, args...)
 }
 
-//Error prints the formatted content to given destination in red color
+// Error prints the formatted content to given destination in red color
 func (c *Color) Error(w io.Writer, format string, args ...interface{}) {
 	c.PrintRed(w, format, args...)
 }

--- a/pkg/pipeline/pipelinelastrun.go
+++ b/pkg/pipeline/pipelinelastrun.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//DynamicLastRun returns the last run for a given pipeline
+// DynamicLastRun returns the last run for a given pipeline
 func LastRun(cs *cli.Clients, pipeline string, ns string) (*v1beta1.PipelineRun, error) {
 	options := metav1.ListOptions{}
 	if pipeline != "" {

--- a/pkg/pipelinerun/tracker.go
+++ b/pkg/pipelinerun/tracker.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-//Tracker tracks the progress of a PipelineRun
+// Tracker tracks the progress of a PipelineRun
 type Tracker struct {
 	Name         string
 	Ns           string
@@ -39,7 +39,7 @@ type Tracker struct {
 	ongoingTasks map[string]bool
 }
 
-//NewTracker returns a new instance of Tracker
+// NewTracker returns a new instance of Tracker
 func NewTracker(name string, ns string, tekton versioned.Interface) *Tracker {
 	return &Tracker{
 		Name:         name,
@@ -49,10 +49,10 @@ func NewTracker(name string, ns string, tekton versioned.Interface) *Tracker {
 	}
 }
 
-//Monitor to observe the progress of PipelineRun. It emits
-//an event upon starting of a new Pipeline's Task.
-//allowed containers the name of the Pipeline tasks, which used as filter
-//limit the events to only those tasks
+// Monitor to observe the progress of PipelineRun. It emits
+// an event upon starting of a new Pipeline's Task.
+// allowed containers the name of the Pipeline tasks, which used as filter
+// limit the events to only those tasks
 func (t *Tracker) Monitor(allowed []string) <-chan []trh.Run {
 
 	factory := informers.NewSharedInformerFactoryWithOptions(

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -40,7 +40,7 @@ func NewStream(pods typedv1.PodInterface, name string, opts *corev1.PodLogOption
 	return &Stream{name, pods, opts}
 }
 
-//Stream Creates a stream object which allows reading the logs
+// Stream Creates a stream object which allows reading the logs
 func (s *Stream) Stream() (io.ReadCloser, error) {
 	return s.pods.GetLogs(s.name, s.opts).Stream()
 }
@@ -68,7 +68,7 @@ func NewWithDefaults(name, ns string, client k8s.Interface) *Pod {
 	}
 }
 
-//Wait wait for the pod to get up and running
+// Wait wait for the pod to get up and running
 func (p *Pod) Wait() (*corev1.Pod, error) {
 	// ensure pod exists before we actually check for it
 	if _, err := p.Get(); err != nil {
@@ -145,12 +145,12 @@ func checkPodStatus(obj interface{}) (*corev1.Pod, error) {
 	return nil, nil
 }
 
-//Get gets the pod
+// Get gets the pod
 func (p *Pod) Get() (*corev1.Pod, error) {
 	return p.Kc.CoreV1().Pods(p.Ns).Get(p.Name, metav1.GetOptions{})
 }
 
-//Container returns the an instance of Container
+// Container returns the an instance of Container
 func (p *Pod) Container(c string) *Container {
 	return &Container{
 		name:        c,
@@ -159,7 +159,7 @@ func (p *Pod) Container(c string) *Container {
 	}
 }
 
-//Stream returns the stream object for given container and mode
+// Stream returns the stream object for given container and mode
 // in order to fetch the logs
 func (p *Pod) Stream(opt *corev1.PodLogOptions) (io.ReadCloser, error) {
 	pods := p.Kc.CoreV1().Pods(p.Ns)

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//LastRun returns the last taskrun for a given task
+// LastRun returns the last taskrun for a given task
 func LastRun(cs *cli.Clients, task string, ns, kind string) (*v1beta1.TaskRun, error) {
 	options := metav1.ListOptions{}
 	if task != "" {

--- a/pkg/test/dynamic/clientset/clientset.go
+++ b/pkg/test/dynamic/clientset/clientset.go
@@ -46,8 +46,8 @@ func (r *Clientset) Add(resource schema.GroupVersionResource, client dynamic.Int
 	r.config[resource] = client
 }
 
-//Resource returns the dynamic Resource for the given GVR. If not configured,
-//an error resource is returned.
+// Resource returns the dynamic Resource for the given GVR. If not configured,
+// an error resource is returned.
 func (r *Clientset) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
 	i, ok := r.config[resource]
 	if !ok {

--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -221,7 +221,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 
 			return emptyMsg
 		}
-		//sort by start Time
+		// sort by start Time
 		SortByStartTimeTaskRun(obj.Items)
 
 		for _, r := range obj.Items {

--- a/test/e2e/resource/create_test.go
+++ b/test/e2e/resource/create_test.go
@@ -680,8 +680,8 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"cadatakey": []byte("Y2EtY2VydAo="), //ca-cert
-			"tokenkey":  []byte("dG9rZW4K"),     //token
+			"cadatakey": []byte("Y2EtY2VydAo="), // ca-cert
+			"tokenkey":  []byte("dG9rZW4K"),     // token
 		},
 	}
 }

--- a/test/framework/helper.go
+++ b/test/framework/helper.go
@@ -69,7 +69,7 @@ func Header(logf logging.FormatLogger, text string) {
 	logf(bar)
 }
 
-//Create Service Account
+// Create Service Account
 func CreateServiceAccountSecret(c *knativetest.KubeClient, namespace string, secretName string) (bool, error) {
 
 	file := os.Getenv("SERVICE_ACCOUNT_KEY_PATH")

--- a/test/wait/helper-wait.go
+++ b/test/wait/helper-wait.go
@@ -100,7 +100,7 @@ func ForPodStateKube(c *knativetest.KubeClient, namespace string, inState PodRun
 			return inState(r)
 		})
 		if err1 != nil {
-			log.Fatal(err1.Error())
+			log.Panic(err1.Error())
 		}
 	}
 
@@ -123,7 +123,7 @@ func ForPodStatus(kubeClient *knativetest.KubeClient, namespace string) {
 			log.Println("Status of resources are up and running ")
 		}
 	case <-time.After(30 * time.Second):
-		log.Fatalln("Status of resources are not up and running ")
+		log.Panicln("Status of resources are not up and running ")
 	}
 
 }

--- a/test/wait/wait.go
+++ b/test/wait/wait.go
@@ -83,7 +83,7 @@ func ForPipelineRunToStart(c *framework.Clients, prname string, namespace string
 	}
 }
 
-//WaitForPipelineRunToComplete Wait for Pipeline Run to complete
+// WaitForPipelineRunToComplete Wait for Pipeline Run to complete
 func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace string) {
 	log.Printf("Waiting for Pipelinerun %s in namespace %s to be started", prname, namespace)
 	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
@@ -129,12 +129,12 @@ func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace str
 
 	for i := 1; i <= len(taskrunList.Items); i++ {
 		if <-errChan != nil {
-			log.Fatalf("Error waiting for TaskRun %s to be running: %s", taskrunList.Items[i-1].Name, err)
+			log.Panicf("Error waiting for TaskRun %s to be running: %s", taskrunList.Items[i-1].Name, err)
 		}
 	}
 
 	if _, err := c.PipelineRunClient.Get(prname, metav1.GetOptions{}); err != nil {
-		log.Fatalf("Failed to get PipelineRun `%s`: %s", prname, err)
+		log.Panicf("Failed to get PipelineRun `%s`: %s", prname, err)
 	}
 
 	log.Printf("Waiting for PipelineRun %s in namespace %s to be Completed", prname, namespace)
@@ -149,7 +149,7 @@ func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace str
 		}
 		return false, nil
 	}, "PipelineRunSuccess"); err != nil {
-		log.Fatalf("Error waiting for PipelineRun %s to finish: %s", prname, err)
+		log.Panicf("Error waiting for PipelineRun %s to finish: %s", prname, err)
 	}
 
 	log.Printf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be completed", prname, namespace)
@@ -177,6 +177,6 @@ func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace str
 	wg.Wait()
 
 	if _, err := c.PipelineRunClient.Get(prname, metav1.GetOptions{}); err != nil {
-		log.Fatalf("Failed to get PipelineRun `%s`: %s", prname, err)
+		log.Panicf("Failed to get PipelineRun `%s`: %s", prname, err)
 	}
 }


### PR DESCRIPTION
Closes #1160 

# Changes

In `golangci-lint` version 1.31, `gocritic` has the following changes:
* A space is required after each code comment, so something like //comment would be flagged but // comment is acceptable. This is the same comment standard used by Kubernetes as well.
* [`exitAfterDefer`](https://quasilyte.dev/blog/post/log-fatal-vs-log-panic/) recommends the use of `log.Panic` versus `log.Fatal`
* `Replace(..., -1)` should be replaced with `ReplaceAll(...)`. More [here](https://github.com/go-critic/go-critic/issues/872)

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
