### PR TITLE
Support --clustertask Option for tkn tr delete

### DIFF
--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -30,6 +30,7 @@ or
 ```
       --all                           Delete all TaskRuns in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --clustertask string            The name of a ClusterTask whose TaskRuns should be deleted (does not delete the ClusterTask)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
       --keep int                      Keep n most recent number of TaskRuns

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -28,6 +28,10 @@ Delete TaskRuns in a namespace
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
+\fB\-\-clustertask\fP=""
+    The name of a ClusterTask whose TaskRuns should be deleted (does not delete the ClusterTask)
+
+.PP
 \fB\-f\fP, \fB\-\-force\fP[=false]
     Whether to force deletion (default: false)
 


### PR DESCRIPTION
# Changes

Currently `tkn tr delete` doesn't support `--clustertask` flag. Due to this
if the user wants to delete the `taskruns` associated with a `clustertask`
was not possible.

This PR add `--clustertask` as flag and now user can delete all the
`TaskRun` from a particular namespace associated with a `ClusterTask`.
The command will filter the taskruns by label ie `tekton.dev/task` or
`tekton.dev/clusterTask`. Also if the user passes `--task` and
`--clustertask` together then it will give an error.

closes #1228

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Add support for --clustertask option in tkn tr delete which allows to delete all the taskruns associated with a particular clustertask
```