### PR TITLE
Reorganize Release Process Docs and Add Details

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,29 +1,43 @@
 # TektonCD CLI Release Process
 
+### Prerequisites
+
 - You need to be a member of tektoncd-cli [OWNERS](OWNERS) and be a member of the [CLI maintainers team](https://github.com/orgs/tektoncd/teams/cli-maintainers) to be able to push a new branch for the release and update the CLI Homebrew formula. 
+
+- You need to have your own Kubernetes cluster (e.g. `minikube`, `gcp`, or other means) with Tekton installed.
+
+- You need to have [these tools](https://github.com/tektoncd/cli/blob/master/tekton/release.sh#L13y) installed locally.
 
 - You will need to have a [GPG key set up](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) with your git account to push the release branch.
 
-- You need to have your own Kubernetes cluster with Tekton installed under `minikube`, `gcp`, or other means.
+- You will require a github personal access token, which the release script will ask you to provide. You can generate a GitHub token using the following 
+[instructions](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Your token needs following access: `admin:org, read:packages, repo, write:packages`.
+
+- You need to have your user added to the `https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/`. Request it by going [here](https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/permissions/) and asking for admin access.
+
+- You need to have your user added to the [launchpad team](https://launchpad.net/~tektoncd), and make sure as well that you have setup your GPG key and add it to your profile on launchpad.
+
+- Set the `GOPATH` environment variable so that the release script will recognize the following path to the cli project: `${GOPATH}/src/github.com/tektoncd/cli`
+
+### Release Steps
+
+The steps below are meant to be followed in order. Some steps can be done in a different order, but it is generally recommended to follow the process outlined below without skipping steps.
 
 - Start reading this [README](tekton/README.md), and you can start a new release
   with the [release.sh](tekton/release.sh) script.
 
-- Update the version numbers in the main [README.md](README.md) to the version you are releasing by opening a pull request to the master branch of this repository. Do not worry about updating the README for the release branch.
-
 - When the release is done in https://github.com/tektoncd/cli/releases, edit the
-  release and change it from pre-release as released.
+  release and change it from pre-release to released. Make sure to do this before 
+  the next step for the rpm package. 
 
 - When it's released, you can build the rpm package according to this
-  [README](tekton/rpmbuild/README.md) document. Make sure you have done the PREREQ to be
+  [README](tekton/rpmbuild/README.md). Make sure you have done the prerequisite to be
   able to upload it to the copr repository. This could take some time if copr
   builder is busy.
 
 - While the rpm task is building the rpm package, you can start building the
-  debian package according to this [README](tekton/debbuild/README.md)
-  document. Make sure you have done the prerequist to be able to upload to the
-  [launchpad team](https://launchpad.net/~tektoncd), and make sure as well that
-  you have setup your GPG key and add it to your profile on launchpad.
+  debian package according to this [README](tekton/debbuild/README.md). Make sure 
+  you have done the prerequisite to be able to upload to the launchpad team.
 
 - You need to edit the Changelog according to the other templates in there.
   Usually you may want to do this in hackmd so you can have other cli
@@ -41,7 +55,7 @@ dnf upgrade tektoncd-cli
 
 - Make an update on [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/tektoncd-cli.rb) for tektoncd-cli formula.
 
-  * Make sure you get the proper `sha256sum`. You need to download the `Source Code (tar.gz)` from the [release section of the cli GitHub](https://github.com/tektoncd/cli/releases) and run the command below for the release version you are working on:
+  * Make sure you get the proper `sha256sum`. You need to download the `Source Code (tar.gz)` from this [link](https://github.com/Homebrew/homebrew-core/blob/master/Formula/tektoncd-cli.rb#L4), but replace the version number with the version number you have released. After downloading, run the command below on the downloaded file (once again you will need to replace the version shown below with the released version):
   
     ```shell script
     sha256sum cli-0.7.1.tar.gz 
@@ -59,9 +73,14 @@ dnf upgrade tektoncd-cli
 
   * [tkn image](https://github.com/tektoncd/plumbing/blob/master/tekton/images/tkn/Dockerfile)
 
+- Update the version numbers in the main [README.md](README.md) to the version you are releasing by opening a pull request to the master branch of this repository. Do not worry about updating the README for the release branch.
+
+- Make sure we have a nice ChangeLog before doing the release, listing `features`
+and `bugs`, and be thankful to the contributors by listing them. An example is shown [here](https://github.com/tektoncd/cli/releases/tag/v0.13.0).
+
 - Announce and spread the love on twitter. Make sure you tag
   [@tektoncd](https://twitter.com/tektoncd) account so you get retweeted and
   perhaps add the major new features in the tweet. See [here](https://twitter.com/chmouel/status/1177172542144036869) for an example.
   Do not fear to add a bunch of  emojis 🎉🥳. Ask @vdemeester for tips 🤣.
 
-- Notify the cli channel on slack.
+- Notify the cli, pipeline, and general channels on slack.

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -6,7 +6,7 @@ release the Tekton Pipelines cli!
 This directory contains the
 [`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md) and
 [`Pipelines`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md)
-that we use for releases and pull requests.
+that we use for releasing the cli.
 
 TODO(tektoncd/pipeline#538): In tektoncd/pipeline#538 or tektoncd/pipeline#537 we will update
 [Prow](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#pull-request-process)
@@ -15,8 +15,7 @@ to invoke these `Pipelines` automatically, but, for now, we invoke them manually
 ## Release Pipeline
 
 You can use the script [`./release.sh`](release.sh) that will do everything
-that needs to be done for the release. In order to run `release.sh`, you will 
-need [these tools](https://github.com/tektoncd/cli/blob/master/tekton/release.sh#L13y) installed locally.
+that needs to be done for the release. 
 
 The first argument to `release.sh` is the release version. It
 needs to be in a format like `v1.2.3`, which is basically SEMVER.
@@ -29,18 +28,13 @@ make sure to provide them in order from the oldest to the newest.
 If you give the `*` argument for the commits to pick up, it would apply all the new
 commits.
 
-It will them use your Kubernetes cluster with Tekton and apply what needs to be done for
+The release script will ask you to provide a GitHub token with appropriate priviledges as 
+documented under the [release process prerequisites](../RELEASE_PROCESS.md#Prerequisites).
+
+It will then use your Kubernetes cluster with Tekton and apply what needs to be done for
 running the release.
 
-For running the release pipeline, you will require a github token, which script will ask
-to provide. You can generate a GitHub token using the following 
-[instructions](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). 
-Your token needs following access `admin:org, read:packages, repo, write:packages`
-
 Finally it will launch the `tkn` cli that you have installed locally to show the logs.
-
-Make sure we have a nice ChangeLog before doing the release, listing `features`
-and `bugs` and be thankful to the contributors by listing them. An example is shown [here](https://github.com/tektoncd/cli/releases/tag/v0.6.0).
 
 ## Debugging
 

--- a/tekton/rpmbuild/README.md
+++ b/tekton/rpmbuild/README.md
@@ -36,13 +36,13 @@ need to have a PipelineResource for your git repository. See
 * You need to get your API file from https://copr.fedorainfracloud.org/api/ and have it saved to `~/.config/copr`. You will need to change the 
 `username` field to `chmouel` since the copr repo is currently `/chmouel/tektoncd-cli/`.
 
+* Make sure you have the GitHub token set as documented in [RELEASE_PROCESS.md](../../RELEASE_PROCESS.md). You can also just add the `--namespace` option to all `kubectl` commands below and specify the namespace where you ran the release (by default, the namespace used in `release.sh` is `release`).
+
 * You create the secret from that copr config file:
 
 ```
 kubectl create secret generic copr-cli-config --from-file=copr=${HOME}/.config/copr
 ```
-
-* Make sure you have the GitHUB token set as documented in [RELEASE_PROCESS.md](../../RELEASE_PROCESS.md)
 
 * You should be able create the task with:
 


### PR DESCRIPTION
Closes #1195 

Instead of making one large release process doc, I have instead reorganized the `RELEASE_PROCESS` into the sections `Prerequisites` and `Release Steps`. Some information from `tekton/README` has been moved to `RELEASE_PROCESS`. 

Additionally, a few minor notes have been added to provide some clarity on the release process steps, including:
* Having `GOPATH` correctly set
* Getting the correct checksum for the homebrew update
* Reordering some rpm steps and providing a tip on what namespace to run the release in to make use of the GitHub personal access token

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
