### PR TITLE
Common Way of Referring to Tekton Resources in User Facing Messages: TriggerBinding

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -30,7 +30,7 @@ CLI for tekton pipelines
 * [tkn resource](tkn_resource.md)	 - Manage pipeline resources
 * [tkn task](tkn_task.md)	 - Manage Tasks
 * [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
-* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage triggerbindings
+* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage TriggerBindings
 * [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates
 * [tkn version](tkn_version.md)	 - Prints version information
 

--- a/docs/cmd/tkn_triggerbinding.md
+++ b/docs/cmd/tkn_triggerbinding.md
@@ -1,6 +1,6 @@
 ## tkn triggerbinding
 
-Manage triggerbindings
+Manage TriggerBindings
 
 ***Aliases**: tb,triggerbindings*
 
@@ -12,7 +12,7 @@ tkn triggerbinding
 
 ### Synopsis
 
-Manage triggerbindings
+Manage TriggerBindings
 
 ### Options
 
@@ -27,7 +27,7 @@ Manage triggerbindings
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn triggerbinding delete](tkn_triggerbinding_delete.md)	 - Delete triggerbindings in a namespace
-* [tkn triggerbinding describe](tkn_triggerbinding_describe.md)	 - Describes a triggerbinding in a namespace
-* [tkn triggerbinding list](tkn_triggerbinding_list.md)	 - Lists triggerbindings in a namespace
+* [tkn triggerbinding delete](tkn_triggerbinding_delete.md)	 - Delete TriggerBindings in a namespace
+* [tkn triggerbinding describe](tkn_triggerbinding_describe.md)	 - Describes a TriggerBinding in a namespace
+* [tkn triggerbinding list](tkn_triggerbinding_list.md)	 - Lists TriggerBindings in a namespace
 

--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -1,6 +1,6 @@
 ## tkn triggerbinding delete
 
-Delete triggerbindings in a namespace
+Delete TriggerBindings in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn triggerbinding delete
 
 ### Synopsis
 
-Delete triggerbindings in a namespace
+Delete TriggerBindings in a namespace
 
 ### Examples
 
@@ -47,5 +47,5 @@ or
 
 ### SEE ALSO
 
-* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage triggerbindings
+* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage TriggerBindings
 

--- a/docs/cmd/tkn_triggerbinding_describe.md
+++ b/docs/cmd/tkn_triggerbinding_describe.md
@@ -1,6 +1,6 @@
 ## tkn triggerbinding describe
 
-Describes a triggerbinding in a namespace
+Describes a TriggerBinding in a namespace
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn triggerbinding describe
 
 ### Synopsis
 
-Describes a triggerbinding in a namespace
+Describes a TriggerBinding in a namespace
 
 ### Examples
 
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage triggerbindings
+* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage TriggerBindings
 

--- a/docs/cmd/tkn_triggerbinding_list.md
+++ b/docs/cmd/tkn_triggerbinding_list.md
@@ -1,6 +1,6 @@
 ## tkn triggerbinding list
 
-Lists triggerbindings in a namespace
+Lists TriggerBindings in a namespace
 
 ***Aliases**: ls*
 
@@ -12,11 +12,11 @@ tkn triggerbinding list
 
 ### Synopsis
 
-Lists triggerbindings in a namespace
+Lists TriggerBindings in a namespace
 
 ### Examples
 
-List all triggerbindings in namespace 'bar':
+List all TriggerBindings in namespace 'bar':
 
 	tkn triggerbinding list -n bar
 
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage triggerbindings
+* [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage TriggerBindings
 

--- a/docs/man/man1/tkn-triggerbinding-delete.1
+++ b/docs/man/man1/tkn-triggerbinding-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggerbinding\-delete \- Delete triggerbindings in a namespace
+tkn\-triggerbinding\-delete \- Delete TriggerBindings in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggerbinding\-delete \- Delete triggerbindings in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete triggerbindings in a namespace
+Delete TriggerBindings in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-triggerbinding-describe.1
+++ b/docs/man/man1/tkn-triggerbinding-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggerbinding\-describe \- Describes a triggerbinding in a namespace
+tkn\-triggerbinding\-describe \- Describes a TriggerBinding in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggerbinding\-describe \- Describes a triggerbinding in a namespace
 
 .SH DESCRIPTION
 .PP
-Describes a triggerbinding in a namespace
+Describes a TriggerBinding in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-triggerbinding-list.1
+++ b/docs/man/man1/tkn-triggerbinding-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggerbinding\-list \- Lists triggerbindings in a namespace
+tkn\-triggerbinding\-list \- Lists TriggerBindings in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggerbinding\-list \- Lists triggerbindings in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists triggerbindings in a namespace
+Lists TriggerBindings in a namespace
 
 
 .SH OPTIONS
@@ -57,7 +57,7 @@ Lists triggerbindings in a namespace
 
 .SH EXAMPLE
 .PP
-List all triggerbindings in namespace 'bar':
+List all TriggerBindings in namespace 'bar':
 
 .PP
 .RS

--- a/docs/man/man1/tkn-triggerbinding.1
+++ b/docs/man/man1/tkn-triggerbinding.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggerbinding \- Manage triggerbindings
+tkn\-triggerbinding \- Manage TriggerBindings
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggerbinding \- Manage triggerbindings
 
 .SH DESCRIPTION
 .PP
-Manage triggerbindings
+Manage TriggerBindings
 
 
 .SH OPTIONS

--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -41,7 +41,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete triggerbindings in a namespace",
+		Short:        "Delete TriggerBindings in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,

--- a/pkg/cmd/triggerbinding/describe.go
+++ b/pkg/cmd/triggerbinding/describe.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"text/tabwriter"
 	"text/template"
 
@@ -61,7 +60,7 @@ or
 	c := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"desc"},
-		Short:   "Describes a triggerbinding in a namespace",
+		Short:   "Describes a TriggerBinding in a namespace",
 		Example: eg,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -76,8 +75,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -123,7 +121,7 @@ func printTriggerBindingDescription(s *cli.Stream, p cli.Params, tbName string) 
 
 	tb, err := cs.Triggers.TriggersV1alpha1().TriggerBindings(p.Namespace()).Get(context.Background(), tbName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get triggerbinding %s from %s namespace: %v", tbName, p.Namespace(), err)
+		return fmt.Errorf("failed to get TriggerBinding %s from %s namespace: %v", tbName, p.Namespace(), err)
 	}
 
 	var data = struct {
@@ -139,8 +137,7 @@ func printTriggerBindingDescription(s *cli.Stream, p cli.Params, tbName string) 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
 	tparsed := template.Must(template.New("Describe Triggerbinding").Funcs(funcMap).Parse(describeTemplate))
 	if err = tparsed.Execute(w, data); err != nil {
-		fmt.Fprintf(s.Err, "Failed to execute template \n")
-		return err
+		return fmt.Errorf("failed to execute template: %v", err)
 	}
 	return w.Flush()
 }

--- a/pkg/cmd/triggerbinding/list.go
+++ b/pkg/cmd/triggerbinding/list.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	emptyMsg = "No triggerbindings found"
+	emptyMsg = "No TriggerBindings found"
 )
 
 func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 
