### PR TITLE
Fix APIversion not shown on describe commands

### DIFF
--- a/pkg/cmd/clustertriggerbinding/describe.go
+++ b/pkg/cmd/clustertriggerbinding/describe.go
@@ -105,7 +105,7 @@ func describeClusterTriggerBindingOutput(w io.Writer, p cli.Params, f *cliopts.P
 	// tektoncd go client fails to set these; probably a bug
 	ctb.GetObjectKind().SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: "triggers.tekton.dev",
+			Version: "triggers.tekton.dev/v1alpha1",
 			Kind:    "ClusterTriggerBinding",
 		})
 

--- a/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_WithOutputName.golden
+++ b/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_WithOutputName.golden
@@ -1,1 +1,1 @@
-clustertriggerbinding/ctb1
+clustertriggerbinding.triggers.tekton.dev/ctb1

--- a/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_WithOutputYaml.golden
+++ b/pkg/cmd/clustertriggerbinding/testdata/TestClusterTriggerBindingDescribe_WithOutputYaml.golden
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev
+apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterTriggerBinding
 metadata:
   creationTimestamp: null

--- a/pkg/cmd/eventlistener/describe.go
+++ b/pkg/cmd/eventlistener/describe.go
@@ -190,7 +190,7 @@ func describeEventListenerOutput(w io.Writer, p cli.Params, f *cliopts.PrintFlag
 	// tektoncd go client fails to set these; probably a bug
 	el.GetObjectKind().SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: "triggers.tekton.dev",
+			Version: "triggers.tekton.dev/v1alpha1",
 			Kind:    "EventListener",
 		})
 

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OutputYAMLWithMultipleBindingAndInterceptors.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OutputYAMLWithMultipleBindingAndInterceptors.golden
@@ -1,6 +1,6 @@
 {
     "kind": "EventListener",
-    "apiVersion": "triggers.tekton.dev",
+    "apiVersion": "triggers.tekton.dev/v1alpha1",
     "metadata": {
         "name": "el1",
         "namespace": "ns",

--- a/pkg/cmd/triggerbinding/describe.go
+++ b/pkg/cmd/triggerbinding/describe.go
@@ -106,7 +106,7 @@ func describeTriggerBindingOutput(w io.Writer, p cli.Params, f *cliopts.PrintFla
 	// tektoncd go client fails to set these; probably a bug
 	tb.GetObjectKind().SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: "triggers.tekton.dev",
+			Version: "triggers.tekton.dev/v1alpha1",
 			Kind:    "TriggerBinding",
 		})
 

--- a/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_WithOutputName.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_WithOutputName.golden
@@ -1,1 +1,1 @@
-triggerbinding/tb1
+triggerbinding.triggers.tekton.dev/tb1

--- a/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_WithOutputYaml.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestTriggerBindingDescribe_WithOutputYaml.golden
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev
+apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
   creationTimestamp: null

--- a/pkg/cmd/triggertemplate/describe.go
+++ b/pkg/cmd/triggertemplate/describe.go
@@ -126,7 +126,7 @@ func describeTriggerTemplateOutput(w io.Writer, p cli.Params, f *cliopts.PrintFl
 	// tektoncd go client fails to set these; probably a bug
 	tt.GetObjectKind().SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: "triggers.tekton.dev",
+			Version: "triggers.tekton.dev/v1alpha1",
 			Kind:    "TriggerTemplate",
 		})
 

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithOutputName.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithOutputName.golden
@@ -1,1 +1,1 @@
-triggertemplate/tt1
+triggertemplate.triggers.tekton.dev/tt1

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithOutputYaml.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithOutputYaml.golden
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev
+apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
This will fix the issue of APIversion not shown on describe
with output format for trigger related commands

Fix #1230

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix APIversion not shown on describe commands
```
