### PR TITLE
Add --no-headers flag to tkn clustertriggerbinding list command

### DIFF
--- a/docs/cmd/tkn_clustertriggerbinding_list.md
+++ b/docs/cmd/tkn_clustertriggerbinding_list.md
@@ -30,6 +30,7 @@ or
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
+      --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/man/man1/tkn-clustertriggerbinding-list.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-list.1
@@ -28,6 +28,10 @@ Lists ClusterTriggerBindings in a namespace
     help for list
 
 .PP
+\fB\-\-no\-headers\fP[=false]
+    do not print column headers with output (default print column headers with output)
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 

--- a/pkg/cmd/clustertriggerbinding/list.go
+++ b/pkg/cmd/clustertriggerbinding/list.go
@@ -35,7 +35,12 @@ const (
 	emptyMsg = "No ClusterTriggerBindings found"
 )
 
+type listOptions struct {
+	NoHeaders bool
+}
+
 func listCommand(p cli.Params) *cobra.Command {
+	opts := &listOptions{}
 	f := cliopts.NewPrintFlags("list")
 
 	eg := `List all ClusterTriggerBindings:
@@ -89,7 +94,7 @@ or
 				return printer.PrintObject(stream.Out, tbs, f)
 			}
 
-			if err = printFormatted(stream, tbs, p); err != nil {
+			if err = printFormatted(stream, tbs, p, opts.NoHeaders); err != nil {
 				return fmt.Errorf("failed to print ClusterTriggerBindings: %v", err)
 			}
 			return nil
@@ -98,7 +103,7 @@ or
 	}
 
 	f.AddFlags(c)
-
+	c.Flags().BoolVar(&opts.NoHeaders, "no-headers", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 	return c
 }
 
@@ -119,14 +124,16 @@ func list(client versioned.Interface, namespace string) (*v1alpha1.ClusterTrigge
 	return tbs, nil
 }
 
-func printFormatted(s *cli.Stream, tbs *v1alpha1.ClusterTriggerBindingList, p cli.Params) error {
+func printFormatted(s *cli.Stream, tbs *v1alpha1.ClusterTriggerBindingList, p cli.Params, noHeaders bool) error {
 	if len(tbs.Items) == 0 {
 		fmt.Fprintln(s.Err, emptyMsg)
 		return nil
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "NAME\tAGE")
+	if !noHeaders {
+		fmt.Fprintln(w, "NAME\tAGE")
+	}
 	for _, tb := range tbs.Items {
 		fmt.Fprintf(w, "%s\t%s\n",
 			tb.Name,

--- a/pkg/cmd/clustertriggerbinding/list_test.go
+++ b/pkg/cmd/clustertriggerbinding/list_test.go
@@ -70,6 +70,12 @@ func TestListClusterTriggerBinding(t *testing.T) {
 			args:      []string{"list", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"},
 			wantError: false,
 		},
+		{
+			name:      "List ClusterTriggerBindings without headers",
+			command:   command(t, ctbs, now),
+			args:      []string{"list", "--no-headers"},
+			wantError: false,
+		},
 	}
 
 	for _, td := range tests {

--- a/pkg/cmd/clustertriggerbinding/testdata/TestListClusterTriggerBinding-List_ClusterTriggerBindings_without_headers.golden
+++ b/pkg/cmd/clustertriggerbinding/testdata/TestListClusterTriggerBinding-List_ClusterTriggerBindings_without_headers.golden
@@ -1,0 +1,4 @@
+ctb1   2 minutes ago
+ctb2   30 seconds ago
+ctb3   1 week ago
+ctb4   ---


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds support for ` --no-headers` flag to `tkn clustertriggerbinding list` command as requested in issue #799.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
Add support for ` --no-headers` flag to `tkn clustertriggerbinding list`. 
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
