### PR TITLE
Remove release-note block indentation in PR template 🌮

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,19 +28,19 @@ release notes for the next release!
 
 For pull requests with a release note:
 
-    ```release-note
-    Your release note here
-    ```
+```release-note
+Your release note here
+```
 
 For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
 
-    ```release-note
-    action required: your release note here
-    ```
+```release-note
+action required: your release note here
+```
 
 For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
 
-    ```release-note
-    NONE
-    ```
+```release-note
+NONE
+```
 -->


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Having the indentation on those code block make its more painful for
users to easily write the release note block.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @tektoncd/cli-maintainers 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._
