### PR TITLE
Common Way of Referring to Tekton Resources in User Facing Messages: EventListener

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -24,7 +24,7 @@ CLI for tekton pipelines
 * [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
 * [tkn completion](tkn_completion.md)	 - Prints shell completion scripts
 * [tkn condition](tkn_condition.md)	 - Manage conditions
-* [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners
+* [tkn eventlistener](tkn_eventlistener.md)	 - Manage EventListeners
 * [tkn pipeline](tkn_pipeline.md)	 - Manage pipelines
 * [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
 * [tkn resource](tkn_resource.md)	 - Manage pipeline resources

--- a/docs/cmd/tkn_eventlistener.md
+++ b/docs/cmd/tkn_eventlistener.md
@@ -1,6 +1,6 @@
 ## tkn eventlistener
 
-Manage eventlisteners
+Manage EventListeners
 
 ***Aliases**: el,eventlisteners*
 
@@ -12,7 +12,7 @@ tkn eventlistener
 
 ### Synopsis
 
-Manage eventlisteners
+Manage EventListeners
 
 ### Options
 
@@ -29,6 +29,6 @@ Manage eventlisteners
 * [tkn](tkn.md)	 - CLI for tekton pipelines
 * [tkn eventlistener delete](tkn_eventlistener_delete.md)	 - Delete EventListeners in a namespace
 * [tkn eventlistener describe](tkn_eventlistener_describe.md)	 - Describe EventListener in a namespace
-* [tkn eventlistener list](tkn_eventlistener_list.md)	 - Lists eventlisteners in a namespace
+* [tkn eventlistener list](tkn_eventlistener_list.md)	 - Lists EventListeners in a namespace
 * [tkn eventlistener logs](tkn_eventlistener_logs.md)	 - Show EventListener logs
 

--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -47,5 +47,5 @@ or
 
 ### SEE ALSO
 
-* [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners
+* [tkn eventlistener](tkn_eventlistener.md)	 - Manage EventListeners
 

--- a/docs/cmd/tkn_eventlistener_describe.md
+++ b/docs/cmd/tkn_eventlistener_describe.md
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners
+* [tkn eventlistener](tkn_eventlistener.md)	 - Manage EventListeners
 

--- a/docs/cmd/tkn_eventlistener_list.md
+++ b/docs/cmd/tkn_eventlistener_list.md
@@ -1,6 +1,6 @@
 ## tkn eventlistener list
 
-Lists eventlisteners in a namespace
+Lists EventListeners in a namespace
 
 ***Aliases**: ls*
 
@@ -12,11 +12,11 @@ tkn eventlistener list
 
 ### Synopsis
 
-Lists eventlisteners in a namespace
+Lists EventListeners in a namespace
 
 ### Examples
 
-List all eventlisteners in namespace 'bar':
+List all EventListeners in namespace 'bar':
 
 	tkn eventlistener list -n bar
 
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners
+* [tkn eventlistener](tkn_eventlistener.md)	 - Manage EventListeners
 

--- a/docs/cmd/tkn_eventlistener_logs.md
+++ b/docs/cmd/tkn_eventlistener_logs.md
@@ -41,5 +41,5 @@ Show 2 lines of most recent logs from all EventListener pods:
 
 ### SEE ALSO
 
-* [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners
+* [tkn eventlistener](tkn_eventlistener.md)	 - Manage EventListeners
 

--- a/docs/man/man1/tkn-eventlistener-list.1
+++ b/docs/man/man1/tkn-eventlistener-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-eventlistener\-list \- Lists eventlisteners in a namespace
+tkn\-eventlistener\-list \- Lists EventListeners in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-eventlistener\-list \- Lists eventlisteners in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists eventlisteners in a namespace
+Lists EventListeners in a namespace
 
 
 .SH OPTIONS
@@ -57,7 +57,7 @@ Lists eventlisteners in a namespace
 
 .SH EXAMPLE
 .PP
-List all eventlisteners in namespace 'bar':
+List all EventListeners in namespace 'bar':
 
 .PP
 .RS

--- a/docs/man/man1/tkn-eventlistener.1
+++ b/docs/man/man1/tkn-eventlistener.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-eventlistener \- Manage eventlisteners
+tkn\-eventlistener \- Manage EventListeners
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-eventlistener \- Manage eventlisteners
 
 .SH DESCRIPTION
 .PP
-Manage eventlisteners
+Manage EventListeners
 
 
 .SH OPTIONS

--- a/pkg/cmd/eventlistener/describe.go
+++ b/pkg/cmd/eventlistener/describe.go
@@ -209,7 +209,7 @@ func printEventListenerDescription(s *cli.Stream, p cli.Params, elName string) e
 
 	el, err := cs.Triggers.TriggersV1alpha1().EventListeners(p.Namespace()).Get(context.Background(), elName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get eventlistener %s: %v", elName, err)
+		return fmt.Errorf("failed to get EventListener %s: %v", elName, err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/eventlistener/eventlistener.go
+++ b/pkg/cmd/eventlistener/eventlistener.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "eventlistener",
 		Aliases: []string{"el", "eventlisteners"},
-		Short:   "Manage eventlisteners",
+		Short:   "Manage EventListeners",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/eventlistener/list.go
+++ b/pkg/cmd/eventlistener/list.go
@@ -39,7 +39,7 @@ const (
 func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 
-	eg := `List all eventlisteners in namespace 'bar':
+	eg := `List all EventListeners in namespace 'bar':
 
 	tkn eventlistener list -n bar
 
@@ -51,7 +51,7 @@ or
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists eventlisteners in a namespace",
+		Short:   "Lists EventListeners in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -64,7 +64,7 @@ or
 
 			els, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf("failed to list eventlisteners from %s namespace: %v", p.Namespace(), err)
+				return fmt.Errorf("failed to list EventListeners from %s namespace: %v", p.Namespace(), err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
@@ -82,7 +82,7 @@ or
 			}
 
 			if err = printFormatted(stream, els, p); err != nil {
-				return errors.New(`failed to print eventlisteners \n`)
+				return errors.New(`failed to print EventListeners`)
 			}
 			return nil
 		},

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_InvalidNamespace.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_InvalidNamespace.golden
@@ -1,1 +1,1 @@
-Error: failed to get eventlistener bar: eventlisteners.triggers.tekton.dev "bar" not found
+Error: failed to get EventListener bar: eventlisteners.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_NonExistedName.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_NonExistedName.golden
@@ -1,1 +1,1 @@
-Error: failed to get eventlistener bar: eventlisteners.triggers.tekton.dev "bar" not found
+Error: failed to get EventListener bar: eventlisteners.triggers.tekton.dev "bar" not found


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `EventListener` instead of a variety of ways it is referenced throughout `tkn` (e.g., `eventlistener`, `EventListener`). 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Standardize the use of EventListener in user-facing messages for tkn eventlistener commands
```