### PR TITLE
Fix deployment fetch issue for multiple namespaces

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -64,7 +64,11 @@ func getDeployments(c *cli.Clients, newLabel, oldLabel, ns string) (*v1.Deployme
 	for _, n := range defaultNamespaces {
 		deployments, err = getDeploy(c, newLabel, oldLabel, n)
 		if err != nil {
-			return nil, err
+			if strings.Contains(err.Error(), fmt.Sprintf(`cannot list resource "deployments" in API group "apps" in the namespace "%s"`, n)) {
+				continue
+			} else {
+				return nil, err
+			}
 		}
 		if len(deployments.Items) != 0 {
 			break


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Missed to handle multiple namespaces as part of this PR https://github.com/tektoncd/cli/pull/1092

/cc @piyush-garg @vdemeester 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
