### PR TITLE
Fix unit test failures with go 1.15

### DIFF
--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -1248,6 +1248,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 		input       pipelinev1beta1test.Clients
 		inputStream io.Reader
 		wantError   bool
+		hasPrefix   bool
 		want        string
 		goldenFile  bool
 	}{
@@ -1479,7 +1480,8 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "time: unknown unit d in duration 5d",
+			hasPrefix:   true,
+			want:        `time: unknown unit`,
 		},
 		{
 			name: "Dry run with PodTemplate",
@@ -1623,7 +1625,12 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 				if err == nil {
 					t.Errorf("Error expected here")
 				}
-				test.AssertOutput(t, tp.want, err.Error())
+
+				if tp.hasPrefix {
+					test.AssertOutputPrefix(t, tp.want, err.Error())
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
+				}
 			} else {
 				if err != nil {
 					t.Errorf("Unexpected error")

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -969,6 +969,7 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 		namespace  string
 		input      *test.Params
 		wantError  bool
+		hasPrefix  bool
 		want       string
 		goldenFile bool
 	}{
@@ -1347,7 +1348,8 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			namespace: "",
 			input:     c2,
 			wantError: true,
-			want:      "time: unknown unit d in duration 5d",
+			hasPrefix: true,
+			want:      `time: unknown unit`,
 		},
 		{
 			name: "Dry Run with PodTemplate",
@@ -1379,7 +1381,12 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 				if err == nil {
 					t.Errorf("error expected here")
 				}
-				test.AssertOutput(t, tp.want, err.Error())
+
+				if tp.hasPrefix {
+					test.AssertOutputPrefix(t, tp.want, err.Error())
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
+				}
 			} else {
 				if err != nil {
 					t.Errorf("unexpected Error")

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -4358,6 +4358,7 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 		dynamic    dynamic.Interface
 		input      pipelinev1beta1test.Clients
 		wantError  bool
+		hasPrefix  bool
 		want       string
 		goldenFile bool
 	}{
@@ -4518,7 +4519,8 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 			dynamic:   dc,
 			input:     cs,
 			wantError: true,
-			want:      "time: unknown unit d in duration 5d",
+			hasPrefix: true,
+			want:      `time: unknown unit`,
 		},
 		{
 			name: "Dry Run with output=json -f v1beta1",
@@ -4583,7 +4585,12 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				if err == nil {
 					t.Errorf("error expected here")
 				}
-				test.AssertOutput(t, tp.want, err.Error())
+
+				if tp.hasPrefix {
+					test.AssertOutputPrefix(t, tp.want, err.Error())
+				} else {
+					test.AssertOutput(t, tp.want, err.Error())
+				}
 			} else {
 				if err != nil {
 					t.Errorf("unexpected Error")

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -16,6 +16,7 @@ package formatted
 import (
 	"bytes"
 	"html/template"
+	"strconv"
 
 	"testing"
 
@@ -39,7 +40,8 @@ func TestRainbowsColours(t *testing.T) {
 
 	rb = newRainbow()
 	for c := range palette {
-		rb.get(string(c))
+		a := strconv.Itoa(c)
+		rb.get(a)
 	}
 	assert.Equal(t, rb.counter.value, uint32(0)) // Looped back to 0
 }

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -56,4 +57,20 @@ Expected
 Actual
 %s
 `, diff, expected, actual)
+}
+
+func AssertOutputPrefix(t *testing.T, expected, actual string) {
+	t.Helper()
+
+	if !strings.HasPrefix(actual, expected) {
+		t.Errorf(`
+Unexpected output:
+
+Expected prefix
+%s
+
+Actual
+%s
+`, expected, actual)
+	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Closes https://github.com/tektoncd/cli/issues/1202

It seems from go 1.15, the error message has been slightly changed and it is quoted now. Why don't we use a prefix match to test if the error messages are as expected?

- [go 1.15](https://github.com/golang/go/blob/go1.15/src/time/format.go#L1443)
- [go 1.14](https://github.com/golang/go/blob/go1.14/src/time/format.go#L1443)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

```release-note
none
```