-	eg := `List all triggerbindings in namespace 'bar':
+	eg := `List all TriggerBindings in namespace 'bar':
 
 	tkn triggerbinding list -n bar
 
@@ -50,7 +50,7 @@ or
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists triggerbindings in a namespace",
+		Short:   "Lists TriggerBindings in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -63,7 +63,7 @@ or
 
 			tbs, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf("failed to list triggerbindings from %s namespace: %v", p.Namespace(), err)
+				return fmt.Errorf("failed to list TriggerBindings from %s namespace: %v", p.Namespace(), err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
@@ -90,7 +90,7 @@ or
 			}
 
 			if err = printFormatted(stream, tbs, p); err != nil {
-				return errors.New("failed to print triggerbindings")
+				return errors.New("failed to print TriggerBindings")
 			}
 			return nil
 

--- a/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-Invalid_namespace.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-Invalid_namespace.golden
@@ -1,1 +1,1 @@
-No triggerbindings found
+No TriggerBindings found

--- a/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-No_TriggerBinding.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-No_TriggerBinding.golden
@@ -1,1 +1,1 @@
-No triggerbindings found
+No TriggerBindings found

--- a/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_Invalid_Namespace.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_Invalid_Namespace.golden
@@ -1,1 +1,1 @@
-Error: failed to get triggerbinding bar from invalid namespace: triggerbindings.triggers.tekton.dev "bar" not found
+Error: failed to get TriggerBinding bar from invalid namespace: triggerbindings.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_NonExistedName.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_NonExistedName.golden
@@ -1,1 +1,1 @@
-Error: failed to get triggerbinding bar from ns namespace: triggerbindings.triggers.tekton.dev "bar" not found
+Error: failed to get TriggerBinding bar from ns namespace: triggerbindings.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggerbinding/triggerbinding.go
+++ b/pkg/cmd/triggerbinding/triggerbinding.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "triggerbinding",
 		Aliases: []string{"tb", "triggerbindings"},
-		Short:   "Manage triggerbindings",
+		Short:   "Manage TriggerBindings",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `TriggerBinding` instead of a variety of ways it is referenced throughout `tkn` (e.g., `triggerbinding`, `TriggerBinding`). 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Standardize the use of ClusterTriggerBinding in user-facing messages for tkn triggerbinding commands
```