### PR TITLE
Update Condition Tests from Test Builders to Structs

### DIFF
--- a/pkg/cmd/condition/delete_test.go
+++ b/pkg/cmd/condition/delete_test.go
@@ -22,9 +22,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
-	cb "github.com/tektoncd/cli/pkg/test/builder"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,18 +43,27 @@ func TestConditionDelete(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		conditions := []*v1alpha1.Condition{
-			tb.Condition("condition1",
-				tb.ConditionNamespace("ns"),
-				cb.ConditionCreationTime(clock.Now().Add(-1*time.Minute)),
-			),
-			tb.Condition("condition2",
-				tb.ConditionNamespace("ns"),
-				cb.ConditionCreationTime(clock.Now().Add(-1*time.Minute)),
-			),
-			tb.Condition("condition3",
-				tb.ConditionNamespace("ns"),
-				cb.ConditionCreationTime(clock.Now().Add(-1*time.Minute)),
-			),
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "condition1",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "condition2",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "condition3",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				},
+			},
 		}
 		s, _ := test.SeedTestData(t, pipelinetest.Data{Conditions: conditions, Namespaces: ns})
 		seeds = append(seeds, s)

--- a/pkg/cmd/condition/describe_test.go
+++ b/pkg/cmd/condition/describe_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	tb "github.com/tektoncd/pipeline/test/builder"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
@@ -30,57 +30,158 @@ import (
 
 func TestConditionDescribe(t *testing.T) {
 	conditions := []*v1alpha1.Condition{
-		tb.Condition("cond-1",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(
-				tb.ConditionSpecCheck("test", "busybox"),
-				tb.ConditionSpecCheckScript("echo hello"),
-				tb.ConditionParamSpec("myarg", v1alpha1.ParamTypeString, tb.ParamSpecDescription("param type is string"),
-					tb.ParamSpecDefault("default")),
-				tb.ConditionParamSpec("print", v1alpha1.ParamTypeArray, tb.ParamSpecDescription("param type is array"),
-					tb.ParamSpecDefault("booms", "booms", "booms")),
-				tb.ConditionParamSpec("print", v1alpha1.ParamTypeString),
-				tb.ConditionResource("my-repo", v1alpha1.PipelineResourceTypeGit),
-				tb.ConditionResource("my-image", v1alpha1.PipelineResourceTypeImage),
-				tb.ConditionResource("code-image", v1alpha1.PipelineResourceTypeImage),
-				tb.ConditionDescription("test"),
-			),
-		),
-		tb.Condition("cond-2",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(
-				tb.ConditionSpecCheck("test", "busybox"),
-				tb.ConditionSpecCheckScript("echo hello"),
-			),
-		),
-		tb.Condition("cond-3",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(
-				tb.ConditionSpecCheck("test", "busybox"),
-				tb.ConditionSpecCheckScript("echo hello"),
-				tb.ConditionParamSpec("print", v1alpha1.ParamTypeString),
-				tb.ConditionResource("my-repo", v1alpha1.PipelineResourceTypeGit),
-				tb.ConditionDescription("test"),
-			),
-		),
-		tb.Condition("cond-4",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(
-				tb.ConditionSpecCheck("test", "busybox",
-					tb.Args("echo", "hello"),
-					tb.Command("/bin/sh"),
-				),
-				tb.ConditionParamSpec("myarg", v1alpha1.ParamTypeString, tb.ParamSpecDescription("param type is string"),
-					tb.ParamSpecDefault("default")),
-				tb.ConditionParamSpec("print", v1alpha1.ParamTypeArray, tb.ParamSpecDescription("param type is array"),
-					tb.ParamSpecDefault("booms", "booms", "booms")),
-				tb.ConditionParamSpec("print", v1alpha1.ParamTypeString),
-				tb.ConditionResource("my-repo", v1alpha1.PipelineResourceTypeGit),
-				tb.ConditionResource("my-image", v1alpha1.PipelineResourceTypeImage),
-				tb.ConditionResource("code-image", v1alpha1.PipelineResourceTypeImage),
-				tb.ConditionDescription("test"),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cond-1",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Check: v1beta1.Step{
+					Container: corev1.Container{
+						Name:  "test",
+						Image: "busybox",
+					},
+					Script: "echo hello",
+				},
+				Params: []v1beta1.ParamSpec{
+					{
+						Name:        "myarg",
+						Type:        v1beta1.ParamTypeString,
+						Description: "param type is string",
+						Default: &v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "default",
+						},
+					},
+					{
+						Name:        "print",
+						Type:        v1beta1.ParamTypeArray,
+						Description: "param type is array",
+						Default: &v1beta1.ArrayOrString{
+							Type:     v1beta1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+					{
+						Name: "print",
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Resources: []v1beta1.ResourceDeclaration{
+					{
+						Name: "my-repo",
+						Type: v1alpha1.PipelineResourceTypeGit,
+					},
+					{
+						Name: "my-image",
+						Type: v1alpha1.PipelineResourceTypeImage,
+					},
+					{
+						Name: "code-image",
+						Type: v1alpha1.PipelineResourceTypeImage,
+					},
+				},
+				Description: "test",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cond-2",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Check: v1beta1.Step{
+					Container: corev1.Container{
+						Name:  "test",
+						Image: "busybox",
+					},
+					Script: "echo hello",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cond-3",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Check: v1beta1.Step{
+					Container: corev1.Container{
+						Name:  "test",
+						Image: "busybox",
+					},
+					Script: "echo hello",
+				},
+				Params: []v1beta1.ParamSpec{
+					{
+						Name: "print",
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Resources: []v1beta1.ResourceDeclaration{
+					{
+						Name: "my-repo",
+						Type: v1alpha1.PipelineResourceTypeGit,
+					},
+				},
+				Description: "test",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cond-4",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Check: v1beta1.Step{
+					Container: corev1.Container{
+						Name:    "test",
+						Image:   "busybox",
+						Args:    []string{"echo", "hello"},
+						Command: []string{"/bin/sh"},
+					},
+				},
+				Params: []v1beta1.ParamSpec{
+					{
+						Name:        "myarg",
+						Type:        v1beta1.ParamTypeString,
+						Description: "param type is string",
+						Default: &v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "default",
+						},
+					},
+					{
+						Name:        "print",
+						Type:        v1beta1.ParamTypeArray,
+						Description: "param type is array",
+						Default: &v1beta1.ArrayOrString{
+							Type:     v1beta1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+					{
+						Name: "print",
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Resources: []v1beta1.ResourceDeclaration{
+					{
+						Name: "my-repo",
+						Type: v1alpha1.PipelineResourceTypeGit,
+					},
+					{
+						Name: "my-image",
+						Type: v1alpha1.PipelineResourceTypeImage,
+					},
+					{
+						Name: "code-image",
+						Type: v1alpha1.PipelineResourceTypeImage,
+					},
+				},
+				Description: "test",
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{

--- a/pkg/cmd/condition/list_test.go
+++ b/pkg/cmd/condition/list_test.go
@@ -23,9 +23,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
-	cb "github.com/tektoncd/cli/pkg/test/builder"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	tb "github.com/tektoncd/pipeline/test/builder"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
@@ -54,46 +52,69 @@ func TestConditionList(t *testing.T) {
 
 	// Testdata pattern1.
 	conditions := []*v1alpha1.Condition{
-		tb.Condition("condition1",
-			tb.ConditionNamespace("ns"),
-			cb.ConditionCreationTime(clock.Now().Add(-1*time.Minute)),
-		),
-		tb.Condition("condition2",
-			tb.ConditionNamespace("ns"),
-			cb.ConditionCreationTime(clock.Now().Add(-20*time.Second)),
-		),
-		tb.Condition("condition3",
-			tb.ConditionNamespace("ns"),
-			cb.ConditionCreationTime(clock.Now().Add(-512*time.Hour)),
-		),
-		tb.Condition("condition4",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(tb.ConditionDescription("a test condition")),
-			cb.ConditionCreationTime(clock.Now().Add(-513*time.Hour)),
-		),
-		tb.Condition("condition5",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(
-				tb.ConditionDescription("a test condition to check the trimming is working"),
-			),
-			cb.ConditionCreationTime(clock.Now().Add(-514*time.Hour)),
-		),
-		tb.Condition("condition6",
-			tb.ConditionNamespace("ns"),
-			tb.ConditionSpec(
-				tb.ConditionDescription(""),
-			),
-			cb.ConditionCreationTime(clock.Now().Add(-516*time.Hour)),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition1",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition2",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition3",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-512 * time.Hour)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition4",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-513 * time.Hour)},
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Description: "a test condition",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition5",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-514 * time.Hour)},
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Description: "a test condition to check the trimming is working",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition6",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-516 * time.Hour)},
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Description: "",
+			},
+		},
 	}
 	s, _ := test.SeedTestData(t, pipelinetest.Data{Conditions: conditions, Namespaces: ns})
 
 	// Testdata pattern2.
 	conditions2 := []*v1alpha1.Condition{
-		tb.Condition("condition1",
-			tb.ConditionNamespace("ns"),
-			cb.ConditionCreationTime(clock.Now().Add(-1*time.Minute)),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "condition1",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
 	}
 	s2, _ := test.SeedTestData(t, pipelinetest.Data{Conditions: conditions2, Namespaces: ns})
 	s2.Pipeline.PrependReactor("list", "conditions", func(action k8stest.Action) (bool, runtime.Object, error) {


### PR DESCRIPTION
Part of #1145 

Migrating unit tests for `tkn condition` from test builders to structs. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```