### PR TITLE
Add a flag for getting the status when describing TaskRun or PipelineRun

### DIFF
--- a/docs/cmd/tkn_pipelinerun_describe.md
+++ b/docs/cmd/tkn_pipelinerun_describe.md
@@ -34,6 +34,8 @@ or
   -L, --last                          show description for last PipelineRun
       --limit int                     lists number of PipelineRuns when selecting a PipelineRun to describe (default 5)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
+      --status                        use status to get the status of a PipelineRun
+      --taskruns                      show the status of taskruns, must be specified with --status
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/cmd/tkn_taskrun_describe.md
+++ b/docs/cmd/tkn_taskrun_describe.md
@@ -34,6 +34,8 @@ or
   -L, --last                          show description for last TaskRun
       --limit int                     lists number of TaskRuns when selecting a TaskRun to describe (default 5)
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
+      --status                        use status to get the status of a TaskRun
+      --steps                         show the status of steps, must be specified with --status
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/man/man1/tkn-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-pipelinerun-describe.1
@@ -44,6 +44,14 @@ Describe a PipelineRun in a namespace
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-as\-json|jsonpath\-file.
 
 .PP
+\fB\-\-status\fP[=false]
+    use status to get the status of a PipelineRun
+
+.PP
+\fB\-\-taskruns\fP[=false]
+    show the status of taskruns, must be specified with \-\-status
+
+.PP
 \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].

--- a/docs/man/man1/tkn-taskrun-describe.1
+++ b/docs/man/man1/tkn-taskrun-describe.1
@@ -44,6 +44,14 @@ Describe a TaskRun in a namespace
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-as\-json|jsonpath\-file.
 
 .PP
+\fB\-\-status\fP[=false]
+    use status to get the status of a TaskRun
+
+.PP
+\fB\-\-steps\fP[=false]
+    show the status of steps, must be specified with \-\-status
+
+.PP
 \fB\-\-template\fP=""
     Template string or path to template file to use when \-o=go\-template, \-o=go\-template\-file. The template format is golang templates [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]].

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_status_with_taskruns.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_status_with_taskruns.golden
@@ -1,0 +1,9 @@
+Status
+
+STATUS
+Succeeded
+
+Taskruns
+
+ NAME   TASK NAME   STATUS
+ tr-1   t-1         Succeeded

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_status_with_steps.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_status_with_steps.golden
@@ -1,0 +1,10 @@
+Status
+
+STATUS
+Succeeded
+
+Steps
+
+ NAME     STATUS
+ step-1   Completed
+ step-2   Completed

--- a/pkg/options/describe.go
+++ b/pkg/options/describe.go
@@ -42,6 +42,7 @@ type DescribeOptions struct {
 	AskOpts              survey.AskOpt
 	Fzf                  bool
 	Last                 bool
+	Status               bool
 }
 
 func NewDescribeOptions(p cli.Params) *DescribeOptions {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Closes #1090.

Add a flag `--status` for getting the status when describing TaskRun or PipelineRun.

```shell
$ bin/tkn taskrun describe --status    
? Select taskrun: hello-run-wc2f6 started 1 day ago
Succeeded

$ bin/tkn tr describe --status --steps
? Select taskrun: error-run-5hv4r started 5 days ago
🌡️  Status

STATUS
Failed

🦶 Steps

 NAME      STATUS
 ∙ error   Error

$ bin/tkn pr describe --status --taskruns                
🌡️  Status

STATUS
Failed

🗂  Taskruns

 NAME                                                TASK NAME       STATUS
 ∙ jib-maven-test-pipeline-run-verify-digest-bxx88   verify-digest   Failed
 ∙ jib-maven-test-pipeline-run-jib-maven-wqk77       jib-maven       Succeeded
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Add `--status` flag for status when describing TaskRun and PipelineRun
```
