### PR TITLE
Common Way of Referring to Tekton Resources in User Facing Messages: TriggerTemplate

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -31,6 +31,6 @@ CLI for tekton pipelines
 * [tkn task](tkn_task.md)	 - Manage Tasks
 * [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 * [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage TriggerBindings
-* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates
+* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage TriggerTemplates
 * [tkn version](tkn_version.md)	 - Prints version information
 

--- a/docs/cmd/tkn_triggertemplate.md
+++ b/docs/cmd/tkn_triggertemplate.md
@@ -1,6 +1,6 @@
 ## tkn triggertemplate
 
-Manage triggertemplates
+Manage TriggerTemplates
 
 ***Aliases**: tt,triggertemplates*
 
@@ -12,7 +12,7 @@ tkn triggertemplate
 
 ### Synopsis
 
-Manage triggertemplates
+Manage TriggerTemplates
 
 ### Options
 
@@ -27,7 +27,7 @@ Manage triggertemplates
 ### SEE ALSO
 
 * [tkn](tkn.md)	 - CLI for tekton pipelines
-* [tkn triggertemplate delete](tkn_triggertemplate_delete.md)	 - Delete triggertemplates in a namespace
-* [tkn triggertemplate describe](tkn_triggertemplate_describe.md)	 - Describes a triggertemplate in a namespace
-* [tkn triggertemplate list](tkn_triggertemplate_list.md)	 - Lists triggertemplates in a namespace
+* [tkn triggertemplate delete](tkn_triggertemplate_delete.md)	 - Delete TriggerTemplates in a namespace
+* [tkn triggertemplate describe](tkn_triggertemplate_describe.md)	 - Describes a TriggerTemplate in a namespace
+* [tkn triggertemplate list](tkn_triggertemplate_list.md)	 - Lists TriggerTemplates in a namespace
 

--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -1,6 +1,6 @@
 ## tkn triggertemplate delete
 
-Delete triggertemplates in a namespace
+Delete TriggerTemplates in a namespace
 
 ***Aliases**: rm*
 
@@ -12,7 +12,7 @@ tkn triggertemplate delete
 
 ### Synopsis
 
-Delete triggertemplates in a namespace
+Delete TriggerTemplates in a namespace
 
 ### Examples
 
@@ -47,5 +47,5 @@ or
 
 ### SEE ALSO
 
-* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates
+* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage TriggerTemplates
 

--- a/docs/cmd/tkn_triggertemplate_describe.md
+++ b/docs/cmd/tkn_triggertemplate_describe.md
@@ -1,6 +1,6 @@
 ## tkn triggertemplate describe
 
-Describes a triggertemplate in a namespace
+Describes a TriggerTemplate in a namespace
 
 ***Aliases**: desc*
 
@@ -12,7 +12,7 @@ tkn triggertemplate describe
 
 ### Synopsis
 
-Describes a triggertemplate in a namespace
+Describes a TriggerTemplate in a namespace
 
 ### Examples
 
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates
+* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage TriggerTemplates
 

--- a/docs/cmd/tkn_triggertemplate_list.md
+++ b/docs/cmd/tkn_triggertemplate_list.md
@@ -1,6 +1,6 @@
 ## tkn triggertemplate list
 
-Lists triggertemplates in a namespace
+Lists TriggerTemplates in a namespace
 
 ***Aliases**: ls*
 
@@ -12,11 +12,11 @@ tkn triggertemplate list
 
 ### Synopsis
 
-Lists triggertemplates in a namespace
+Lists TriggerTemplates in a namespace
 
 ### Examples
 
-List all triggertemplates in namespace 'bar':
+List all TriggerTemplates in namespace 'bar':
 
 	tkn triggertemplate list -n bar
 
@@ -45,5 +45,5 @@ or
 
 ### SEE ALSO
 
-* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage triggertemplates
+* [tkn triggertemplate](tkn_triggertemplate.md)	 - Manage TriggerTemplates
 

--- a/docs/man/man1/tkn-triggertemplate-delete.1
+++ b/docs/man/man1/tkn-triggertemplate-delete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggertemplate\-delete \- Delete triggertemplates in a namespace
+tkn\-triggertemplate\-delete \- Delete TriggerTemplates in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggertemplate\-delete \- Delete triggertemplates in a namespace
 
 .SH DESCRIPTION
 .PP
-Delete triggertemplates in a namespace
+Delete TriggerTemplates in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-triggertemplate-describe.1
+++ b/docs/man/man1/tkn-triggertemplate-describe.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggertemplate\-describe \- Describes a triggertemplate in a namespace
+tkn\-triggertemplate\-describe \- Describes a TriggerTemplate in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggertemplate\-describe \- Describes a triggertemplate in a namespace
 
 .SH DESCRIPTION
 .PP
-Describes a triggertemplate in a namespace
+Describes a TriggerTemplate in a namespace
 
 
 .SH OPTIONS

--- a/docs/man/man1/tkn-triggertemplate-list.1
+++ b/docs/man/man1/tkn-triggertemplate-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggertemplate\-list \- Lists triggertemplates in a namespace
+tkn\-triggertemplate\-list \- Lists TriggerTemplates in a namespace
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggertemplate\-list \- Lists triggertemplates in a namespace
 
 .SH DESCRIPTION
 .PP
-Lists triggertemplates in a namespace
+Lists TriggerTemplates in a namespace
 
 
 .SH OPTIONS
@@ -57,7 +57,7 @@ Lists triggertemplates in a namespace
 
 .SH EXAMPLE
 .PP
-List all triggertemplates in namespace 'bar':
+List all TriggerTemplates in namespace 'bar':
 
 .PP
 .RS

--- a/docs/man/man1/tkn-triggertemplate.1
+++ b/docs/man/man1/tkn-triggertemplate.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-tkn\-triggertemplate \- Manage triggertemplates
+tkn\-triggertemplate \- Manage TriggerTemplates
 
 
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ tkn\-triggertemplate \- Manage triggertemplates
 
 .SH DESCRIPTION
 .PP
-Manage triggertemplates
+Manage TriggerTemplates
 
 
 .SH OPTIONS

--- a/pkg/cmd/triggertemplate/delete.go
+++ b/pkg/cmd/triggertemplate/delete.go
@@ -41,7 +41,7 @@ or
 	c := &cobra.Command{
 		Use:          "delete",
 		Aliases:      []string{"rm"},
-		Short:        "Delete triggertemplates in a namespace",
+		Short:        "Delete TriggerTemplates in a namespace",
 		Example:      eg,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,

--- a/pkg/cmd/triggertemplate/describe.go
+++ b/pkg/cmd/triggertemplate/describe.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"text/tabwriter"
 	"text/template"
 
@@ -81,7 +80,7 @@ or
 	c := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"desc"},
-		Short:   "Describes a triggertemplate in a namespace",
+		Short:   "Describes a TriggerTemplate in a namespace",
 		Example: eg,
 		Annotations: map[string]string{
 			"commandType": "main",
@@ -96,8 +95,7 @@ or
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Error: output option not set properly \n")
-				return err
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			if output != "" {
@@ -143,7 +141,7 @@ func printTriggerTemplateDescription(s *cli.Stream, p cli.Params, ttname string)
 
 	tt, err := cs.Triggers.TriggersV1alpha1().TriggerTemplates(p.Namespace()).Get(context.Background(), ttname, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get triggertemplate %s from %s namespace: %v", ttname, p.Namespace(), err)
+		return fmt.Errorf("failed to get TriggerTemplate %s from %s namespace: %v", ttname, p.Namespace(), err)
 	}
 
 	var data = struct {

--- a/pkg/cmd/triggertemplate/list.go
+++ b/pkg/cmd/triggertemplate/list.go
@@ -16,7 +16,6 @@ package triggertemplate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"text/tabwriter"
 
@@ -32,13 +31,13 @@ import (
 )
 
 const (
-	emptyMsg = "No triggertemplates found"
+	emptyMsg = "No TriggerTemplates found"
 )
 
 func listCommand(p cli.Params) *cobra.Command {
 	f := cliopts.NewPrintFlags("list")
 
-	eg := `List all triggertemplates in namespace 'bar':
+	eg := `List all TriggerTemplates in namespace 'bar':
 
 	tkn triggertemplate list -n bar
 
@@ -50,7 +49,7 @@ or
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "Lists triggertemplates in a namespace",
+		Short:   "Lists TriggerTemplates in a namespace",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -63,12 +62,12 @@ or
 
 			tts, err := list(cs.Triggers, p.Namespace())
 			if err != nil {
-				return fmt.Errorf("failed to list triggertemplates from %s namespace: %v", p.Namespace(), err)
+				return fmt.Errorf("failed to list TriggerTemplates from %s namespace: %v", p.Namespace(), err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
 			if err != nil {
-				return errors.New("output option not set properly")
+				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
 			stream := &cli.Stream{
@@ -81,7 +80,7 @@ or
 			}
 
 			if err = printFormatted(stream, tts, p); err != nil {
-				return errors.New("failed to print triggertemplates")
+				return fmt.Errorf("failed to print TriggerTemplates: %v", err)
 			}
 			return nil
 

--- a/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-Invalid_namespace.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-Invalid_namespace.golden
@@ -1,1 +1,1 @@
-No triggertemplates found
+No TriggerTemplates found

--- a/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-No_TriggerTemplate.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-No_TriggerTemplate.golden
@@ -1,1 +1,1 @@
-No triggertemplates found
+No TriggerTemplates found

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_Invalid_Namespace.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_Invalid_Namespace.golden
@@ -1,1 +1,1 @@
-Error: failed to get triggertemplate bar from invalid namespace: triggertemplates.triggers.tekton.dev "bar" not found
+Error: failed to get TriggerTemplate bar from invalid namespace: triggertemplates.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_NonExistedName.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_NonExistedName.golden
@@ -1,1 +1,1 @@
-Error: failed to get triggertemplate bar from ns namespace: triggertemplates.triggers.tekton.dev "bar" not found
+Error: failed to get TriggerTemplate bar from ns namespace: triggertemplates.triggers.tekton.dev "bar" not found

--- a/pkg/cmd/triggertemplate/triggertemplate.go
+++ b/pkg/cmd/triggertemplate/triggertemplate.go
@@ -24,7 +24,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "triggertemplate",
 		Aliases: []string{"tt", "triggertemplates"},
-		Short:   "Manage triggertemplates",
+		Short:   "Manage TriggerTemplates",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},


### PR DESCRIPTION
Part of #605 

This pull request changes all user-facing messages to use `TriggerTemplate` instead of a variety of ways it is referenced throughout `tkn` (e.g., `triggertemplate`, `TriggerTemplate`). 

Additionally, this pr removes printing error messages to Stderr, and instead returns the errors to be handled by Cobra instead.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Standardize the use of TriggerTemplate in user-facing messages for tkn triggertemplate commands
```