### PR TITLE
Update TaskRun Tests from Test Builders to Structs

### DIFF
--- a/pkg/cmd/taskrun/cancel_test.go
+++ b/pkg/cmd/taskrun/cancel_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"testing"
 
-	tb "github.com/tektoncd/cli/internal/builder/v1alpha1"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -37,28 +36,50 @@ import (
 
 func TestTaskRunCancel(t *testing.T) {
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("taskrun-1",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("task")),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionUnknown,
-					Reason: v1beta1.TaskRunReasonRunning.String(),
-				}),
-			),
-		),
-		tb.TaskRun("taskrun-2",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "failure-task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("failure-task")),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrun-1",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "task"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "task",
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionUnknown,
+							Reason: v1beta1.TaskRunReasonRunning.String(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrun-2",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "failure-task"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "failure-task",
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	trs2 := []*v1alpha1.TaskRun{
@@ -87,17 +108,28 @@ func TestTaskRunCancel(t *testing.T) {
 	}
 
 	trs3 := []*v1alpha1.TaskRun{
-		tb.TaskRun("cancel-taskrun-1",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "cancel-task"),
-			tb.TaskRunSpec(tb.TaskRunTaskRef("cancel-task")),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionFalse,
-					Reason: v1beta1.TaskRunReasonCancelled.String(),
-				}),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cancel-taskrun-1",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "cancel-task"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "cancel-task",
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: v1beta1.TaskRunReasonCancelled.String(),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	ns := []*corev1.Namespace{

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	tb "github.com/tektoncd/cli/internal/builder/v1alpha1"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -30,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
-	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
@@ -45,94 +43,161 @@ func TestTaskRunDelete(t *testing.T) {
 	}
 
 	tasks := []*v1alpha1.Task{
-		tb.Task("random",
-			tb.TaskNamespace("ns"),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "random",
+				Namespace: "ns",
+			},
+		},
 	}
 
 	clustertasks := []*v1alpha1.ClusterTask{
-		tb.ClusterTask("random"),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "random",
+			},
+		},
 	}
 
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("tr0-1",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind)),
-			),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
-		tb.TaskRun("tr0-2",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind)),
-			),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
-		tb.TaskRun("tr0-3",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/task", "random"),
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.NamespacedTaskKind)),
-			),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
-		tb.TaskRun("tr0-4",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/clusterTask", "random"),
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.ClusterTaskKind)),
-			),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
-		tb.TaskRun("tr0-5",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/clusterTask", "random"),
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.ClusterTaskKind)),
-			),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
-		tb.TaskRun("tr0-6",
-			tb.TaskRunNamespace("ns"),
-			tb.TaskRunLabel("tekton.dev/clusterTask", "random"),
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef("random", tb.TaskRefKind(v1alpha1.ClusterTaskKind)),
-			),
-			tb.TaskRunStatus(
-				tb.StatusCondition(apis.Condition{
-					Status: corev1.ConditionTrue,
-					Reason: v1beta1.TaskRunReasonSuccessful.String(),
-				}),
-			),
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr0-1",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "random",
+					Kind: v1alpha1.NamespacedTaskKind,
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr0-2",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "random",
+					Kind: v1alpha1.NamespacedTaskKind,
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr0-3",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/task": "random"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "random",
+					Kind: v1alpha1.NamespacedTaskKind,
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr0-4",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/clusterTask": "random"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "random",
+					Kind: v1alpha1.ClusterTaskKind,
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr0-5",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/clusterTask": "random"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "random",
+					Kind: v1alpha1.ClusterTaskKind,
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr0-6",
+				Namespace: "ns",
+				Labels:    map[string]string{"tekton.dev/clusterTask": "random"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "random",
+					Kind: v1alpha1.ClusterTaskKind,
+				},
+			},
+			Status: v1alpha1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+			},
+		},
 	}
 	type clients struct {
 		pipelineClient pipelinetest.Clients

--- a/test/resources/eventlistener/eventlistener-multi-replica.yaml
+++ b/test/resources/eventlistener/eventlistener-multi-replica.yaml
@@ -34,4 +34,4 @@ spec:
       bindings:
         - ref: github-pr-binding
       template:
-        name: github-template
+        ref: github-template

--- a/test/resources/eventlistener/eventlistener.yaml
+++ b/test/resources/eventlistener/eventlistener.yaml
@@ -33,7 +33,7 @@ spec:
       bindings:
         - ref: github-pr-binding
       template:
-        name: github-template
+        ref: github-template
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding


### PR DESCRIPTION
# Changes

Migrating unit tests for `tkn taskrun` from test builders to structs.

Part of #1145 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```