### PR TITLE
Update readme for 0.13.1 and fix lint task

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Download the latest binary executable for your operating system:
   brew install tektoncd-cli
   ```
 
-  - Or by the [released tarball](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Darwin_x86_64.tar.gz):
+  - Or by the [released tarball](https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Darwin_x86_64.tar.gz):
 
   ```shell
   # Get the tar.xz
-  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Darwin_x86_64.tar.gz
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Darwin_x86_64.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
-  sudo tar xvzf tkn_0.13.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
+  sudo tar xvzf tkn_0.13.1_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
   ```
 
 * Windows
@@ -41,7 +41,7 @@ Download the latest binary executable for your operating system:
 
   - Or by the released zip file in the instructions below:
 
-  - Uncompress the [zip file](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Windows_x86_64.zip)
+  - Uncompress the [zip file](https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Windows_x86_64.zip)
   - Add the location of where the executable is to your `Path` by opening `Control Panel>System and Security>System>Advanced System Settings`
   - Click on `Environment Variables`, select the `Path` variable, and click `Edit`
   - Click `New` and add the location of the uncompressed zip to the `Path`
@@ -49,40 +49,40 @@ Download the latest binary executable for your operating system:
 
 #### Linux tarballs
 
-* [Linux AMD 64](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_x86_64.tar.gz)
+* [Linux AMD 64](https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_x86_64.tar.gz)
 
   ```shell
   # Get the tar.xz
-  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_x86_64.tar.gz
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_x86_64.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
-  sudo tar xvzf tkn_0.13.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+  sudo tar xvzf tkn_0.13.1_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
   ```
 
-* [Linux ARM 64](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_arm64.tar.gz)
+* [Linux ARM 64](https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_arm64.tar.gz)
 
   ```shell
   # Get the tar.xz
-  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_arm64.tar.gz
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_arm64.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
-  sudo tar xvzf tkn_0.13.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+  sudo tar xvzf tkn_0.13.1_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
   ```
 
-* [Linux IBM Z](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_s390x.tar.gz)
+* [Linux IBM Z](https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_s390x.tar.gz)
 
   ```shell
   # Get the tar.gz
-  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_s390x.tar.gz
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_s390x.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
-  sudo tar xvzf tkn_0.13.0_Linux_s390x.tar.gz -C /usr/local/bin/ tkn
+  sudo tar xvzf tkn_0.13.1_Linux_s390x.tar.gz -C /usr/local/bin/ tkn
   ```
 
-* [Linux IBM P](https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_ppc64le.tar.gz)
+* [Linux IBM P](https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_ppc64le.tar.gz)
 
   ```shell
   # Get the tar.gz
-  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.0/tkn_0.13.0_Linux_ppc64le.tar.gz
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.1/tkn_0.13.1_Linux_ppc64le.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
-  sudo tar xvzf tkn_0.13.0_Linux_ppc64le.tar.gz -C /usr/local/bin/ tkn
+  sudo tar xvzf tkn_0.13.1_Linux_ppc64le.tar.gz -C /usr/local/bin/ tkn
   ```
 
 
@@ -105,12 +105,12 @@ Download the latest binary executable for your operating system:
   dnf install tektoncd-cli
   ```
 
-  * [Binary RPM package](https://github.com/tektoncd/cli/releases/download/v0.13.0/tektoncd-cli-0.13.0_Linux-64bit.rpm)
+  * [Binary RPM package](https://github.com/tektoncd/cli/releases/download/v0.13.1/tektoncd-cli-0.13.1_Linux-64bit.rpm)
 
   On any other RPM based distros, you can install the rpm directly:
 
    ```shell
-    rpm -Uvh https://github.com/tektoncd/cli/releases/download/v0.13.0/tektoncd-cli-0.13.0_Linux-64bit.rpm
+    rpm -Uvh https://github.com/tektoncd/cli/releases/download/v0.13.1/tektoncd-cli-0.13.1_Linux-64bit.rpm
    ```
 
 #### Linux Debs
@@ -128,13 +128,13 @@ Download the latest binary executable for your operating system:
 
   The PPA may work with older releases, but that hasn't been tested.
 
-  * [Binary DEB package](https://github.com/tektoncd/cli/releases/download/v0.13.0/tektoncd-cli-0.13.0_Linux-64bit.deb)
+  * [Binary DEB package](https://github.com/tektoncd/cli/releases/download/v0.13.1/tektoncd-cli-0.13.1_Linux-64bit.deb)
 
   On any other Debian or Ubuntu based distro, you can simply install the binary package directly with `dpkg`:
 
   ```shell
-  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.0/tektoncd-cli-0.13.0_Linux-64bit.deb
-  dpkg -i tektoncd-cli-0.13.0_Linux-64bit.deb
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.13.1/tektoncd-cli-0.13.1_Linux-64bit.deb
+  dpkg -i tektoncd-cli-0.13.1_Linux-64bit.deb
   ```
 
 # Source install

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -54,7 +54,7 @@ spec:
         - name: flags
           value: "-v --timeout 10m"
         - name: version
-          value: v1.24.0
+          value: v1.31.0
       workspaces:
         - name: source
           workspace: shared-workspace


### PR DESCRIPTION
This will update the readme for v0.13.1 release
and will update the lint version in release pipeline
as the task is failing

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
