### PR TITLE
Fix Alignment of Usage

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -40,7 +40,7 @@ import (
 
 const usageTemplate = `Usage:{{if .Runnable}}
 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}


### PR DESCRIPTION
Noticed this when adding the `tkn hub` integration. The `Usage:` section of help is slightly off:

```
$ tkn
CLI for tekton pipelines

Usage:
tkn [flags]
  tkn [command]
```

This change will make it look like the following:

```
$ ./tkn 
CLI for tekton pipelines

Usage:
tkn [flags]
tkn [command]
```
# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Fix alignment of Usage in help command
```