### PR TITLE
Enable auto select support in PipelineRunDescribe if only one PipelineRun Present

### DIFF
--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_withoutNameOfOnlyOnePipelineRunPresent.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_withoutNameOfOnlyOnePipelineRunPresent.golden
@@ -1,0 +1,27 @@
+Name:        pipeline-run
+Namespace:   ns
+
+Status
+
+STARTED   DURATION   STATUS
+---       ---        ---
+
+Resources
+
+ No resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent.golden
@@ -1,0 +1,29 @@
+Name:        pipeline-run
+Namespace:   ns
+Labels:
+ tekton.dev/pipeline=pipeline
+
+Status
+
+STARTED   DURATION   STATUS
+---       ---        ---
+
+Resources
+
+ No resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Taskruns
+
+ No taskruns


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When only one pipelineRun is present then instead of prompting to user to select the
pipelineRun at the time of running the pipelineRun describe command then pipelineRun will
be autoselected and the output will be displayed.

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Enable auto-select support in PipelineRun describe command if only one is present
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
