### PR TITLE
Do Not Delete ClusterTask TaskRuns with --task Flag

### DIFF
--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	taskpkg "github.com/tektoncd/cli/pkg/task"
 	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
@@ -146,11 +147,12 @@ func taskRunLister(p cli.Params, keep int, cs *cli.Clients) func(string) ([]stri
 		lOpts := metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("tekton.dev/task=%s", taskName),
 		}
-		taskRuns, err := trlist.TaskRuns(cs, lOpts, p.Namespace())
+		trs, err := trlist.TaskRuns(cs, lOpts, p.Namespace())
 		if err != nil {
 			return nil, err
 		}
-		return keepTaskRuns(taskRuns, keep), nil
+		trs.Items = taskpkg.FilterByRef(trs.Items, string(v1beta1.NamespacedTaskKind))
+		return keepTaskRuns(trs, keep), nil
 	}
 }
 

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -192,7 +192,7 @@ func list(p cli.Params, task string, limit int, labelselector string, allnamespa
 
 	// this is required as the same label is getting added for both task and ClusterTask
 	if task != "" {
-		trs.Items = taskpkg.FilterByRef(trs.Items, "Task")
+		trs.Items = taskpkg.FilterByRef(trs.Items, string(v1beta1.NamespacedTaskKind))
 	}
 
 	trslen := len(trs.Items)

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/tektoncd/cli/pkg/cli"
 	trlist "github.com/tektoncd/cli/pkg/taskrun/list"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -55,20 +54,9 @@ func LastRun(cs *cli.Clients, task string, ns, kind string) (*v1beta1.TaskRun, e
 	return &latest, nil
 }
 
-// this will filter the taskkrun which have reference to Task
+// this will filter the taskrun which have reference to Task
 func FilterByRef(taskruns []v1beta1.TaskRun, kind string) []v1beta1.TaskRun {
 	var filtered []v1beta1.TaskRun
-	for _, taskrun := range taskruns {
-		if string(taskrun.Spec.TaskRef.Kind) == kind {
-			filtered = append(filtered, taskrun)
-		}
-	}
-	return filtered
-}
-
-// this will filter the taskkrun which have reference to Task
-func FilterByRefV1alpha1(taskruns []v1alpha1.TaskRun, kind string) []v1alpha1.TaskRun {
-	var filtered []v1alpha1.TaskRun
 	for _, taskrun := range taskruns {
 		if string(taskrun.Spec.TaskRef.Kind) == kind {
 			filtered = append(filtered, taskrun)


### PR DESCRIPTION
When running `tkn tr delete` with the `--task` option, if a ClusterTask exists with the same name, the ClusterTask's TaskRuns will also be deleted. This is because of TaskRuns for ClusterTasks having the `tekton.dev/task` label, which [will be removed in January 2021](https://github.com/tektoncd/pipeline/issues/2533#issuecomment-623454245).

For now, the workaround is to filter the TaskRuns by the TaskRefKind, ignoring the run for the deletion process if its kind is `ClusterTask`. A follow up to this pr should be an option added to `tkn tr delete` to delete TaskRuns associated with a ClusterTask. 

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Prevent tkn tr delete --task from deleting TaskRuns associated with ClusterTasks
```