### PR TITLE
Add --all-namespaces flag to TriggerTemplate List subcommand

### DIFF
--- a/docs/cmd/tkn_triggertemplate_list.md
+++ b/docs/cmd/tkn_triggertemplate_list.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+  -A, --all-namespaces                list TriggerTemplates from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.

--- a/docs/man/man1/tkn-triggertemplate-list.1
+++ b/docs/man/man1/tkn-triggertemplate-list.1
@@ -20,6 +20,10 @@ Lists TriggerTemplates in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
+    list TriggerTemplates from all namespaces
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/triggertemplate/list.go
+++ b/pkg/cmd/triggertemplate/list.go
@@ -34,7 +34,12 @@ const (
 	emptyMsg = "No TriggerTemplates found"
 )
 
+type ListOptions struct {
+	AllNamespaces bool
+}
+
 func listCommand(p cli.Params) *cobra.Command {
+	opts := &ListOptions{}
 	f := cliopts.NewPrintFlags("list")
 
 	eg := `List all TriggerTemplates in namespace 'bar':
@@ -60,9 +65,16 @@ or
 				return err
 			}
 
-			tts, err := list(cs.Triggers, p.Namespace())
+			namespace := p.Namespace()
+			if opts.AllNamespaces {
+				namespace = ""
+			}
+			tts, err := list(cs.Triggers, namespace)
 			if err != nil {
-				return fmt.Errorf("failed to list TriggerTemplates from %s namespace: %v", p.Namespace(), err)
+				if opts.AllNamespaces {
+					return fmt.Errorf("failed to list TriggerTemplates from all namespaces: %v", err)
+				}
+				return fmt.Errorf("failed to list TriggerTemplates from %s namespace: %v", namespace, err)
 			}
 
 			output, err := cmd.LocalFlags().GetString("output")
@@ -79,7 +91,7 @@ or
 				return printer.PrintObject(stream.Out, tts, f)
 			}
 
-			if err = printFormatted(stream, tts, p); err != nil {
+			if err = printFormatted(stream, tts, p, opts.AllNamespaces); err != nil {
 				return fmt.Errorf("failed to print TriggerTemplates: %v", err)
 			}
 			return nil
@@ -89,6 +101,7 @@ or
 
 	f.AddFlags(c)
 
+	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list TriggerTemplates from all namespaces")
 	return c
 }
 
@@ -109,19 +122,32 @@ func list(client versioned.Interface, namespace string) (*v1alpha1.TriggerTempla
 	return tts, nil
 }
 
-func printFormatted(s *cli.Stream, tts *v1alpha1.TriggerTemplateList, p cli.Params) error {
+func printFormatted(s *cli.Stream, tts *v1alpha1.TriggerTemplateList, p cli.Params, allNamespaces bool) error {
 	if len(tts.Items) == 0 {
 		fmt.Fprintln(s.Err, emptyMsg)
 		return nil
 	}
 
+	headers := "NAME\tAGE"
+	if allNamespaces {
+		headers = "NAMESPACE\t" + headers
+	}
+
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "NAME\tAGE")
+	fmt.Fprintln(w, headers)
 	for _, tt := range tts.Items {
-		fmt.Fprintf(w, "%s\t%s\n",
-			tt.Name,
-			formatted.Age(&tt.CreationTimestamp, p.Time()),
-		)
+		if allNamespaces {
+			fmt.Fprintf(w, "%s\t%s\t%s\n",
+				tt.Namespace,
+				tt.Name,
+				formatted.Age(&tt.CreationTimestamp, p.Time()),
+			)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\n",
+				tt.Name,
+				formatted.Age(&tt.CreationTimestamp, p.Time()),
+			)
+		}
 	}
 
 	return w.Flush()

--- a/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-TriggerTemplates_from_all_namespaces.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-TriggerTemplates_from_all_namespaces.golden
@@ -1,0 +1,6 @@
+NAMESPACE   NAME   AGE
+foo         tt1    2 minutes ago
+foo         tt2    30 seconds ago
+foo         tt3    1 week ago
+foo         tt4    ---
+bar         tt5    ---


### PR DESCRIPTION
# Changes

Add support for --all-namespaces flag for `tkn triggertemplate list` to list the triggertemplates from all namespaces.

Fix partially #785 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Add support for --all-namespaces flag to tkn triggertemplate list
```