### PR TITLE
Deprecate -c Shorthand for tkn version --check

### DIFF
--- a/docs/cmd/tkn_version.md
+++ b/docs/cmd/tkn_version.md
@@ -15,7 +15,7 @@ Prints version information
 ### Options
 
 ```
-  -c, --check              check if a newer version is available
+      --check              check if a newer version is available
   -h, --help               help for version
   -n, --namespace string   namespace to check installed controller version
 ```

--- a/docs/man/man1/tkn-version.1
+++ b/docs/man/man1/tkn-version.1
@@ -20,7 +20,7 @@ Prints version information
 
 .SH OPTIONS
 .PP
-\fB\-c\fP, \fB\-\-check\fP[=false]
+\fB\-\-check\fP[=false]
     check if a newer version is available
 
 .PP

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -92,6 +92,8 @@ func Command(p cli.Params) *cobra.Command {
 
 	if skipCheckFlag != "true" {
 		cmd.Flags().BoolVarP(&check, "check", "c", false, "check if a newer version is available")
+		_ = cmd.Flags().MarkShorthandDeprecated("check",
+			"the -c shorthand for tkn version --check will be removed in v0.15.0. See https://github.com/tektoncd/cli/issues/1231.")
 	}
 	return cmd
 }


### PR DESCRIPTION
Closes #1231 

As part of addressing #1212 and adding global options to `tkn version`, the `-c` shorthand for check will need to be removed as it conflicts with the `-c` shorthand for `--context`.

This pull requests marks the shorthand as deprecated so it can be removed in v0.15.0.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Deprecation notice for tkn version --check shorthand (-c)
```
