### PR TITLE
Ignore --follow flag when TaskRun or PipelineRun is done

### DIFF
--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -1584,7 +1584,7 @@ func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 		t.Error("Expecting an error but it's empty")
 	}
 
-	expected := "task output-task create has not started yet or pod for task not yet available"
+	expected := "pod for taskrun output-task-run not available yet"
 	test.AssertOutput(t, expected, err.Error())
 }
 
@@ -1697,7 +1697,7 @@ func TestLog_taskrun_follow_mode_no_pod_name_v1beta1(t *testing.T) {
 		t.Error("Expecting an error but it's empty")
 	}
 
-	expected := "task output-task create has not started yet or pod for task not yet available"
+	expected := "pod for taskrun output-task-run not available yet"
 	test.AssertOutput(t, expected, err.Error())
 }
 
@@ -1720,8 +1720,9 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 			tb.TaskRunStatus(
 				tb.TaskRunStartTime(trStartTime),
 				tb.StatusCondition(apis.Condition{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionTrue,
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Message: "Running",
 				}),
 				tb.StepState(
 					cb.StepName(trStep1Name),
@@ -1832,8 +1833,9 @@ func TestLog_taskrun_follow_mode_update_pod_name_v1beta1(t *testing.T) {
 				Status: duckv1beta1.Status{
 					Conditions: duckv1beta1.Conditions{
 						{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionTrue,
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionUnknown,
+							Message: v1beta1.TaskRunReasonRunning.String(),
 						},
 					},
 				},
@@ -1946,8 +1948,9 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 			tb.TaskRunStatus(
 				tb.TaskRunStartTime(trStartTime),
 				tb.StatusCondition(apis.Condition{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionTrue,
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Message: "Running",
 				}),
 				tb.StepState(
 					cb.StepName(trStep1Name),
@@ -2056,8 +2059,9 @@ func TestLog_taskrun_follow_mode_update_timeout_v1beta1(t *testing.T) {
 				Status: duckv1beta1.Status{
 					Conditions: duckv1beta1.Conditions{
 						{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionTrue,
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionUnknown,
+							Message: v1beta1.TaskRunReasonRunning.String(),
 						},
 					},
 				},

--- a/pkg/log/pipeline_reader.go
+++ b/pkg/log/pipeline_reader.go
@@ -36,7 +36,7 @@ func (r *Reader) readPipelineLog() (<-chan Log, <-chan error, error) {
 		return nil, nil, err
 	}
 
-	if r.follow {
+	if !pr.IsDone() && r.follow {
 		return r.readLivePipelineLogs(pr)
 	}
 	return r.readAvailablePipelineLogs(pr)

--- a/pkg/log/task_reader.go
+++ b/pkg/log/task_reader.go
@@ -52,7 +52,7 @@ func (r *Reader) readTaskLog() (<-chan Log, <-chan error, error) {
 
 	r.formTaskName(tr)
 
-	if r.follow {
+	if !tr.IsDone() && r.follow {
 		return r.readLiveTaskLogs()
 	}
 	return r.readAvailableTaskLogs(tr)


### PR DESCRIPTION
# Changes

I'm not sure this action is intended or not, but when `--follow` flag is given, reader tries to read live logs instead of available logs. This may confuses user to debug since live logs are not sorted in task order.

In this PR, reader will check if `PipelineRun` or `TaskRun` is done when `follow` flag is given and read available logs instead of live logs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
`log` command will ignore `--follow` flag when given TaskRun/PipelineRun is done
```
