### PR TITLE
Hoist an ActivityTimeout option.

### DIFF
--- a/pkg/log/pipeline_reader.go
+++ b/pkg/log/pipeline_reader.go
@@ -84,7 +84,7 @@ func (r *Reader) readLivePipelineLogs(pr *v1beta1.PipelineRun) (<-chan Log, <-ch
 }
 
 func (r *Reader) readAvailablePipelineLogs(pr *v1beta1.PipelineRun) (<-chan Log, <-chan error, error) {
-	if err := r.waitUntilAvailable(10); err != nil {
+	if err := r.waitUntilAvailable(); err != nil {
 		return nil, nil, err
 	}
 
@@ -121,7 +121,7 @@ func (r *Reader) readAvailablePipelineLogs(pr *v1beta1.PipelineRun) (<-chan Log,
 // only if run status is unknown, open a watch channel on run
 // and keep checking the status until it changes to true|false
 // or the reach timeout
-func (r *Reader) waitUntilAvailable(timeout time.Duration) error {
+func (r *Reader) waitUntilAvailable() error {
 	var first = true
 	opts := metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("metadata.name", r.run).String(),
@@ -156,7 +156,7 @@ func (r *Reader) waitUntilAvailable(timeout time.Duration) error {
 				first = false
 				fmt.Fprintln(r.stream.Out, "Pipeline still running ...")
 			}
-		case <-time.After(timeout * time.Second):
+		case <-time.After(r.activityTimeout):
 			watchRun.Stop()
 			if isPipelineRunRunning(run.Status.Conditions) {
 				fmt.Fprintln(r.stream.Out, "PipelineRun is still running:", run.Status.Conditions[0].Message)

--- a/pkg/log/reader.go
+++ b/pkg/log/reader.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/options"
@@ -24,18 +25,19 @@ import (
 )
 
 type Reader struct {
-	run      string
-	ns       string
-	clients  *cli.Clients
-	streamer stream.NewStreamerFunc
-	stream   *cli.Stream
-	allSteps bool
-	follow   bool
-	tasks    []string
-	steps    []string
-	logType  string
-	task     string
-	number   int
+	run             string
+	ns              string
+	clients         *cli.Clients
+	streamer        stream.NewStreamerFunc
+	stream          *cli.Stream
+	allSteps        bool
+	follow          bool
+	tasks           []string
+	steps           []string
+	logType         string
+	task            string
+	number          int
+	activityTimeout time.Duration
 }
 
 func NewReader(logType string, opts *options.LogOptions) (*Reader, error) {
@@ -57,17 +59,23 @@ func NewReader(logType string, opts *options.LogOptions) (*Reader, error) {
 		run = opts.TaskrunName
 	}
 
+	at := 10 * time.Second
+	if opts.ActivityTimeout != 0 {
+		at = opts.ActivityTimeout
+	}
+
 	return &Reader{
-		run:      run,
-		ns:       opts.Params.Namespace(),
-		clients:  cs,
-		streamer: streamer,
-		stream:   opts.Stream,
-		follow:   opts.Follow,
-		allSteps: opts.AllSteps,
-		tasks:    opts.Tasks,
-		steps:    opts.Steps,
-		logType:  logType,
+		run:             run,
+		ns:              opts.Params.Namespace(),
+		clients:         cs,
+		streamer:        streamer,
+		stream:          opts.Stream,
+		follow:          opts.Follow,
+		allSteps:        opts.AllSteps,
+		tasks:           opts.Tasks,
+		steps:           opts.Steps,
+		logType:         logType,
+		activityTimeout: at,
 	}, nil
 }
 

--- a/pkg/log/task_reader.go
+++ b/pkg/log/task_reader.go
@@ -77,7 +77,7 @@ func (r *Reader) formTaskName(tr *v1beta1.TaskRun) {
 }
 
 func (r *Reader) readLiveTaskLogs() (<-chan Log, <-chan error, error) {
-	tr, err := r.waitUntilTaskPodNameAvailable(10)
+	tr, err := r.waitUntilTaskPodNameAvailable()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,7 +186,7 @@ func (r *Reader) readStepsLogs(steps []*step, pod *pods.Pod, follow bool) (<-cha
 // updated in the status. Open a watch channel on the task run
 // and keep checking the status until the pod name updates
 // or the timeout is reached.
-func (r *Reader) waitUntilTaskPodNameAvailable(timeout time.Duration) (*v1beta1.TaskRun, error) {
+func (r *Reader) waitUntilTaskPodNameAvailable() (*v1beta1.TaskRun, error) {
 	var first = true
 	opts := metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("metadata.name", r.run).String(),
@@ -219,7 +219,7 @@ func (r *Reader) waitUntilTaskPodNameAvailable(timeout time.Duration) (*v1beta1.
 			if first {
 				first = false
 			}
-		case <-time.After(timeout * time.Second):
+		case <-time.After(r.activityTimeout):
 			watchRun.Stop()
 
 			// Check if taskrun failed on start up

--- a/pkg/options/logs.go
+++ b/pkg/options/logs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -47,6 +48,10 @@ type LogOptions struct {
 	AskOpts         survey.AskOpt
 	Fzf             bool
 	Tail            int64
+
+	// ActivityTimeout is the amount of time to wait for some activity
+	// (e.g. Pod ready) before giving up.
+	ActivityTimeout time.Duration
 }
 
 func NewLogOptions(p cli.Params) *LogOptions {


### PR DESCRIPTION
# Changes

Today there are hard-coded timeouts of 10 seconds for each of the log readers.  However, we often hit this timeout on the first task execution on a fresh cluster due to factors like pulling step images (especially on underpowered clusters like KinD or RPi4).

This simply makes the activity timeout configurable via the LogOptions, but keeps the default behavior identical.

Related: https://github.com/mattmoor/mink/issues/357

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
