### PR TITLE
Enable auto-select support in pipelineDescribe if only one pipeline is present

### DIFF
--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -117,6 +117,46 @@ func TestPipelineDescribe_empty(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
+func TestPipelineDescribe_WithoutNameOfOnlyOnePipelinePresent(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+
+}
+
 func TestPipelineDescribe_with_run(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
@@ -739,6 +779,67 @@ func TestPipelineDescribeV1beta1_custom_output(t *testing.T) {
 	if got != "pipeline.tekton.dev/pipeline" {
 		t.Errorf("Result should be 'pipeline.tekton.dev/pipeline' != '%s'", got)
 	}
+}
+
+func TestPipelineDescribeV1beta1_WithoutNameIfOnlyOnePipelinePresent(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1beta1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1beta1.PipelineSpec{
+				Resources: []v1beta1.PipelineDeclaredResource{
+					{
+						Name: "name",
+						Type: v1alpha1.PipelineResourceTypeGit,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1P(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
 func TestPipelineDescribeV1beta1_task_conditions(t *testing.T) {

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_WithoutNameIfOnlyOnePipelinePresent.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_WithoutNameIfOnlyOnePipelinePresent.golden
@@ -1,0 +1,29 @@
+Name:        pipeline
+Namespace:   ns
+
+Resources
+
+ NAME   TYPE
+ name   git
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Tasks
+
+ NAME     TASKREF   RUNAFTER   TIMEOUT   CONDITIONS   PARAMS
+ task-1   task-1               ---       ---          ---
+ task-2   task-2               ---       ---          ---
+
+PipelineRuns
+
+ No pipelineruns

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameOfOnlyOnePipelinePresent.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameOfOnlyOnePipelinePresent.golden
@@ -1,0 +1,26 @@
+Name:        pipeline
+Namespace:   ns
+
+Resources
+
+ No resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Tasks
+
+ No tasks
+
+PipelineRuns
+
+ No pipelineruns


### PR DESCRIPTION



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When only one `pipeline` is present then instead of prompting to user to select the
pipeline at the time of running the `pipeline describe` command then pipeline will
be `autoselected` and the output will be displayed.

Closes: #1111 

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Enable auto-select support in Pipeline describe command if only one is present
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
