### PR TITLE
Update OSX instruction to install from brew 🍻

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ Download the latest binary executable for your operating system:
 
 * Mac OS X
 
-  - `tektoncd-cli` can be installed as a [brew tap](https://brew.sh):
+  - `tektoncd-cli` is available from [brew](https://brew.sh):
 
   ```shell
-  brew tap tektoncd/tools
-  brew install tektoncd/tools/tektoncd-cli
+  brew install tektoncd-cli
   ```
 
   - Or by the [released tarball](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Darwin_x86_64.tar.gz):


### PR DESCRIPTION
# Changes

Update OSX instructions to point to the official brew repo.

We still keep the upload to tektoncd/tools since it's easy to maintain (it's part of goreleaser) 
and if there is an issue merging brew update we can still point user at it in the future.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Brew is available from the official brew repository. You still can install tektoncd cli on OSX from the `tektoncd/tools` tap since both would be supported for the foreseeable future. 
```
