### PR TITLE
Common Way of Referring to Tekton Resources in User Facing Messages: Condition

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -23,7 +23,7 @@ CLI for tekton pipelines
 * [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
 * [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
 * [tkn completion](tkn_completion.md)	 - Prints shell completion scripts
-* [tkn condition](tkn_condition.md)	 - Manage conditions
+* [tkn condition](tkn_condition.md)	 - Manage Conditions
 * [tkn eventlistener](tkn_eventlistener.md)	 - Manage EventListeners
 * [tkn pipeline](tkn_pipeline.md)	 - Manage pipelines
 * [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns

--- a/docs/cmd/tkn_condition.md
+++ b/docs/cmd/tkn_condition.md
@@ -1,6 +1,6 @@
 ## tkn condition
 
-Manage conditions
+Manage Conditions
 
 ***Aliases**: cond,conditions*
 
@@ -12,7 +12,7 @@ tkn condition
 
 ### Synopsis
 
-Manage conditions
+Manage Conditions
 
 ### Options
 
@@ -27,7 +27,7 @@ Manage conditions
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn condition delete](tkn_condition_delete.md)	 - Delete a condition in a namespace
+* [tkn condition delete](tkn_condition_delete.md)	 - Delete Conditions in a namespace
 * [tkn condition describe](tkn_condition_describe.md)	 - Describe Conditions in a namespace
-* [tkn condition list](tkn_condition_list.md)	 - Lists conditions in a namespace
+* [tkn condition list](tkn_condition_list.md)	 - Lists Conditions in a namespace
 

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -1,6 +1,6 @@
 ## tkn condition delete
 
-Delete a condition in a namespace
+Delete Conditions in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn condition delete
 
 ### Synopsis
 
-Delete a condition in a namespace
+Delete Conditions in a namespace
 
 ### Examples
 
@@ -47,5 +47,5 @@ or
 
 ### SEE ALSO
 
-* [tkn condition](tkn_condition.md)	 - Manage conditions
+* [tkn condition](tkn_condition.md)	 - Manage Conditions
 

--- a/docs/cmd/tkn_condition_describe.md
+++ b/docs/cmd/tkn_condition_describe.md
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn condition](tkn_condition.md)	 - Manage conditions
+* [tkn condition](tkn_condition.md)	 - Manage Conditions
 

--- a/docs/cmd/tkn_condition_list.md
+++ b/docs/cmd/tkn_condition_list.md
@@ -1,6 +1,6 @@
 ## tkn condition list
 
-Lists conditions in a namespace
+Lists Conditions in a namespace
 
 ***Aliases**: ls*
 
@@ -12,7 +12,7 @@ tkn condition list
 
 ### Synopsis
 
-Lists conditions in a namespace
+Lists Conditions in a namespace
 
 ### Options
 
@@ -34,5 +34,5 @@ Lists conditions in a namespace
 
 ### SEE ALSO
 
-* [tkn condition](tkn_condition.md)	 - Manage conditions
+* [tkn condition](tkn_condition.md)	 - Manage Conditions
 

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-condition\-delete \- Delete a condition in a namespace
+tkn\-condition\-delete \- Delete Conditions in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-condition\-delete \- Delete a condition in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete a condition in a namespace
+Delete Conditions in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-condition-list.1
+++ b/docs/man/man1/tkn-condition-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-condition\-list \- Lists conditions in a namespace
+tkn\-condition\-list \- Lists Conditions in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-condition\-list \- Lists conditions in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists conditions in a namespace
+Lists Conditions in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-condition.1
+++ b/docs/man/man1/tkn-condition.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-condition \- Manage conditions
+tkn\-condition \- Manage Conditions
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-condition \- Manage conditions
 
 .SH DESCRIPTION
 .PP
-Manage conditions
+Manage Conditions
 
 
 .SH OPTIONS

--- a/pkg/cmd/condition/condition.go
+++ b/pkg/cmd/condition/condition.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "condition",
 		Aliases: []string{"cond", "conditions"},
-		Short:   "Manage conditions",
+		Short:   "Manage Conditions",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/condition/delete.go
+++ b/pkg/cmd/condition/delete.go
@@ -41,7 +41,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete a condition in a namespace",
+		Short:        "Delete Conditions in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,

--- a/pkg/cmd/condition/describe.go
+++ b/pkg/cmd/condition/describe.go
@@ -17,7 +17,6 @@ package condition
 import (
 	"context"
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"text/template"
 
@@ -108,8 +107,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			condition, err := getCondition(p, args[0])
@@ -141,7 +139,7 @@ func getCondition(p cli.Params, name string) (*v1alpha1.Condition, error) {
 
 	condition, err := cs.Tekton.TektonV1alpha1().Conditions(p.Namespace()).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to find condition %q", name)
+		return nil, fmt.Errorf("failed to find Condition %q", name)
 	}
 
 	// NOTE: this is required for -o json|yaml to work properly since

--- a/pkg/cmd/condition/list.go
+++ b/pkg/cmd/condition/list.go
@@ -42,7 +42,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists conditions in a namespace",
+		Short:   "Lists Conditions in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -54,8 +54,7 @@ func listCommand(p cli.Params) *cobra.Command {
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(stream.Err, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -78,8 +77,7 @@ func printConditionDetails(s *cli.Stream, p cli.Params) error {
 
 	conditions, err := listAllConditions(cs.Tekton, p.Namespace())
 	if err != nil {
-		fmt.Fprintf(s.Err, "Failed to list conditions from %s namespace \n", p.Namespace())
-		return err
+		return fmt.Errorf("failed to list Conditions from %s namespace: %v", p.Namespace(), err)
 	}
 
 	if len(conditions.Items) == 0 {
@@ -108,8 +106,7 @@ func printConditionListObj(s *cli.Stream, p cli.Params, f *cliopts.PrintFlags) e
 
 	conditions, err := listAllConditions(cs.Tekton, p.Namespace())
 	if err != nil {
-		fmt.Fprintf(s.Err, "Failed to list conditions from %s namespace \n", p.Namespace())
-		return err
+		return fmt.Errorf("failed to list Conditions from %s namespace: %v", p.Namespace(), err)
 	}
 	return printer.PrintObject(s.Out, conditions, f)
 }

--- a/pkg/cmd/condition/testdata/TestConditionDescribe-invalid_condition_name.golden
+++ b/pkg/cmd/condition/testdata/TestConditionDescribe-invalid_condition_name.golden
@@ -1,1 +1,1 @@
-Error: failed to find condition "invalid"
+Error: failed to find Condition "invalid"

--- a/pkg/cmd/condition/testdata/TestConditionDescribe-invalid_namespace.golden
+++ b/pkg/cmd/condition/testdata/TestConditionDescribe-invalid_namespace.golden
@@ -1,1 +1,1 @@
-Error: failed to find condition "cond-2"
+Error: failed to find Condition "cond-2"

--- a/pkg/cmd/condition/testdata/TestConditionList-Failed_to_list_condition_resources.golden
+++ b/pkg/cmd/condition/testdata/TestConditionList-Failed_to_list_condition_resources.golden
@@ -1,2 +1,1 @@
-Failed to list conditions from ns namespace 
-Error: test error
+Error: failed to list Conditions from ns namespace: test error

--- a/pkg/cmd/condition/testdata/TestConditionList-Failed_to_list_condition_resources_with_specify_output_flag.golden
+++ b/pkg/cmd/condition/testdata/TestConditionList-Failed_to_list_condition_resources_with_specify_output_flag.golden
@@ -1,2 +1,1 @@
-Failed to list conditions from ns namespace 
-Error: test error
+Error: failed to list Conditions from ns namespace: test error


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `Condition` instead of a variety of ways it is referenced throughout `tkn` (e.g., `condition`, `Condition`). 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Standardize the use of Condition in user-facing messages for tkn condition commands
```