### PR TITLE
Refactor PipelineRun and TaskRun Cancel Error Based on Condition Status

### DIFF
--- a/pkg/cmd/pipelinerun/cancel_test.go
+++ b/pkg/cmd/pipelinerun/cancel_test.go
@@ -74,17 +74,59 @@ func Test_cancel_pipelinerun(t *testing.T) {
 	prName := "test-pipeline-run-123"
 
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun(prName,
-			tb.PipelineRunNamespace("ns"),
-			tb.PipelineRunLabel("tekton.dev/pipeline", "pipelineName"),
-			tb.PipelineRunSpec("pipelineName",
-				tb.PipelineRunServiceAccountName("test-sa"),
-				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
-				tb.PipelineRunResourceBinding("build-image", tb.PipelineResourceBindingRef("some-image")),
-				tb.PipelineRunParam("pipeline-param-1", "somethingmorefun"),
-				tb.PipelineRunParam("rev-param", "revision1"),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prName,
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipelineName"},
+			},
+			Spec: v1alpha1.PipelineRunSpec{
+				PipelineRef: &v1alpha1.PipelineRef{
+					Name: "pipelineName",
+				},
+				ServiceAccountName: "test-sa",
+				Resources: []v1alpha1.PipelineResourceBinding{
+					{
+						Name: "git-repo",
+						ResourceRef: &v1alpha1.PipelineResourceRef{
+							Name: "some-repo",
+						},
+					},
+					{
+						Name: "build-image",
+						ResourceRef: &v1alpha1.PipelineResourceRef{
+							Name: "some-image",
+						},
+					},
+				},
+				Params: []v1alpha1.Param{
+					{
+						Name: "pipeline-param-1",
+						Value: v1alpha1.ArrayOrString{
+							Type:      v1alpha1.ParamTypeString,
+							StringVal: "somethingmorefun",
+						},
+					},
+					{
+						Name: "somethingmorefun",
+						Value: v1alpha1.ArrayOrString{
+							Type:      v1alpha1.ParamTypeString,
+							StringVal: "revision1",
+						},
+					},
+				},
+			},
+			Status: v1alpha1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionUnknown,
+							Type:   apis.ConditionReady,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	cs, _ := test.SeedTestData(t, pipelinetest.Data{PipelineRuns: prs, Namespaces: ns})
@@ -365,6 +407,16 @@ func Test_cancel_pipelinerun_v1beta1(t *testing.T) {
 						Value: v1beta1.ArrayOrString{
 							Type:      v1beta1.ParamTypeString,
 							StringVal: "revision1",
+						},
+					},
+				},
+			},
+			Status: v1alpha1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionUnknown,
+							Type:   apis.ConditionReady,
 						},
 					},
 				},

--- a/pkg/cmd/taskrun/cancel_test.go
+++ b/pkg/cmd/taskrun/cancel_test.go
@@ -43,7 +43,7 @@ func TestTaskRunCancel(t *testing.T) {
 			tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
 			tb.TaskRunStatus(
 				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
+					Status: corev1.ConditionUnknown,
 					Reason: v1beta1.TaskRunReasonRunning.String(),
 				}),
 			),
@@ -62,17 +62,28 @@ func TestTaskRunCancel(t *testing.T) {
 	}
 
 	trs2 := []*v1alpha1.TaskRun{
-		tb.TaskRun("failure-taskrun-1",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "failure-task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("failure-task")),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonFailed.String(),
-				}),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "failure-taskrun-1",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "failure-task"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "failure-task",
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionUnknown,
+							Type:   apis.ConditionReady,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	trs3 := []*v1alpha1.TaskRun{
@@ -242,7 +253,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 				Status: duckv1beta1.Status{
 					Conditions: duckv1beta1.Conditions{
 						{
-							Status: corev1.ConditionTrue,
+							Status: corev1.ConditionUnknown,
 							Reason: v1beta1.TaskRunReasonRunning.String(),
 						},
 					},
@@ -311,7 +322,7 @@ func TestTaskRunCancel_v1beta1(t *testing.T) {
 				Status: duckv1beta1.Status{
 					Conditions: duckv1beta1.Conditions{
 						{
-							Status: corev1.ConditionTrue,
+							Status: corev1.ConditionUnknown,
 							Reason: v1beta1.TaskRunReasonFailed.String(),
 						},
 					},

--- a/test/resources/cancel/pipeline-cancel.yaml
+++ b/test/resources/cancel/pipeline-cancel.yaml
@@ -12,26 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: EventListener
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
 metadata:
-  name: github-listener-interceptor
+  name: sleep-pipeline
 spec:
-  serviceAccountName: tekton-triggers-github-sa
-  replicas: 3
-  triggers:
-    - name: github-listener
-      interceptors:
-        - github:
-            secretRef:
-              secretName: github-secret
-              secretKey: secretToken
-            eventTypes:
-              - pull_request
-        - cel:
-            filter: "body.action in ['opened', 'synchronize', 'reopened']"
-      bindings:
-        - ref: github-pr-binding
-      template:
-        name: github-template
+  params:
+  - name: seconds
+    default: 10s
+    type: string
+  tasks:
+  - name: pipelinetask1
+    taskRef:
+      kind: Task
+      name: sleep
+    params:
+    - name: seconds
+      value: $(params.seconds)

--- a/test/resources/cancel/task-cancel.yaml
+++ b/test/resources/cancel/task-cancel.yaml
@@ -12,26 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: EventListener
+apiVersion: tekton.dev/v1alpha1
+kind: Task
 metadata:
-  name: github-listener-interceptor
+  name: sleep
 spec:
-  serviceAccountName: tekton-triggers-github-sa
-  replicas: 3
-  triggers:
-    - name: github-listener
-      interceptors:
-        - github:
-            secretRef:
-              secretName: github-secret
-              secretKey: secretToken
-            eventTypes:
-              - pull_request
-        - cel:
-            filter: "body.action in ['opened', 'synchronize', 'reopened']"
-      bindings:
-        - ref: github-pr-binding
-      template:
-        name: github-template
+  params:
+  - name: seconds
+    default: 10s
+    type: string
+  steps:
+    - name: sleep
+      image: ubuntu
+      command:
+        - sleep
+      args:
+        - $(params.seconds)


### PR DESCRIPTION
Closes #1188 

Instead of validating based on the result of `formatted.Condition`, the validation should check whether the condition status of the run is `ConditionUnknown`, which indicates the PipelineRun or TaskRun is still running and can be cancelled. There needed to be some minor tweaks to unit tests which had condition statuses for running that were incorrect. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```