### PR TITLE
Update PipelineResource Tests from Test Builders to Structs

### DIFF
--- a/pkg/cmd/pipelineresource/create_test.go
+++ b/pkg/cmd/pipelineresource/create_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	goexpect "github.com/Netflix/go-expect"
-	tb "github.com/tektoncd/cli/internal/builder/v1alpha1"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -36,14 +35,29 @@ func init() {
 	core.DisableColor = true
 }
 
+func getPipelineResource() *v1alpha1.PipelineResource {
+	return &v1alpha1.PipelineResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "res",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeImage,
+			Params: []v1alpha1.ResourceParam{
+				{
+					Name:  "url",
+					Value: "git@github.com:tektoncd/cli.git",
+				},
+			},
+		},
+	}
+}
+
 func TestPipelineResource_resource_noName(t *testing.T) {
+	pres := getPipelineResource()
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		PipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("res",
-				tb.PipelineResourceNamespace("namespace"),
-				tb.PipelineResourceSpec("git",
-					tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
-				)),
+			pres,
 		},
 		Namespaces: []*corev1.Namespace{
 			{
@@ -105,14 +119,10 @@ func TestPipelineResource_resource_noName(t *testing.T) {
 
 func TestPipelineResource_resource_already_exist(t *testing.T) {
 	t.Skip("Skipping due of flakiness")
+	pres := getPipelineResource()
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{
 		PipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("res",
-				tb.PipelineResourceNamespace("namespace"),
-				tb.PipelineResourceSpec("git",
-					tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
-				),
-			),
+			pres,
 		},
 		Namespaces: []*corev1.Namespace{
 			{

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	tb "github.com/tektoncd/cli/internal/builder/v1alpha1"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
@@ -39,12 +38,21 @@ func TestPipelineResourceDelete(t *testing.T) {
 	seeds := make([]pipelinetest.Clients, 0)
 	for i := 0; i < 5; i++ {
 		pres := []*v1alpha1.PipelineResource{
-			tb.PipelineResource("pre-1",
-				tb.PipelineResourceNamespace("ns"),
-				tb.PipelineResourceSpec("image",
-					tb.PipelineResourceSpecParam("URL", "quay.io/tekton/controller"),
-				),
-			),
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pre-1",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeImage,
+					Params: []v1alpha1.ResourceParam{
+						{
+							Name:  "URL",
+							Value: "quay.io/tekton/controller",
+						},
+					},
+				},
+			},
 		}
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineResources: pres, Namespaces: ns})
 		seeds = append(seeds, cs)

--- a/pkg/cmd/pipelineresource/describe_test.go
+++ b/pkg/cmd/pipelineresource/describe_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/jonboulle/clockwork"
-	tb "github.com/tektoncd/cli/internal/builder/v1alpha1"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
@@ -83,13 +82,22 @@ func TestPipelineResourceDescribe_WithParams(t *testing.T) {
 	}
 
 	pres := []*v1alpha1.PipelineResource{
-		tb.PipelineResource("test-1",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("image",
-				tb.PipelineResourceDescription("a test description"),
-				tb.PipelineResourceSpecParam("URL", "quay.io/tekton/controller"),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-1",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type:        v1alpha1.PipelineResourceTypeImage,
+				Description: "a test description",
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "URL",
+						Value: "quay.io/tekton/controller",
+					},
+				},
+			},
+		},
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineResources: pres, Namespaces: ns})
@@ -109,15 +117,33 @@ func TestPipelineResourceDescribe_WithSecretParams(t *testing.T) {
 	}
 
 	pres := []*v1alpha1.PipelineResource{
-		tb.PipelineResource("test-1",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("image",
-				tb.PipelineResourceDescription("a test description"),
-				tb.PipelineResourceSpecParam("URL", "quay.io/tekton/controller"),
-				tb.PipelineResourceSpecParam("TAG", "latest"),
-				tb.PipelineResourceSpecSecretParam("githubToken", "github-secrets", "token"),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-1",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type:        v1alpha1.PipelineResourceTypeImage,
+				Description: "a test description",
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "URL",
+						Value: "quay.io/tekton/controller",
+					},
+					{
+						Name:  "TAG",
+						Value: "latest",
+					},
+				},
+				SecretParams: []v1alpha1.SecretParam{
+					{
+						FieldName:  "githubToken",
+						SecretKey:  "token",
+						SecretName: "github-secrets",
+					},
+				},
+			},
+		},
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineResources: pres, Namespaces: ns})
@@ -134,9 +160,12 @@ func TestPipelineResourcesDescribe_custom_output(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	prs := []*v1alpha1.PipelineResource{
-		tb.PipelineResource(name,
-			tb.PipelineResourceNamespace("ns"),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "ns",
+			},
+		},
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{

--- a/pkg/cmd/pipelineresource/list_test.go
+++ b/pkg/cmd/pipelineresource/list_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	tb "github.com/tektoncd/cli/internal/builder/v1alpha1"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
@@ -32,40 +31,90 @@ import (
 func TestPipelineResourceList(t *testing.T) {
 
 	pres := []*v1alpha1.PipelineResource{
-		tb.PipelineResource("test",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("git",
-				tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli-new.git"),
-			),
-		),
-		tb.PipelineResource("test-1",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("image",
-				tb.PipelineResourceSpecParam("URL", "quey.io/tekton/controller"),
-			),
-		),
-		tb.PipelineResource("test-2",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("git",
-				tb.PipelineResourceSpecParam("url", "git@github.com:tektoncd/cli.git"),
-			),
-		),
-		tb.PipelineResource("test-3",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("image"),
-		),
-		tb.PipelineResource("test-4",
-			tb.PipelineResourceNamespace("test-ns-2"),
-			tb.PipelineResourceSpec("image",
-				tb.PipelineResourceSpecParam("URL", "quey.io/tekton/webhook"),
-			),
-		),
-		tb.PipelineResource("test-5",
-			tb.PipelineResourceNamespace("test-ns-1"),
-			tb.PipelineResourceSpec("cloudEvent",
-				tb.PipelineResourceSpecParam("targetURI", "http://sink"),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeGit,
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "url",
+						Value: "git@github.com:tektoncd/cli-new.git",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-1",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeImage,
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "URL",
+						Value: "quey.io/tekton/controller",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-2",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeGit,
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "url",
+						Value: "git@github.com:tektoncd/cli.git",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-3",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeImage,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-4",
+				Namespace: "test-ns-2",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeImage,
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "URL",
+						Value: "quey.io/tekton/webhook",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-5",
+				Namespace: "test-ns-1",
+			},
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeCloudEvent,
+				Params: []v1alpha1.ResourceParam{
+					{
+						Name:  "targetURI",
+						Value: "http://sink",
+					},
+				},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{


### PR DESCRIPTION
Regardless of whether to go with the approach in this [comment](https://github.com/tektoncd/cli/issues/1145#issuecomment-694898219) in #1145, PipelineResources should be moved to structs since they are not part of the `v1beta1` API.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
