### PR TITLE
Add --no-headers flag to tkn triggerbinding list command

### DIFF
--- a/docs/cmd/tkn_triggerbinding_list.md
+++ b/docs/cmd/tkn_triggerbinding_list.md
@@ -31,6 +31,7 @@ or
   -A, --all-namespaces                list TriggerBindings from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
+      --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/man/man1/tkn-triggerbinding-list.1
+++ b/docs/man/man1/tkn-triggerbinding-list.1
@@ -32,6 +32,10 @@ Lists TriggerBindings in a namespace
     help for list
 
 .PP
+\fB\-\-no\-headers\fP[=false]
+    do not print column headers with output (default print column headers with output)
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 

--- a/pkg/cmd/triggerbinding/list.go
+++ b/pkg/cmd/triggerbinding/list.go
@@ -37,6 +37,7 @@ const (
 
 type listOptions struct {
 	AllNamespaces bool
+	NoHeaders     bool
 }
 
 func listCommand(p cli.Params) *cobra.Command {
@@ -102,7 +103,7 @@ or
 				return printer.PrintObject(stream.Out, tbs, f)
 			}
 
-			if err = printFormatted(stream, tbs, p, opts.AllNamespaces); err != nil {
+			if err = printFormatted(stream, tbs, p, opts.AllNamespaces, opts.NoHeaders); err != nil {
 				return errors.New("failed to print TriggerBindings")
 			}
 			return nil
@@ -112,6 +113,7 @@ or
 
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list TriggerBindings from all namespaces")
+	c.Flags().BoolVar(&opts.NoHeaders, "no-headers", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 	return c
 }
 
@@ -132,7 +134,7 @@ func list(client versioned.Interface, namespace string) (*v1alpha1.TriggerBindin
 	return tbs, nil
 }
 
-func printFormatted(s *cli.Stream, tbs *v1alpha1.TriggerBindingList, p cli.Params, allNamespaces bool) error {
+func printFormatted(s *cli.Stream, tbs *v1alpha1.TriggerBindingList, p cli.Params, allNamespaces bool, noHeaders bool) error {
 	if len(tbs.Items) == 0 {
 		fmt.Fprintln(s.Err, emptyMsg)
 		return nil
@@ -144,7 +146,9 @@ func printFormatted(s *cli.Stream, tbs *v1alpha1.TriggerBindingList, p cli.Param
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, headers)
+	if !noHeaders {
+		fmt.Fprintln(w, headers)
+	}
 	for _, tb := range tbs.Items {
 		if allNamespaces {
 			fmt.Fprintf(w, "%s\t%s\t%s\n",

--- a/pkg/cmd/triggerbinding/list_test.go
+++ b/pkg/cmd/triggerbinding/list_test.go
@@ -103,6 +103,18 @@ func TestListTriggerBinding(t *testing.T) {
 			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
+		{
+			name:      "List TriggerBindings without headers",
+			command:   command(t, tbs, now, ns),
+			args:      []string{"list", "--no-headers"},
+			wantError: false,
+		},
+		{
+			name:      "List TriggerBindings from all namespaces without headers",
+			command:   command(t, tbs, now, ns),
+			args:      []string{"list", "--no-headers", "--all-namespaces"},
+			wantError: false,
+		},
 	}
 
 	for _, td := range tests {

--- a/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-List_TriggerBindings_from_all_namespaces_without_headers.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-List_TriggerBindings_from_all_namespaces_without_headers.golden
@@ -1,0 +1,5 @@
+bar   tb0   2 minutes ago
+foo   tb1   2 minutes ago
+foo   tb2   30 seconds ago
+foo   tb3   1 week ago
+foo   tb4   ---

--- a/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-List_TriggerBindings_without_headers.golden
+++ b/pkg/cmd/triggerbinding/testdata/TestListTriggerBinding-List_TriggerBindings_without_headers.golden
@@ -1,0 +1,5 @@
+tb0   2 minutes ago
+tb1   2 minutes ago
+tb2   30 seconds ago
+tb3   1 week ago
+tb4   ---


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR adds support for `--no-headers` flag to `tkn triggerbinding list` command as requested in issue #799.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
Add support for `--no-headers` flag to `tkn triggerbinding list`.
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
