### PR TITLE
Use python3 binary instead of python or we won't find it

### DIFF
--- a/tekton/rpmbuild/build.sh
+++ b/tekton/rpmbuild/build.sh
@@ -19,7 +19,7 @@ sed "s/_VERSION_/${version}/" ${repospecfile} > ${TMPD}/tekton.spec
 
 sed -i '/bundled(golang/d' ${TMPD}/tekton.spec
 
-mapfile -t bundle < <(python -c "ver = None;
+mapfile -t bundle < <(python3 -c "ver = None;
 def version(line): global ver; ver = line.split()[2]; return '';
 
 print '\n'.join(filter(None,[line for line in ['Provides: bundled(golang({})) = {}'.format(line.rstrip('\n'), ver) if line[0] != '#' else version(line.rstrip('\n').replace('+incompatible','')) for line in open('../../vendor/modules.txt')]][::-1]))")


### PR DESCRIPTION
Error when release was :

```[build-rpm] tekton/rpmbuild/build.sh: line 22: python: command not found```


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```