### PR TITLE
Fix tkn version with no kubeconfig

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -56,7 +56,16 @@ func Command(p cli.Params) *cobra.Command {
 			"commandType": "utility",
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
+			if err := flags.InitParams(p, cmd); err != nil {
+				// this check allows tkn version to be run without
+				// a kubeconfig so users can verify the tkn version
+				noConfigErr := strings.Contains(err.Error(), "no configuration has been provided")
+				if noConfigErr {
+					return nil
+				}
+				return err
+			}
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)


### PR DESCRIPTION
Closes #1275 

This will allow `tkn version` to be run without a kubeconfig so users can verify the version of tkn installed without needing access to a cluster.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
