### PR TITLE
Adds version field while listing all the tasks

### DIFF
--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -36,18 +36,18 @@ No Tasks found
 {{ else -}}
 {{- if not $.NoHeaders -}}
 {{- if $.AllNamespaces -}}
-NAMESPACE	NAME	DESCRIPTION	AGE
+NAMESPACE	NAME	DESCRIPTION	VERSION	AGE
 {{ else -}}
-NAME	DESCRIPTION	AGE
-{{ end -}} 
+NAME	DESCRIPTION	VERSION	AGE
+{{ end -}}
 {{- end -}}
 {{- range $_, $t := .Tasks.Items }}{{- if $t }}
 {{- if $.AllNamespaces -}}
-{{ $t.Namespace }}	{{ $t.Name }}	{{ formatDesc $t.Spec.Description }}	{{ formatAge $t.CreationTimestamp $.Time }}
-{{ else -}} 
-{{ $t.Name }}	{{ formatDesc $t.Spec.Description }}	{{ formatAge $t.CreationTimestamp $.Time }}
+{{ $t.Namespace }}	{{ $t.Name }}	{{ formatDesc $t.Spec.Description }}	{{ formatVersion $t.Labels }}	{{ formatAge $t.CreationTimestamp $.Time }}
+{{ else -}}
+{{ $t.Name }}	{{ formatDesc $t.Spec.Description }}	{{ formatVersion $t.Labels }}	{{ formatAge $t.CreationTimestamp $.Time }}
 {{ end }}{{- end }}{{- end }}
