### PR TITLE
Fix rpm build for release

### DIFF
--- a/tekton/rpmbuild/README.md
+++ b/tekton/rpmbuild/README.md
@@ -42,6 +42,8 @@ need to have a PipelineResource for your git repository. See
 kubectl create secret generic copr-cli-config --from-file=copr=${HOME}/.config/copr
 ```
 
+* Make sure you have the GitHUB token set as documented in [RELEASE_PROCESS.md](../../RELEASE_PROCESS.md)
+
 * You should be able create the task with:
 
 ```

--- a/tekton/rpmbuild/rpmbuild-run.yml
+++ b/tekton/rpmbuild/rpmbuild-run.yml
@@ -1,16 +1,19 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: rpmbuild-taskrun
 spec:
   taskRef:
+    kind: Task
     name: rpmbuild
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: source
-        resourceRef:
-          name: tektoncd-cli-git
-    params:
-    - name: copr-cli-secret
-      value: copr-cli-config
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: master
+            - name: url
+              value: https://github.com/tektoncd/cli

--- a/tekton/rpmbuild/rpmbuild.yml
+++ b/tekton/rpmbuild/rpmbuild.yml
@@ -1,30 +1,27 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: rpmbuild
 spec:
-  inputs:
-    params:
-    - name: copr-cli-secret
-      description: copr cli secret
-      default: copr-cli-config
-    - name: github-token-secret
-      description: name of the secret holding the github-token
-      default: github-token
-    resources:
-    - name: source
-      type: git
-      targetPath: src
+  resources:
+    inputs:
+      - name: source
+        type: git
+        targetPath: src
   steps:
   - name: build-rpm
+    env:
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: bot-token-github
+          key: bot-token
+    - name: COPR_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: copr-cli-config
+          key: copr
     image: quay.io/chmouel/rpmbuild
     workingdir: /workspace/src
     command: ["tekton/rpmbuild/build.sh"]
-    volumeMounts:
-      - name: copr-cli-config
-        mountPath: /var/secret/copr
-  volumes:
-    - name: copr-cli-config
-      secret:
-        secretName: "$(inputs.params.copr-cli-secret)"


### PR DESCRIPTION
* fix referenced pipelineresource not existing anymore
* Use a github-token to do github operation to don't get rate limited (since we
have already one setup)
* use v1beta1

Fixes #1171


```release-note
   NONE
```