### PR TITLE
📦 Use VERSION file debian/versiion for debian package if we find it

### DIFF
--- a/tekton/debbuild/container/buildpackage.sh
+++ b/tekton/debbuild/container/buildpackage.sh
@@ -37,8 +37,8 @@ cd tektoncd-cli-${version}
 # Make it easy for devs
 [[ -d /debian ]] && { rm -rf debian && cp -a /debian . ; }
 
-# Makefile will use it automatically to set the binary version
-echo ${version} > VERSION
+# debian/rules will use it automatically to set the binary version
+echo ${version} > debian/VERSION
 
 dch -M -v ${version}-${RELEASE} -D $(sed -n '/DISTRIB_CODENAME/ { s/.*=//;p;;}' /etc/lsb-release) "new update"
 

--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -16,7 +16,7 @@ BUILD_DATE := $(BUILD_DATE:+0000=Z)
 override_dh_auto_build:
 	@set -x ; export XDG_CACHE_HOME=/tmp/cache ; \
 	RELEASED_VERSION=`curl -s  https://api.github.com/repos/tektoncd/cli/releases/latest|python3 -c "import sys, json;x=json.load(sys.stdin);print(x['tag_name'])"|sed 's/^v//'` ; test -n "$$RELEASED_VERSION" || RELEASED_VERSION=$(BUILD_DATE) ; \
-	test -e ./VERSION && VERSION=`cat VERSION` || VERSION=$$RELEASED_VERSION ; \
+	test -e ./debian/VERSION && VERSION=`cat debian/VERSION` || VERSION=$$RELEASED_VERSION ; \
 		go build -mod=vendor -v -o ${TKN} -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$$VERSION" ./cmd/tkn
 	$(TKN) version
 	$(TKN) completion zsh > debian/tkn.zsh-completion


### PR DESCRIPTION
    Use debian/VERSION when building debian package

    It seems that when building on launchpad, we cannot detect the version
    by doing a curl. Perhaps they restrict network access or github API get
    restricted?

    We can't use just VERSION at the root dir since dpkg-source doesnt
    include it, but we can do that inside the debian/ dir so let's just do
    that.

Fixes bug #1256


```release-note
NONE
```
