### PR TITLE
Add --all-namespaces flag to tkn eventlistener list command

### DIFF
--- a/docs/cmd/tkn_eventlistener_list.md
+++ b/docs/cmd/tkn_eventlistener_list.md
@@ -28,6 +28,7 @@ or
 ### Options
 
 ```
+  -A, --all-namespaces                list EventListeners from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.

--- a/docs/man/man1/tkn-eventlistener-list.1
+++ b/docs/man/man1/tkn-eventlistener-list.1
@@ -20,6 +20,10 @@ Lists EventListeners in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-A\fP, \fB\-\-all\-namespaces\fP[=false]
+    list EventListeners from all namespaces
+
+.PP
 \fB\-\-allow\-missing\-template\-keys\fP[=true]
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 

--- a/pkg/cmd/eventlistener/testdata/TestListEventListener-EventListeners_from_all-namespaces.golden
+++ b/pkg/cmd/eventlistener/testdata/TestListEventListener-EventListeners_from_all-namespaces.golden
@@ -1,0 +1,7 @@
+NAMESPACE   NAME   AGE              URL                                             AVAILABLE
+bar         tb0    2 minutes ago    http://tb0-listener.default.svc.cluster.local   True
+foo         tb1    2 minutes ago    http://tb1-listener.default.svc.cluster.local   True
+foo         tb2    30 seconds ago   http://tb2-listener.default.svc.cluster.local   True
+foo         tb3    1 week ago       http://tb3-listener.default.svc.cluster.local   True
+foo         tb4    ---              ---                                             ---
+foo         tb5    10 seconds ago   ---                                             False


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds support for --all-namespaces flag for tkn eventlistener list command as mentioned in issue #785.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

Add support for --all-namespaces flag to tkn eventlistener list.
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
