### PR TITLE
Remove --check Shorthand and Add Global Flags to Version Command

### DIFF
--- a/docs/cmd/tkn_version.md
+++ b/docs/cmd/tkn_version.md
@@ -15,9 +15,12 @@ Prints version information
 ### Options
 
 ```
-      --check              check if a newer version is available
-  -h, --help               help for version
-  -n, --namespace string   namespace to check installed controller version
+      --check               check if a newer version is available
+  -c, --context string      name of the kubeconfig context to use (default: kubectl config current-context)
+  -h, --help                help for version
+  -k, --kubeconfig string   kubectl config file (default: $HOME/.kube/config)
+  -n, --namespace string    namespace to check installed controller version
+  -C, --no-color            disable coloring (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-version.1
+++ b/docs/man/man1/tkn-version.1
@@ -24,12 +24,24 @@ Prints version information
     check if a newer version is available
 
 .PP
+\fB\-c\fP, \fB\-\-context\fP=""
+    name of the kubeconfig context to use (default: kubectl config current\-context)
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for version
 
 .PP
+\fB\-k\fP, \fB\-\-kubeconfig\fP=""
+    kubectl config file (default: $HOME/.kube/config)
+
+.PP
 \fB\-n\fP, \fB\-\-namespace\fP=""
     namespace to check installed controller version
+
+.PP
+\fB\-C\fP, \fB\-\-no\-color\fP[=false]
+    disable coloring (default: false)
 
 
 .SH SEE ALSO

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/flags"
 	"github.com/tektoncd/cli/pkg/version"
 )
 
@@ -53,6 +54,9 @@ func Command(p cli.Params) *cobra.Command {
 		Short: "Prints version information",
 		Annotations: map[string]string{
 			"commandType": "utility",
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return flags.InitParams(p, cmd)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
@@ -89,12 +93,12 @@ func Command(p cli.Params) *cobra.Command {
 
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", namespace,
 		"namespace to check installed controller version")
+	flags.AddTektonOptions(cmd)
 
 	if skipCheckFlag != "true" {
-		cmd.Flags().BoolVarP(&check, "check", "c", false, "check if a newer version is available")
-		_ = cmd.Flags().MarkShorthandDeprecated("check",
-			"the -c shorthand for tkn version --check will be removed in v0.15.0. See https://github.com/tektoncd/cli/issues/1231.")
+		cmd.Flags().BoolVar(&check, "check", false, "check if a newer version is available")
 	}
+
 	return cmd
 }
 


### PR DESCRIPTION
Closes #1233 
Closes #1212 

# Changes

This pull request removes the `-c` shorthand for check as described in #1233 and also adds global option to version. The main intention is to make `--kubeconfig` available for `tkn version` as described in #1212.

There should maybe be a follow up to this pr to remove `--no-color` as it isn't really applicable with `tkn version`. 

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Remove -c shorthand for tkn version --check and add global tkn flags to version
```