-{{- end -}} 
+{{- end -}}
 `
 
 type ListOptions struct {
@@ -118,8 +118,9 @@ func printTaskDetails(s *cli.Stream, p cli.Params, allnamespaces bool, noheaders
 	}
 
 	funcMap := template.FuncMap{
-		"formatAge":  formatted.Age,
-		"formatDesc": formatted.FormatDesc,
+		"formatAge":     formatted.Age,
+		"formatDesc":    formatted.FormatDesc,
+		"formatVersion": formatted.FormatVersion,
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -142,6 +142,14 @@ func TestTaskList_Only_Tasks_v1alpha1(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "kiwis",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				Labels:            map[string]string{"app.kubernetes.io/version": "0.1"},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -161,6 +169,7 @@ func TestTaskList_Only_Tasks_v1alpha1(t *testing.T) {
 		cb.UnstructuredT(tasks[3], version),
 		cb.UnstructuredT(tasks[4], version),
 		cb.UnstructuredT(tasks[5], version),
+		cb.UnstructuredT(tasks[6], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -234,6 +243,14 @@ func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 				Description: "a test task to test description of task",
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "kiwis",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				Labels:            map[string]string{"app.kubernetes.io/version": "0.1"},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -253,6 +270,7 @@ func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 		cb.UnstructuredV1beta1T(tasks[3], version),
 		cb.UnstructuredV1beta1T(tasks[4], version),
 		cb.UnstructuredV1beta1T(tasks[5], version),
+		cb.UnstructuredV1beta1T(tasks[6], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -326,6 +344,14 @@ func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
 				Description: "a test task to test description of task",
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "kiwis",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				Labels:            map[string]string{"app.kubernetes.io/version": "0.1"},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{
@@ -345,6 +371,7 @@ func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
 		cb.UnstructuredV1beta1T(tasks[3], version),
 		cb.UnstructuredV1beta1T(tasks[4], version),
 		cb.UnstructuredV1beta1T(tasks[5], version),
+		cb.UnstructuredV1beta1T(tasks[6], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -469,6 +496,14 @@ func TestTaskList_Only_Tasks_all_namespaces_v1beta1(t *testing.T) {
 				Description: "a test task to test description of task",
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "kiwis",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				Labels:            map[string]string{"app.kubernetes.io/version": "0.1"},
+			},
+		},
 	}
 
 	version := "v1beta1"
@@ -486,6 +521,7 @@ func TestTaskList_Only_Tasks_all_namespaces_v1beta1(t *testing.T) {
 		cb.UnstructuredV1beta1T(tasks[9], version),
 		cb.UnstructuredV1beta1T(tasks[10], version),
 		cb.UnstructuredV1beta1T(tasks[11], version),
+		cb.UnstructuredV1beta1T(tasks[12], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
@@ -609,6 +645,14 @@ func TestTaskList_Only_Tasks_all_namespaces_no_headers_v1beta1(t *testing.T) {
 				Description: "a test task to test description of task",
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "kiwis",
+				Namespace:         "namespace",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
+				Labels:            map[string]string{"app.kubernetes.io/version": "0.1"},
+			},
+		},
 	}
 
 	version := "v1beta1"
@@ -626,6 +670,7 @@ func TestTaskList_Only_Tasks_all_namespaces_no_headers_v1beta1(t *testing.T) {
 		cb.UnstructuredV1beta1T(tasks[9], version),
 		cb.UnstructuredV1beta1T(tasks[10], version),
 		cb.UnstructuredV1beta1T(tasks[11], version),
+		cb.UnstructuredV1beta1T(tasks[12], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)

--- a/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_all_namespaces_no_headers_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_all_namespaces_no_headers_v1beta1.golden
@@ -1,12 +1,13 @@
-namespace       tomatoes                            1 minute ago
-namespace       mangoes                             20 seconds ago
-namespace       bananas                             3 weeks ago
-namespace       apples                              3 weeks ago
-namespace       potatoes   a test task              3 weeks ago
-namespace       onions     a test task to test...   3 weeks ago
-espace-de-nom   tomates                             1 minute ago
-espace-de-nom   mangues                             20 seconds ago
-espace-de-nom   bananes                             3 weeks ago
-espace-de-nom   pommes                              3 weeks ago
-espace-de-nom   patates    a test task              3 weeks ago
-espace-de-nom   oignons    a test task to test...   3 weeks ago
+namespace       tomatoes                            ---   1 minute ago
+namespace       mangoes                             ---   20 seconds ago
+namespace       bananas                             ---   3 weeks ago
+namespace       apples                              ---   3 weeks ago
+namespace       potatoes   a test task              ---   3 weeks ago
+namespace       onions     a test task to test...   ---   3 weeks ago
+espace-de-nom   tomates                             ---   1 minute ago
+espace-de-nom   mangues                             ---   20 seconds ago
+espace-de-nom   bananes                             ---   3 weeks ago
+espace-de-nom   pommes                              ---   3 weeks ago
+espace-de-nom   patates    a test task              ---   3 weeks ago
+espace-de-nom   oignons    a test task to test...   ---   3 weeks ago
+namespace       kiwis                               0.1   1 minute ago

--- a/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_all_namespaces_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_all_namespaces_v1beta1.golden
@@ -1,13 +1,14 @@
-NAMESPACE       NAME       DESCRIPTION              AGE
-namespace       tomatoes                            1 minute ago
-namespace       mangoes                             20 seconds ago
-namespace       bananas                             3 weeks ago
-namespace       apples                              3 weeks ago
-namespace       potatoes   a test task              3 weeks ago
-namespace       onions     a test task to test...   3 weeks ago
-espace-de-nom   tomates                             1 minute ago
-espace-de-nom   mangues                             20 seconds ago
-espace-de-nom   bananes                             3 weeks ago
-espace-de-nom   pommes                              3 weeks ago
-espace-de-nom   patates    a test task              3 weeks ago
-espace-de-nom   oignons    a test task to test...   3 weeks ago
+NAMESPACE       NAME       DESCRIPTION              VERSION   AGE
+namespace       tomatoes                            ---       1 minute ago
+namespace       mangoes                             ---       20 seconds ago
+namespace       bananas                             ---       3 weeks ago
+namespace       apples                              ---       3 weeks ago
+namespace       potatoes   a test task              ---       3 weeks ago
+namespace       onions     a test task to test...   ---       3 weeks ago
+espace-de-nom   tomates                             ---       1 minute ago
+espace-de-nom   mangues                             ---       20 seconds ago
+espace-de-nom   bananes                             ---       3 weeks ago
+espace-de-nom   pommes                              ---       3 weeks ago
+espace-de-nom   patates    a test task              ---       3 weeks ago
+espace-de-nom   oignons    a test task to test...   ---       3 weeks ago
+namespace       kiwis                               0.1       1 minute ago

--- a/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_no_headers_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_no_headers_v1beta1.golden
@@ -1,6 +1,7 @@
-tomatoes                            1 minute ago
-mangoes                             20 seconds ago
-bananas                             3 weeks ago
-apples                              3 weeks ago
-potatoes   a test task              3 weeks ago
-onions     a test task to test...   3 weeks ago
+tomatoes                            ---   1 minute ago
+mangoes                             ---   20 seconds ago
+bananas                             ---   3 weeks ago
+apples                              ---   3 weeks ago
+potatoes   a test task              ---   3 weeks ago
+onions     a test task to test...   ---   3 weeks ago
+kiwis                               0.1   1 minute ago

--- a/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_v1alpha1.golden
+++ b/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_v1alpha1.golden
@@ -1,7 +1,8 @@
-NAME       DESCRIPTION              AGE
-tomatoes                            1 minute ago
-mangoes                             20 seconds ago
-bananas                             3 weeks ago
-apples                              3 weeks ago
-potatoes   a test task              3 weeks ago
-onions     a test task to test...   3 weeks ago
+NAME       DESCRIPTION              VERSION   AGE
+tomatoes                            ---       1 minute ago
+mangoes                             ---       20 seconds ago
+bananas                             ---       3 weeks ago
+apples                              ---       3 weeks ago
+potatoes   a test task              ---       3 weeks ago
+onions     a test task to test...   ---       3 weeks ago
+kiwis                               0.1       1 minute ago

--- a/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskList_Only_Tasks_v1beta1.golden
@@ -1,7 +1,8 @@
-NAME       DESCRIPTION              AGE
-tomatoes                            1 minute ago
-mangoes                             20 seconds ago
-bananas                             3 weeks ago
-apples                              3 weeks ago
-potatoes   a test task              3 weeks ago
-onionss    a test task to test...   3 weeks ago
+NAME       DESCRIPTION              VERSION   AGE
+tomatoes                            ---       1 minute ago
+mangoes                             ---       20 seconds ago
+bananas                             ---       3 weeks ago
+apples                              ---       3 weeks ago
+potatoes   a test task              ---       3 weeks ago
+onionss    a test task to test...   ---       3 weeks ago
+kiwis                               0.1       1 minute ago

--- a/pkg/formatted/version.go
+++ b/pkg/formatted/version.go
@@ -1,0 +1,22 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+func FormatVersion(version map[string]string) string {
+	if len(version) == 0 {
+		return "---"
+	}
+	return version["app.kubernetes.io/version"]
+}

--- a/pkg/formatted/version_test.go
+++ b/pkg/formatted/version_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import (
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/test"
+)
+
+func TestVersion(t *testing.T) {
+	version := make(map[string]string)
+
+	version["app.kubernetes.io/version"] = "v1"
+
+	out := FormatVersion(version)
+
+	test.AssertOutput(t, "v1", out)
+}
+
+func Test_Without_Version(t *testing.T) {
+	version := make(map[string]string)
+
+	out := FormatVersion(version)
+
+	test.AssertOutput(t, "---", out)
+}

--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -295,8 +295,8 @@ func ListAllTasksOutput(t *testing.T, cs *framework.Clients, td map[int]interfac
 	t.Helper()
 	const (
 		emptyMsg = "No tasks found"
-		header   = "NAME\tDESCRIPTION\tAGE"
-		body     = "%s\t%s\t%s\n"
+		header   = "NAME\tDESCRIPTION\tVERSION\tAGE"
+		body     = "%s\t%s\t%s\t%s\n"
 	)
 
 	clock := clockwork.NewFakeClockAt(time.Now())
@@ -317,6 +317,7 @@ func ListAllTasksOutput(t *testing.T, cs *framework.Clients, td map[int]interfac
 		fmt.Fprintf(w, body,
 			task.Name,
 			formatted.FormatDesc(task.Spec.Description),
+			formatted.FormatVersion(task.Labels),
 			formatted.Age(&task.CreationTimestamp, clock),
 		)
 	}


### PR DESCRIPTION
  - This patch list the task with the version of the task

   For e.g.

       ./tkn task list
       NAME                DESCRIPTION              VERSION   AGE
       ansible-tower-cli   Ansible-tower-cli t...   0.1       21 hours ago
       buildah                                      ---       20 hours ago 
      
Partially closes: #1264 

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
