### PR TITLE
Avoid Use of Previous TaskRunSpecStatus and PipelineRunSpecStatus with Start Commands

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -255,6 +255,8 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 		}
 		// Copy over spec from last or previous PipelineRun to use same values for this PipelineRun
 		pr.Spec = usepr.Spec
+		// Reapply blank status in case PipelineRun used was cancelled
+		pr.Spec.Status = ""
 	}
 
 	if err := mergeRes(pr, opt.Resources); err != nil {

--- a/pkg/options/start.go
+++ b/pkg/options/start.go
@@ -92,6 +92,8 @@ func (taskRunOpts *TaskRunOpts) UseTaskRunFrom(tr *v1beta1.TaskRun, cs *cli.Clie
 	}
 	// Copy over spec from last or previous TaskRun to use same values for this TaskRun
 	tr.Spec = trUsed.Spec
+	// Reapply blank status in case TaskRun used was cancelled
+	tr.Spec.Status = ""
 	return nil
 }
 


### PR DESCRIPTION
Closes #1200 

In #1134, the method for using previous TaskRun/PipelineRun runtime values as part of a new run was changed to capture the entire TaskRunSpec/PipelineRunSpec. The problem with this is that the Spec for TaskRuns/PipelineRuns contain the TaskRunSpecStatus/PipelineRunSpecStatus, which are used for cancelling runs. 

If `--use-taskrun`/`--use-pipelinerun` or `--last` are passed the name of a cancelled run, the new run will be cancelled. While the choice of having TaskRunSpecStatus/PipelineRunSpecStatus is a bit curious, `tkn` needs to account for this case. The method used in this pr is to save the SpecStatus and reapply it to the run after the previous spec is copied over to avoid factoring this status into the new run's success or failure. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

For pull requests with a release note:

```release-note
Prevent cancelled TaskRuns/PipelineRuns used with --use-pipelinerun/--use-taskrun and --last from being cancelled
```

/kind bug
