### PR TITLE
Add --no-headers flag to tkn clustertask list command

### DIFF
--- a/docs/cmd/tkn_clustertask_list.md
+++ b/docs/cmd/tkn_clustertask_list.md
@@ -19,6 +19,7 @@ Lists ClusterTasks
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
+      --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/man/man1/tkn-clustertask-list.1
+++ b/docs/man/man1/tkn-clustertask-list.1
@@ -28,6 +28,10 @@ Lists ClusterTasks
     help for list
 
 .PP
+\fB\-\-no\-headers\fP[=false]
+    do not print column headers with output (default print column headers with output)
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 

--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -30,11 +30,16 @@ import (
 
 const (
 	emptyMsg = "No ClusterTasks found\n"
-	header   = "NAME\tDESCRIPTION\tAGE"
 	body     = "%s\t%s\t%s\n"
+	header   = "NAME\tDESCRIPTION\tAGE"
 )
 
+type listOptions struct {
+	NoHeaders bool
+}
+
 func listCommand(p cli.Params) *cobra.Command {
+	opts := &listOptions{}
 	f := cliopts.NewPrintFlags("list")
 
 	c := &cobra.Command{
@@ -59,15 +64,15 @@ func listCommand(p cli.Params) *cobra.Command {
 				Out: cmd.OutOrStdout(),
 				Err: cmd.OutOrStderr(),
 			}
-			return printClusterTaskDetails(stream, p)
+			return printClusterTaskDetails(stream, p, opts.NoHeaders)
 		},
 	}
 	f.AddFlags(c)
-
+	c.Flags().BoolVar(&opts.NoHeaders, "no-headers", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 	return c
 }
 
-func printClusterTaskDetails(s *cli.Stream, p cli.Params) error {
+func printClusterTaskDetails(s *cli.Stream, p cli.Params, noHeaders bool) error {
 	cs, err := p.Clients()
 	if err != nil {
 		return err
@@ -84,7 +89,10 @@ func printClusterTaskDetails(s *cli.Stream, p cli.Params) error {
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, header)
+
+	if !noHeaders {
+		fmt.Fprintln(w, header)
+	}
 
 	for _, clustertask := range clustertasks.Items {
 		fmt.Fprintf(w, body,

--- a/pkg/cmd/clustertask/list_test.go
+++ b/pkg/cmd/clustertask/list_test.go
@@ -196,3 +196,83 @@ func TestClusterTaskListOnlyClusterTasksv1beta1(t *testing.T) {
 	}
 	golden.Assert(t, output, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestClusterTaskListNoHeadersv1alpha1(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	clustertasks := []*v1alpha1.ClusterTask{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "guavas",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "avocados",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+	}
+
+	version := "v1alpha1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredCT(clustertasks[0], version),
+		cb.UnstructuredCT(clustertasks[1], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{ClusterTasks: clustertasks})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Clock: clock, Dynamic: dynamic}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"clustertask"})
+
+	clustertask := Command(p)
+	output, err := test.ExecuteCommand(clustertask, "list", "--no-headers")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, output, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestClusterTaskListNoHeadersv1beta1(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	clustertasks := []*v1beta1.ClusterTask{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "guavas",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "avocados",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-20 * time.Second)},
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1CT(clustertasks[0], version),
+		cb.UnstructuredV1beta1CT(clustertasks[1], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{ClusterTasks: clustertasks})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Clock: clock, Dynamic: dynamic}
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"clustertask"})
+
+	clustertask := Command(p)
+	output, err := test.ExecuteCommand(clustertask, "list", "--no-headers")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, output, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskListNoHeadersv1alpha1.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskListNoHeadersv1alpha1.golden
@@ -1,0 +1,2 @@
+guavas        1 minute ago
+avocados      20 seconds ago

--- a/pkg/cmd/clustertask/testdata/TestClusterTaskListNoHeadersv1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/TestClusterTaskListNoHeadersv1beta1.golden
@@ -1,0 +1,2 @@
+guavas        1 minute ago
+avocados      20 seconds ago


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR adds support for `--no-headers` flag to `tkn clustertask list` command as requested in issue #799.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
Add support for `--no-headers` flag to `tkn clustertask list`.
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
