### PR TITLE
Common Way of Referring to Tekton Resources in User Facing Messages: ClusterTriggerBinding

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -21,7 +21,7 @@ CLI for tekton pipelines
 ### SEE ALSO
 
 * [tkn clustertask](tkn_clustertask.md)	 - Manage ClusterTasks
-* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
+* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage ClusterTriggerBindings
 * [tkn completion](tkn_completion.md)	 - Prints shell completion scripts
 * [tkn condition](tkn_condition.md)	 - Manage conditions
 * [tkn eventlistener](tkn_eventlistener.md)	 - Manage eventlisteners

--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -1,6 +1,6 @@
 ## tkn clustertriggerbinding
 
-Manage clustertriggerbindings
+Manage ClusterTriggerBindings
 
 ***Aliases**: ctb,clustertriggerbindings*
 
@@ -12,7 +12,7 @@ tkn clustertriggerbinding
 
 ### Synopsis
 
-Manage clustertriggerbindings
+Manage ClusterTriggerBindings
 
 ### Options
 
@@ -26,7 +26,7 @@ Manage clustertriggerbindings
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn clustertriggerbinding delete](tkn_clustertriggerbinding_delete.md)	 - Delete clustertriggerbindings
-* [tkn clustertriggerbinding describe](tkn_clustertriggerbinding_describe.md)	 - Describes a clustertriggerbinding
-* [tkn clustertriggerbinding list](tkn_clustertriggerbinding_list.md)	 - Lists clustertriggerbindings in a namespace
+* [tkn clustertriggerbinding delete](tkn_clustertriggerbinding_delete.md)	 - Delete ClusterTriggerBindings
+* [tkn clustertriggerbinding describe](tkn_clustertriggerbinding_describe.md)	 - Describes a ClusterTriggerBinding
+* [tkn clustertriggerbinding list](tkn_clustertriggerbinding_list.md)	 - Lists ClusterTriggerBindings in a namespace
 

--- a/docs/cmd/tkn_clustertriggerbinding_delete.md
+++ b/docs/cmd/tkn_clustertriggerbinding_delete.md
@@ -1,6 +1,6 @@
 ## tkn clustertriggerbinding delete
 
-Delete clustertriggerbindings
+Delete ClusterTriggerBindings
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn clustertriggerbinding delete
 
 ### Synopsis
 
-Delete clustertriggerbindings
+Delete ClusterTriggerBindings
 
 ### Examples
 
@@ -46,5 +46,5 @@ or
 
 ### SEE ALSO
 
-* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
+* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage ClusterTriggerBindings
 

--- a/docs/cmd/tkn_clustertriggerbinding_describe.md
+++ b/docs/cmd/tkn_clustertriggerbinding_describe.md
@@ -1,6 +1,6 @@
 ## tkn clustertriggerbinding describe
 
-Describes a clustertriggerbinding
+Describes a ClusterTriggerBinding
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn clustertriggerbinding describe
 
 ### Synopsis
 
-Describes a clustertriggerbinding
+Describes a ClusterTriggerBinding
 
 ### Examples
 
@@ -44,5 +44,5 @@ or
 
 ### SEE ALSO
 
-* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
+* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage ClusterTriggerBindings
 

--- a/docs/cmd/tkn_clustertriggerbinding_list.md
+++ b/docs/cmd/tkn_clustertriggerbinding_list.md
@@ -1,6 +1,6 @@
 ## tkn clustertriggerbinding list
 
-Lists clustertriggerbindings in a namespace
+Lists ClusterTriggerBindings in a namespace
 
 ***Aliases**: ls*
 
@@ -12,11 +12,11 @@ tkn clustertriggerbinding list
 
 ### Synopsis
 
-Lists clustertriggerbindings in a namespace
+Lists ClusterTriggerBindings in a namespace
 
 ### Examples
 
-List all clustertriggerbindings:
+List all ClusterTriggerBindings:
 
 	tkn clustertriggerbinding list
 
@@ -44,5 +44,5 @@ or
 
 ### SEE ALSO
 
-* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage clustertriggerbindings
+* [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage ClusterTriggerBindings
 

--- a/docs/man/man1/tkn-clustertriggerbinding-delete.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertriggerbinding\-delete \- Delete clustertriggerbindings
+tkn\-clustertriggerbinding\-delete \- Delete ClusterTriggerBindings
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertriggerbinding\-delete \- Delete clustertriggerbindings
 
 .SH DESCRIPTION
 .PP
-Delete clustertriggerbindings
+Delete ClusterTriggerBindings
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-clustertriggerbinding-describe.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertriggerbinding\-describe \- Describes a clustertriggerbinding
+tkn\-clustertriggerbinding\-describe \- Describes a ClusterTriggerBinding
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertriggerbinding\-describe \- Describes a clustertriggerbinding
 
 .SH DESCRIPTION
 .PP
-Describes a clustertriggerbinding
+Describes a ClusterTriggerBinding
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-clustertriggerbinding-list.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertriggerbinding\-list \- Lists clustertriggerbindings in a namespace
+tkn\-clustertriggerbinding\-list \- Lists ClusterTriggerBindings in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertriggerbinding\-list \- Lists clustertriggerbindings in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists clustertriggerbindings in a namespace
+Lists ClusterTriggerBindings in a namespace
 
 
 .SH OPTIONS
@@ -53,7 +53,7 @@ Lists clustertriggerbindings in a namespace
 
 .SH EXAMPLE
 .PP
-List all clustertriggerbindings:
+List all ClusterTriggerBindings:
 
 .PP
 .RS

--- a/docs/man/man1/tkn-clustertriggerbinding.1
+++ b/docs/man/man1/tkn-clustertriggerbinding.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-clustertriggerbinding \- Manage clustertriggerbindings
+tkn\-clustertriggerbinding \- Manage ClusterTriggerBindings
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-clustertriggerbinding \- Manage clustertriggerbindings
 
 .SH DESCRIPTION
 .PP
-Manage clustertriggerbindings
+Manage ClusterTriggerBindings
 
 
 .SH OPTIONS

--- a/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
+++ b/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "clustertriggerbinding",
 		Aliases: []string{"ctb", "clustertriggerbindings"},
-		Short:   "Manage clustertriggerbindings",
+		Short:   "Manage ClusterTriggerBindings",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cmd/clustertriggerbinding/delete.go
+++ b/pkg/cmd/clustertriggerbinding/delete.go
@@ -41,7 +41,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete clustertriggerbindings",
+		Short:        "Delete ClusterTriggerBindings",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,

--- a/pkg/cmd/clustertriggerbinding/describe.go
+++ b/pkg/cmd/clustertriggerbinding/describe.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"text/tabwriter"
 	"text/template"
 
@@ -60,7 +59,7 @@ or
 	c := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"desc"},
-		Short:   "Describes a clustertriggerbinding",
+		Short:   "Describes a ClusterTriggerBinding",
 		Example: eg,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -75,8 +74,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -122,7 +120,7 @@ func printClusterTriggerBindingDescription(s *cli.Stream, p cli.Params, ctbName 
 
 	ctb, err := cs.Triggers.TriggersV1alpha1().ClusterTriggerBindings().Get(context.Background(), ctbName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get clustertriggerbinding %s: %v", ctbName, err)
+		return fmt.Errorf("failed to get ClusterTriggerBinding %s: %v", ctbName, err)
 	}
 
 	var data = struct {
@@ -138,8 +136,7 @@ func printClusterTriggerBindingDescription(s *cli.Stream, p cli.Params, ctbName 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
 	tparsed := template.Must(template.New("Describe ClusterTriggerbinding").Funcs(funcMap).Parse(describeTemplate))
 	if err = tparsed.Execute(w, data); err != nil {
-		fmt.Fprintf(s.Err, "Failed to execute template \n")
-		return err
+		return fmt.Errorf("failed to execute template: %v", err)
 	}
 	return w.Flush()
 }

--- a/pkg/cmd/clustertriggerbinding/list.go
+++ b/pkg/cmd/clustertriggerbinding/list.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	emptyMsg = "No clustertriggerbindings found"
+	emptyMsg = "No ClusterTriggerBindings found"
 )
 
 func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 
-	eg := `List all clustertriggerbindings:
+	eg := `List all ClusterTriggerBindings:
 
 	tkn clustertriggerbinding list
 
@@ -50,7 +50,7 @@ or
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists clustertriggerbindings in a namespace",
+		Short:   "Lists ClusterTriggerBindings in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -63,7 +63,7 @@ or
 
 			tbs, err := list(cs.Triggers, "")
 			if err != nil {
-				return fmt.Errorf("failed to list clustertriggerbindings: %v", err)
+				return fmt.Errorf("failed to list ClusterTriggerBindings: %v", err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
@@ -90,7 +90,7 @@ or
 			}
 
 			if err = printFormatted(stream, tbs, p); err != nil {
-				return fmt.Errorf("failed to print clustertriggerbindings: %v", err)
+				return fmt.Errorf("failed to print ClusterTriggerBindings: %v", err)
 			}
 			return nil
 

--- a/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_NonExistedName.golden
+++ b/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_NonExistedName.golden
@@ -1,1 +1,1 @@
-Error: failed to get clustertriggerbinding bar: clustertriggerbindings.triggers.tekton.dev "bar" not found
+Error: failed to get ClusterTriggerBinding bar: clustertriggerbindings.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/clustertriggerbinding/testdata/TestListClusterTriggerBinding-No_ClusterTriggerBindings.golden
+++ b/pkg/cmd/clustertriggerbinding/testdata/TestListClusterTriggerBinding-No_ClusterTriggerBindings.golden
@@ -1,1 +1,1 @@
-No clustertriggerbindings found
+No ClusterTriggerBindings found


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `ClusterTriggerBinding` instead of a variety of ways it is referenced throughout `tkn` (e.g., `clustertriggerbinding`, `ClusterTriggerBinding`). 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Standardize the use of ClusterTriggerBinding in user-facing messages for tkn clustertriggerbinding commands
```