### PR TITLE
Add --no-headers flag to tkn triggertemplate list command

### DIFF
--- a/docs/cmd/tkn_triggertemplate_list.md
+++ b/docs/cmd/tkn_triggertemplate_list.md
@@ -31,6 +31,7 @@ or
   -A, --all-namespaces                list TriggerTemplates from all namespaces
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
+      --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```

--- a/docs/man/man1/tkn-triggertemplate-list.1
+++ b/docs/man/man1/tkn-triggertemplate-list.1
@@ -32,6 +32,10 @@ Lists TriggerTemplates in a namespace
     help for list
 
 .PP
+\fB\-\-no\-headers\fP[=false]
+    do not print column headers with output (default print column headers with output)
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-file.
 

--- a/pkg/cmd/triggertemplate/list.go
+++ b/pkg/cmd/triggertemplate/list.go
@@ -36,6 +36,7 @@ const (
 
 type ListOptions struct {
 	AllNamespaces bool
+	NoHeaders     bool
 }
 
 func listCommand(p cli.Params) *cobra.Command {
@@ -91,7 +92,7 @@ or
 				return printer.PrintObject(stream.Out, tts, f)
 			}
 
-			if err = printFormatted(stream, tts, p, opts.AllNamespaces); err != nil {
+			if err = printFormatted(stream, tts, p, opts.AllNamespaces, opts.NoHeaders); err != nil {
 				return fmt.Errorf("failed to print TriggerTemplates: %v", err)
 			}
 			return nil
@@ -102,6 +103,7 @@ or
 	f.AddFlags(c)
 
 	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list TriggerTemplates from all namespaces")
+	c.Flags().BoolVar(&opts.NoHeaders, "no-headers", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 	return c
 }
 
@@ -122,7 +124,7 @@ func list(client versioned.Interface, namespace string) (*v1alpha1.TriggerTempla
 	return tts, nil
 }
 
-func printFormatted(s *cli.Stream, tts *v1alpha1.TriggerTemplateList, p cli.Params, allNamespaces bool) error {
+func printFormatted(s *cli.Stream, tts *v1alpha1.TriggerTemplateList, p cli.Params, allNamespaces bool, noHeaders bool) error {
 	if len(tts.Items) == 0 {
 		fmt.Fprintln(s.Err, emptyMsg)
 		return nil
@@ -134,7 +136,9 @@ func printFormatted(s *cli.Stream, tts *v1alpha1.TriggerTemplateList, p cli.Para
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, headers)
+	if !noHeaders {
+		fmt.Fprintln(w, headers)
+	}
 	for _, tt := range tts.Items {
 		if allNamespaces {
 			fmt.Fprintf(w, "%s\t%s\t%s\n",

--- a/pkg/cmd/triggertemplate/list_test.go
+++ b/pkg/cmd/triggertemplate/list_test.go
@@ -97,6 +97,18 @@ func TestListTriggerTemplate(t *testing.T) {
 			args:      []string{"list", "--all-namespaces"},
 			wantError: false,
 		},
+		{
+			name:      "List TriggerTemplates without headers",
+			command:   command(t, tts, now, ns),
+			args:      []string{"list", "--no-headers"},
+			wantError: false,
+		},
+		{
+			name:      "List TriggerTemplates from all namespaces without headers",
+			command:   command(t, tts, now, ns),
+			args:      []string{"list", "--no-headers", "--all-namespaces"},
+			wantError: false,
+		},
 	}
 
 	for _, td := range tests {

--- a/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-List_TriggerTemplates_from_all_namespaces_without_headers.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-List_TriggerTemplates_from_all_namespaces_without_headers.golden
@@ -1,0 +1,5 @@
+foo   tt1   2 minutes ago
+foo   tt2   30 seconds ago
+foo   tt3   1 week ago
+foo   tt4   ---
+bar   tt5   ---

--- a/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-List_TriggerTemplates_without_headers.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestListTriggerTemplate-List_TriggerTemplates_without_headers.golden
@@ -1,0 +1,5 @@
+tt1   2 minutes ago
+tt2   30 seconds ago
+tt3   1 week ago
+tt4   ---
+tt5   ---


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR adds support for `--no-headers` flag to `tkn triggertemplate list` command as requested in issue #799.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
Add support for `--no-headers` flag to `tkn triggertemplate list`.
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
