### PR TITLE
Refactor e2e scripts and fix tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,14 +29,6 @@ ci_run && {
   initialize $@
 }
 
-# Run the integration tests
-ci_run && {
-  header "Running Go integration tests"
-  failed=0
-  go_test_e2e ./test || failed=1
-  (( failed )) && fail_test
-}
-
 tkn() {
     if [[ -e ./bin/tkn ]];then
         ./bin/tkn $@
@@ -167,18 +159,16 @@ for res in eventlistener triggertemplate triggerbinding clustertriggerbinding; d
 done
 
 # Run the e2e tests
-ci_run && {
-  header "Running Go e2e tests"
-  failed=0
-  if [[ -e ./bin/tkn ]];then
-        export TEST_CLIENT_BINARY='./bin/tkn'
-  else
-        go build -o tkn github.com/tektoncd/cli/cmd/tkn
-        echo "Go Build successfull"
-        export TEST_CLIENT_BINARY=$PWD/tkn
-  fi
-  go_test_e2e ./test/e2e/... || failed=1
-  (( failed )) && fail_test
-}
+header "Running Go e2e tests"
+failed=0
+if [[ -e ./bin/tkn ]];then
+    export TEST_CLIENT_BINARY="${PWD}/bin/tkn"
+else
+    go build -o tkn github.com/tektoncd/cli/cmd/tkn
+    echo "Go Build successfull"
+    export TEST_CLIENT_BINARY="${PWD}/tkn"
+fi
+go_test_e2e ./test/e2e/... || failed=1
+(( failed )) && fail_test
 
 success

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -325,9 +325,8 @@ Waiting for logs to be available...
 
 		pipelineRunGeneratedName := builder.GetPipelineRunListWithName(c, tePipelineName, true).Items[0].Name
 		timeout := 5 * time.Minute
-		// Should fail since runAsNonRoot=true
-		if err := wait.ForPipelineRunState(c, pipelineRunGeneratedName, timeout, wait.PipelineRunFailed(pipelineRunGeneratedName), "PipelineRunFailed"); err != nil {
-			t.Errorf("Error waiting for PipelineRun to fail: %s", err)
+		if err := wait.ForPipelineRunState(c, pipelineRunGeneratedName, timeout, wait.PipelineRunSucceed(pipelineRunGeneratedName), "PipelineRunSucceeded"); err != nil {
+			t.Errorf("Error waiting for PipelineRun to Succeed: %s", err)
 		}
 	})
 

--- a/test/resources/podtemplate/podtemplate.yaml
+++ b/test/resources/podtemplate/podtemplate.yaml
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-securityContext:
-  runAsNonRoot: true
-  runAsUser: 1001
+volumes:
+  - name: custom
+    emptyDir: {}


### PR DESCRIPTION
This will refactor e2e scripts to run e2e tests
always without the flag and remove redundant code
Fix the path for e2e tests binary

Remove securityConext and add a volume to podtemplate
to avoid unnecessary failures because of permissions

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
