### PR TITLE
Fix crash with pipeline describe when using inline taskSpec

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -96,7 +96,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{- else }}
  NAME	TASKREF	RUNAFTER	TIMEOUT	CONDITIONS	PARAMS
 {{- range $i, $t := .Pipeline.Spec.Tasks }}
- {{decorate "bullet" $t.Name }}	{{ $t.TaskRef.Name }}	{{ join $t.RunAfter ", " }}	{{ formatTimeout $t.Timeout }}	{{ formatTaskConditions $t.Conditions }}	{{ formatParam $t.Params $.Pipeline.Spec.Params }}
+ {{decorate "bullet" $t.Name }}	{{ getTaskRefName $t }}	{{ join $t.RunAfter ", " }}	{{ formatTimeout $t.Timeout }}	{{ formatTaskConditions $t.Conditions }}	{{ formatParam $t.Params $.Pipeline.Spec.Params }}
 {{- end }}
 {{- end }}
 
@@ -206,6 +206,7 @@ func printPipelineDescription(out io.Writer, p cli.Params, pname string) error {
 		"formatParam":          formatted.Param,
 		"join":                 strings.Join,
 		"formatTaskConditions": formatted.TaskConditions,
+		"getTaskRefName":       formatted.GetTaskRefName,
 	}
 
 	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_with_taskSpec.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribeV1beta1_with_taskSpec.golden
@@ -1,0 +1,27 @@
+Name:        pipeline
+Namespace:   ns
+
+Resources
+
+ No resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Tasks
+
+ NAME   TASKREF    RUNAFTER   TIMEOUT   CONDITIONS   PARAMS
+ task   EMBEDDED              ---       ---          ---
+
+PipelineRuns
+
+ No pipelineruns

--- a/pkg/formatted/task.go
+++ b/pkg/formatted/task.go
@@ -1,0 +1,26 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func GetTaskRefName(task *v1beta1.PipelineTask) string {
+	if task.TaskRef != nil {
+		return task.TaskRef.Name
+	}
+	return "EMBEDDED"
+}


### PR DESCRIPTION
# Changes

When the task is using a taskSpec we return task name as EMBEDDED

Closes #1302

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->
```release-note
Fix crash with embedded taskrun in pipeline when running `tkn pipeline describe`
```