### PR TITLE
tkn completion command will bail out if something unexpected is passed  

### DIFF
--- a/docs/cmd/tkn_completion.md
+++ b/docs/cmd/tkn_completion.md
@@ -16,6 +16,8 @@ interactive completion
 Supported Shells:
 	- bash
 	- zsh
+	- fish
+	- powershell
 
 
 ### Examples

--- a/docs/man/man1/tkn-completion.1
+++ b/docs/man/man1/tkn-completion.1
@@ -22,6 +22,8 @@ interactive completion
 Supported Shells:
     \- bash
     \- zsh
+    \- fish
+    \- powershell
 
 
 .SH OPTIONS

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -27,6 +27,8 @@ interactive completion
 Supported Shells:
 	- bash
 	- zsh
+	- fish
+	- powershell
 `
 	eg = `To load completions:
 
@@ -72,20 +74,19 @@ func Command() *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "utility",
 		},
-		Args: cobra.MinimumNArgs(1),
+		Args: cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 1 {
-				switch args[0] {
-				case "bash":
-					_ = cmd.Root().GenBashCompletion(os.Stdout)
-				case "zsh":
-					_ = cmd.Root().GenZshCompletion(os.Stdout)
-				case "fish":
-					_ = cmd.Root().GenFishCompletion(os.Stdout, true)
-				case "powershell":
-					_ = cmd.Root().GenPowerShellCompletion(os.Stdout)
-				}
+			switch args[0] {
+			case "bash":
+				_ = cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				_ = cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				_ = cmd.Root().GenPowerShellCompletion(os.Stdout)
 			}
+
 			return nil
 		},
 	}

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -27,6 +27,6 @@ func TestCompletion_Empty(t *testing.T) {
 	if err == nil {
 		t.Errorf("No errors was defined. Output: %s", out)
 	}
-	expected := "requires at least 1 arg(s), only received 0"
+	expected := "accepts 1 arg(s), received 0"
 	test.AssertOutput(t, expected, err.Error())
 }


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- tkn completion command will bail out if something else is passed apart from expected args
- forced the number of args to be 1, passing multiple in valid options was returning 0 for eg: ( tkn completion f b)
- Modified unit test as required
issue https://github.com/tektoncd/cli/issues/1282

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
