### PR TITLE
Debian package: Do not use tkn version as a check

### DIFF
--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -18,7 +18,6 @@ override_dh_auto_build:
 	RELEASED_VERSION=`curl -s  https://api.github.com/repos/tektoncd/cli/releases/latest|python3 -c "import sys, json;x=json.load(sys.stdin);print(x['tag_name'])"|sed 's/^v//'` ; test -n "$$RELEASED_VERSION" || RELEASED_VERSION=$(BUILD_DATE) ; \
 	test -e ./debian/VERSION && VERSION=`cat debian/VERSION` || VERSION=$$RELEASED_VERSION ; \
 		go build -mod=vendor -v -o ${TKN} -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$$VERSION" ./cmd/tkn
-	$(TKN) version
 	$(TKN) completion zsh > debian/tkn.zsh-completion
 	$(TKN) completion bash > debian/tektoncd-cli.bash-completion
 


### PR DESCRIPTION
# Changes


It would fail now when it won't find a KUBECONFIG

tkn completion is good enough for a check that the binary has built properly

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->
```release-note
NONE
```