### PR TITLE
Change --nocolour to --no-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ export NO_COLOR=""
 
 More information on `NO_COLOR` can be found in the [`NO_COLOR` documentation](https://no-color.org/).
 
-To remove color and emojis from the output of a single command execution, the `--nocolour` option can be used with any command, 
+To remove color and emojis from the output of a single command execution, the `--no-color` option can be used with any command, 
 such as in the example below:
 
 ```
-tkn taskrun describe --nocolour
+tkn taskrun describe --no-color
 ```
 
 ## Want to contribute

--- a/docs/cmd/tkn_clustertask.md
+++ b/docs/cmd/tkn_clustertask.md
@@ -20,7 +20,7 @@ Manage ClusterTasks
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertask
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_delete.md
+++ b/docs/cmd/tkn_clustertask_delete.md
@@ -42,7 +42,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_describe.md
+++ b/docs/cmd/tkn_clustertask_describe.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -28,7 +28,7 @@ Lists ClusterTasks
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -52,7 +52,7 @@ like cat,foo,bar
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding.md
+++ b/docs/cmd/tkn_clustertriggerbinding.md
@@ -20,7 +20,7 @@ Manage ClusterTriggerBindings
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -h, --help                help for clustertriggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_delete.md
+++ b/docs/cmd/tkn_clustertriggerbinding_delete.md
@@ -41,7 +41,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_describe.md
+++ b/docs/cmd/tkn_clustertriggerbinding_describe.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_clustertriggerbinding_list.md
+++ b/docs/cmd/tkn_clustertriggerbinding_list.md
@@ -39,7 +39,7 @@ or
 ```
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition.md
+++ b/docs/cmd/tkn_condition.md
@@ -21,7 +21,7 @@ Manage Conditions
   -h, --help                help for condition
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_delete.md
+++ b/docs/cmd/tkn_condition_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_describe.md
+++ b/docs/cmd/tkn_condition_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_condition_list.md
+++ b/docs/cmd/tkn_condition_list.md
@@ -29,7 +29,7 @@ Lists Conditions in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener.md
+++ b/docs/cmd/tkn_eventlistener.md
@@ -21,7 +21,7 @@ Manage EventListeners
   -h, --help                help for eventlistener
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_describe.md
+++ b/docs/cmd/tkn_eventlistener_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_list.md
+++ b/docs/cmd/tkn_eventlistener_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_eventlistener_logs.md
+++ b/docs/cmd/tkn_eventlistener_logs.md
@@ -36,7 +36,7 @@ Show 2 lines of most recent logs from all EventListener pods:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline.md
+++ b/docs/cmd/tkn_pipeline.md
@@ -21,7 +21,7 @@ Manage pipelines
   -h, --help                help for pipeline
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_describe.md
+++ b/docs/cmd/tkn_pipeline_describe.md
@@ -29,7 +29,7 @@ Describes a Pipeline in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_list.md
+++ b/docs/cmd/tkn_pipeline_list.md
@@ -31,7 +31,7 @@ Lists Pipelines in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -48,7 +48,7 @@ Show logs for given Pipeline and PipelineRun:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -64,7 +64,7 @@ my-secret and my-empty-dir)
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun.md
+++ b/docs/cmd/tkn_pipelinerun.md
@@ -21,7 +21,7 @@ Manage PipelineRuns
   -h, --help                help for pipelinerun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -31,7 +31,7 @@ Cancel the PipelineRun named 'foo' from namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -44,7 +44,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -45,7 +45,7 @@ List all PipelineRuns in a namespace 'foo':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -45,7 +45,7 @@ Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (inc
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource.md
+++ b/docs/cmd/tkn_resource.md
@@ -21,7 +21,7 @@ Manage pipeline resources
   -h, --help                help for resource
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_create.md
+++ b/docs/cmd/tkn_resource_create.md
@@ -33,7 +33,7 @@ Creates new PipelineResource as per the given input:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_delete.md
+++ b/docs/cmd/tkn_resource_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_describe.md
+++ b/docs/cmd/tkn_resource_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_resource_list.md
+++ b/docs/cmd/tkn_resource_list.md
@@ -39,7 +39,7 @@ List all PipelineResources in a namespace 'foo':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task.md
+++ b/docs/cmd/tkn_task.md
@@ -21,7 +21,7 @@ Manage Tasks
   -h, --help                help for task
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_describe.md
+++ b/docs/cmd/tkn_task_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_list.md
+++ b/docs/cmd/tkn_task_list.md
@@ -31,7 +31,7 @@ Lists Tasks in a namespace
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_logs.md
+++ b/docs/cmd/tkn_task_logs.md
@@ -47,7 +47,7 @@ Show logs for given Task and associated TaskRun:
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -53,7 +53,7 @@ like cat,foo,bar
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun.md
+++ b/docs/cmd/tkn_taskrun.md
@@ -21,7 +21,7 @@ Manage TaskRuns
   -h, --help                help for taskrun
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_cancel.md
+++ b/docs/cmd/tkn_taskrun_cancel.md
@@ -31,7 +31,7 @@ Cancel the TaskRun named 'foo' from namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -44,7 +44,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -43,7 +43,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -45,7 +45,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -46,7 +46,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding.md
+++ b/docs/cmd/tkn_triggerbinding.md
@@ -21,7 +21,7 @@ Manage TriggerBindings
   -h, --help                help for triggerbinding
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_describe.md
+++ b/docs/cmd/tkn_triggerbinding_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggerbinding_list.md
+++ b/docs/cmd/tkn_triggerbinding_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate.md
+++ b/docs/cmd/tkn_triggertemplate.md
@@ -21,7 +21,7 @@ Manage TriggerTemplates
   -h, --help                help for triggertemplate
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -42,7 +42,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_describe.md
+++ b/docs/cmd/tkn_triggertemplate_describe.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tkn_triggertemplate_list.md
+++ b/docs/cmd/tkn_triggertemplate_list.md
@@ -40,7 +40,7 @@ or
   -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
   -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string    namespace to use (default: from $KUBECONFIG)
-  -C, --nocolour            disable colouring (default: false)
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-clustertask-delete.1
+++ b/docs/man/man1/tkn-clustertask-delete.1
@@ -59,8 +59,8 @@ Delete ClusterTasks in a cluster
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertask-describe.1
+++ b/docs/man/man1/tkn-clustertask-describe.1
@@ -47,8 +47,8 @@ Describe a ClusterTask
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -47,8 +47,8 @@ Lists ClusterTasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -94,8 +94,8 @@ Start ClusterTasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertask.1
+++ b/docs/man/man1/tkn-clustertask.1
@@ -32,8 +32,8 @@ Manage ClusterTasks
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-clustertriggerbinding-delete.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-delete.1
@@ -55,8 +55,8 @@ Delete ClusterTriggerBindings
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertriggerbinding-describe.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-describe.1
@@ -47,8 +47,8 @@ Describes a ClusterTriggerBinding
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertriggerbinding-list.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-list.1
@@ -47,8 +47,8 @@ Lists ClusterTriggerBindings in a namespace
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-clustertriggerbinding.1
+++ b/docs/man/man1/tkn-clustertriggerbinding.1
@@ -32,8 +32,8 @@ Manage ClusterTriggerBindings
     kubectl config file (default: $HOME/.kube/config)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-condition-delete.1
+++ b/docs/man/man1/tkn-condition-delete.1
@@ -59,8 +59,8 @@ Delete Conditions in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-condition-describe.1
+++ b/docs/man/man1/tkn-condition-describe.1
@@ -51,8 +51,8 @@ Describe Conditions in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-condition-list.1
+++ b/docs/man/man1/tkn-condition-list.1
@@ -51,8 +51,8 @@ Lists Conditions in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-condition.1
+++ b/docs/man/man1/tkn-condition.1
@@ -36,8 +36,8 @@ Manage Conditions
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-eventlistener-delete.1
+++ b/docs/man/man1/tkn-eventlistener-delete.1
@@ -59,8 +59,8 @@ Delete EventListeners in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener-describe.1
+++ b/docs/man/man1/tkn-eventlistener-describe.1
@@ -51,8 +51,8 @@ Describe EventListener in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener-list.1
+++ b/docs/man/man1/tkn-eventlistener-list.1
@@ -51,8 +51,8 @@ Lists EventListeners in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener-logs.1
+++ b/docs/man/man1/tkn-eventlistener-logs.1
@@ -42,8 +42,8 @@ Show EventListener logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-eventlistener.1
+++ b/docs/man/man1/tkn-eventlistener.1
@@ -36,8 +36,8 @@ Manage EventListeners
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -63,8 +63,8 @@ Delete Pipelines in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline-describe.1
+++ b/docs/man/man1/tkn-pipeline-describe.1
@@ -51,8 +51,8 @@ Describes a Pipeline in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-list.1
+++ b/docs/man/man1/tkn-pipeline-list.1
@@ -59,8 +59,8 @@ Lists Pipelines in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -54,8 +54,8 @@ Show Pipeline logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -110,8 +110,8 @@ Parameters, at least those that have no default value
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipeline.1
+++ b/docs/man/man1/tkn-pipeline.1
@@ -36,8 +36,8 @@ Manage pipelines
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -38,8 +38,8 @@ Cancel a PipelineRun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -67,8 +67,8 @@ Delete PipelineRuns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -63,8 +63,8 @@ Describe a PipelineRun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -71,8 +71,8 @@ Lists PipelineRuns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -62,8 +62,8 @@ Show the logs of a PipelineRun
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-pipelinerun.1
+++ b/docs/man/man1/tkn-pipelinerun.1
@@ -36,8 +36,8 @@ Manage PipelineRuns
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-resource-create.1
+++ b/docs/man/man1/tkn-resource-create.1
@@ -51,8 +51,8 @@ Create a pipeline resource in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource-delete.1
+++ b/docs/man/man1/tkn-resource-delete.1
@@ -59,8 +59,8 @@ Delete pipeline resources in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource-describe.1
+++ b/docs/man/man1/tkn-resource-describe.1
@@ -51,8 +51,8 @@ Describes a pipeline resource in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource-list.1
+++ b/docs/man/man1/tkn-resource-list.1
@@ -63,8 +63,8 @@ Lists pipeline resources in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-resource.1
+++ b/docs/man/man1/tkn-resource.1
@@ -36,8 +36,8 @@ Manage pipeline resources
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -63,8 +63,8 @@ Delete Tasks in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-describe.1
+++ b/docs/man/man1/tkn-task-describe.1
@@ -51,8 +51,8 @@ Describe a Task in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-list.1
+++ b/docs/man/man1/tkn-task-list.1
@@ -59,8 +59,8 @@ Lists Tasks in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-logs.1
+++ b/docs/man/man1/tkn-task-logs.1
@@ -54,8 +54,8 @@ Show Task logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -102,8 +102,8 @@ Start Tasks
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-task.1
+++ b/docs/man/man1/tkn-task.1
@@ -36,8 +36,8 @@ Manage Tasks
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-taskrun-cancel.1
+++ b/docs/man/man1/tkn-taskrun-cancel.1
@@ -38,8 +38,8 @@ Cancel a TaskRun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -67,8 +67,8 @@ Delete TaskRuns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -63,8 +63,8 @@ Describe a TaskRun in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -71,8 +71,8 @@ Lists TaskRuns in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -62,8 +62,8 @@ Show TaskRuns logs
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-taskrun.1
+++ b/docs/man/man1/tkn-taskrun.1
@@ -36,8 +36,8 @@ Manage TaskRuns
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-triggerbinding-delete.1
+++ b/docs/man/man1/tkn-triggerbinding-delete.1
@@ -59,8 +59,8 @@ Delete TriggerBindings in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggerbinding-describe.1
+++ b/docs/man/man1/tkn-triggerbinding-describe.1
@@ -51,8 +51,8 @@ Describes a TriggerBinding in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggerbinding-list.1
+++ b/docs/man/man1/tkn-triggerbinding-list.1
@@ -51,8 +51,8 @@ Lists TriggerBindings in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggerbinding.1
+++ b/docs/man/man1/tkn-triggerbinding.1
@@ -36,8 +36,8 @@ Manage TriggerBindings
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-triggertemplate-delete.1
+++ b/docs/man/man1/tkn-triggertemplate-delete.1
@@ -59,8 +59,8 @@ Delete TriggerTemplates in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggertemplate-describe.1
+++ b/docs/man/man1/tkn-triggertemplate-describe.1
@@ -51,8 +51,8 @@ Describes a TriggerTemplate in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggertemplate-list.1
+++ b/docs/man/man1/tkn-triggertemplate-list.1
@@ -51,8 +51,8 @@ Lists TriggerTemplates in a namespace
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-triggertemplate.1
+++ b/docs/man/man1/tkn-triggertemplate.1
@@ -36,8 +36,8 @@ Manage TriggerTemplates
     namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB\-C\fP, \fB\-\-nocolour\fP[=false]
-    disable colouring (default: false)
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO


### PR DESCRIPTION
Closes #1219 

This pull request changes to `--nocolour` option to `--no-color` while still supporting the `--nocolour` flag. In documentation and help commands, `--no-color` will be shown as the available option. However, `--nocolour` should still work as was implemented previously. 

If there is a recommended approach to supporting old flag names better than the one I have implemented here (which basically adds `--no-color` as a new flag and hides but still supports `--nocolour`), please let me know. 

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Change --nocolour option to --no-color while still supporting --nocolour
```