### PR TITLE
Try to get plugins from path if not in homedir

### DIFF
--- a/cmd/tkn/main.go
+++ b/cmd/tkn/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 
@@ -46,8 +47,12 @@ func main() {
 		}
 		exCmd, err := findPlugin(pluginDir, pluginCmd)
 		if err != nil {
-			// Can't find the binary in PATH, bailing to usual execution
-			goto CoreTkn
+			// If we can't find the binary in plugin dir, try in the $PATH and
+			// if not then bail out
+			exCmd, err = exec.LookPath(pluginCmd)
+			if err != nil {
+				goto CoreTkn
+			}
 		}
 
 		if err := syscall.Exec(exCmd, append([]string{exCmd}, os.Args[2:]...), os.Environ()); err != nil {

--- a/test/e2e/plugin/plugin_test.go
+++ b/test/e2e/plugin/plugin_test.go
@@ -47,3 +47,26 @@ func TestTknPlugin(t *testing.T) {
 		})
 	})
 }
+
+func TestTknPluginPath(t *testing.T) {
+	tkn, err := cli.NewTknRunner("any-namespace")
+	assert.NilError(t, err)
+	currentpath, err := os.Getwd()
+	assert.NilError(t, err)
+	defer env.Patch(t, "PATH", os.Getenv("PATH")+":"+currentpath)()
+	t.Run("Success", func(t *testing.T) {
+		tkn.MustSucceed(t, "success")
+		tkn.MustSucceed(t, "success", "with", "args")
+	})
+	t.Run("Failure", func(t *testing.T) {
+		tkn.Run("failure").Assert(t, icmd.Expected{
+			ExitCode: 12,
+		})
+		tkn.Run("failure", "with", "args").Assert(t, icmd.Expected{
+			ExitCode: 12,
+		})
+		tkn.Run("failure", "exit20").Assert(t, icmd.Expected{
+			ExitCode: 20,
+		})
+	})
+}


### PR DESCRIPTION
# Changes

If we can't find the plugins in the plugin dir we will try to get it from the
path.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Plugins are now searched within the user path, they will be first looked over into `~/.config/tkn/plugins` and then if not found into the path
```