### PR TITLE
Add a flag to not print the taskname/step prefix when showing logs

### DIFF
--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -36,6 +36,7 @@ Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (inc
   -h, --help           help for logs
   -L, --last           show logs for last PipelineRun
       --limit int      lists number of PipelineRuns (default 5)
+      --prefix         prefix each log line with the log source (task name and step name) (default true)
   -t, --task strings   show logs for mentioned Tasks only
 ```
 

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -37,6 +37,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
   -h, --help           help for logs
   -L, --last           show logs for last TaskRun
       --limit int      lists number of TaskRuns (default 5)
+      --prefix         prefix each log line with the log source (step name) (default true)
   -s, --step strings   show logs for mentioned steps only
 ```
 

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -44,6 +44,10 @@ Show the logs of a PipelineRun
     lists number of PipelineRuns
 
 .PP
+\fB\-\-prefix\fP[=true]
+    prefix each log line with the log source (task name and step name)
+
+.PP
 \fB\-t\fP, \fB\-\-task\fP=[]
     show logs for mentioned Tasks only
 

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -44,6 +44,10 @@ Show TaskRuns logs
     lists number of TaskRuns
 
 .PP
+\fB\-\-prefix\fP[=true]
+    prefix each log line with the log source (step name)
+
+.PP
 \fB\-s\fP, \fB\-\-step\fP=[]
     show logs for mentioned steps only
 

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -80,6 +80,7 @@ Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (inc
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last PipelineRun")
 	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a PipelineRun")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Prefixing, "prefix", "", true, "prefix each log line with the log source (task name and step name)")
 	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned Tasks only")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of PipelineRuns")
 
@@ -106,7 +107,7 @@ func Run(opts *options.LogOptions) error {
 		return err
 	}
 
-	log.NewWriter(log.LogTypePipeline).Write(opts.Stream, logC, errC)
+	log.NewWriter(log.LogTypePipeline, opts.Prefixing).Write(opts.Stream, logC, errC)
 
 	return nil
 }

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -83,6 +83,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last TaskRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Prefixing, "prefix", "", true, "prefix each log line with the log source (step name)")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of TaskRuns")
 	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a TaskRun")
 	c.Flags().StringSliceVarP(&opts.Steps, "step", "s", []string{}, "show logs for mentioned steps only")
@@ -110,7 +111,7 @@ func Run(opts *options.LogOptions) error {
 		return err
 	}
 
-	log.NewWriter(log.LogTypeTask).Write(opts.Stream, logC, errC)
+	log.NewWriter(log.LogTypeTask, opts.Prefixing).Write(opts.Stream, logC, errC)
 	return nil
 }
 

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -204,7 +204,7 @@ func TestLog_no_taskrun_arg(t *testing.T) {
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			trlo := logoptsV1alpha1("", "ns", tp.input, fake.Streamer(fake.Logs()), false, false, []string{}, tp.dc)
+			trlo := logoptsV1alpha1("", "ns", tp.input, fake.Streamer(fake.Logs()), false, false, false, []string{}, tp.dc)
 			_, err := fetchLogs(trlo)
 			if tp.wantError {
 				if err == nil {
@@ -402,7 +402,7 @@ func TestLog_taskrun_logs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, false, []string{}, dc)
+	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, false, true, []string{}, dc)
 	output, _ := fetchLogs(trlo)
 
 	expectedLogs := []string{
@@ -412,6 +412,18 @@ func TestLog_taskrun_logs(t *testing.T) {
 	expected := strings.Join(expectedLogs, "\n") + "\n"
 
 	test.AssertOutput(t, expected, output)
+
+	trlo = logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, false, false, []string{}, dc)
+	output, _ = fetchLogs(trlo)
+
+	expectedLogs = []string{
+		"wrote a file\n",
+		"Build successful\n",
+	}
+	expected = strings.Join(expectedLogs, "\n") + "\n"
+
+	test.AssertOutput(t, expected, output)
+
 }
 
 func TestLog_taskrun_logs_v1beta1(t *testing.T) {
@@ -519,7 +531,7 @@ func TestLog_taskrun_logs_v1beta1(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, true, []string{}, dc)
 	output, _ := fetchLogs(trlo)
 
 	expectedLogs := []string{
@@ -527,6 +539,17 @@ func TestLog_taskrun_logs_v1beta1(t *testing.T) {
 		"[nop] Build successful\n",
 	}
 	expected := strings.Join(expectedLogs, "\n") + "\n"
+
+	test.AssertOutput(t, expected, output)
+
+	trlo = logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, false, []string{}, dc)
+	output, _ = fetchLogs(trlo)
+
+	expectedLogs = []string{
+		"wrote a file\n",
+		"Build successful\n",
+	}
+	expected = strings.Join(expectedLogs, "\n") + "\n"
 
 	test.AssertOutput(t, expected, output)
 }
@@ -607,7 +630,7 @@ func TestLog_taskrun_logs_no_pod_name(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, true, []string{}, dc)
 	_, err = fetchLogs(trlo)
 
 	if err == nil {
@@ -694,7 +717,7 @@ func TestLog_taskrun_logs_no_pod_name_v1beta1(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, true, []string{}, dc)
 	_, err = fetchLogs(trlo)
 
 	if err == nil {
@@ -836,7 +859,7 @@ func TestLog_taskrun_all_steps(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	trl := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), true, false, []string{}, dc)
+	trl := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), true, false, true, []string{}, dc)
 	output, _ := fetchLogs(trl)
 
 	expectedLogs := []string{
@@ -981,7 +1004,7 @@ func TestLog_taskrun_all_steps_v1beta1(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	trl := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), true, false, []string{}, dc)
+	trl := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), true, false, true, []string{}, dc)
 	output, _ := fetchLogs(trl)
 
 	expectedLogs := []string{
@@ -1125,7 +1148,7 @@ func TestLog_taskrun_given_steps(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trl := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, false, []string{trStep1Name}, dc)
+	trl := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, false, true, []string{trStep1Name}, dc)
 	output, _ := fetchLogs(trl)
 
 	expectedLogs := []string{
@@ -1266,7 +1289,7 @@ func TestLog_taskrun_given_steps_v1beta1(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trl := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, []string{trStep1Name}, dc)
+	trl := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, false, true, []string{trStep1Name}, dc)
 	output, _ := fetchLogs(trl)
 
 	expectedLogs := []string{
@@ -1408,7 +1431,7 @@ func TestLog_taskrun_follow_mode(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 	output, _ := fetchLogs(trlo)
 
 	expectedLogs := []string{
@@ -1551,7 +1574,7 @@ func TestLog_taskrun_follow_mode_v1beta1(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 	output, _ := fetchLogs(trlo)
 
 	expectedLogs := []string{
@@ -1973,7 +1996,7 @@ func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 	_, err = fetchLogs(trlo)
 	if err == nil {
 		t.Error("Expecting an error but it's empty")
@@ -2113,7 +2136,7 @@ func TestLog_taskrun_follow_mode_no_pod_name_v1beta1(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 	_, err = fetchLogs(trlo)
 	if err == nil {
 		t.Error("Expecting an error but it's empty")
@@ -2255,7 +2278,7 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 
 	go func() {
 		time.Sleep(time.Second * 1)
@@ -2408,7 +2431,7 @@ func TestLog_taskrun_follow_mode_update_pod_name_v1beta1(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 
 	go func() {
 		time.Sleep(time.Second * 1)
@@ -2561,7 +2584,7 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 
 	go func() {
 		time.Sleep(time.Second * 1)
@@ -2709,7 +2732,7 @@ func TestLog_taskrun_follow_mode_update_timeout_v1beta1(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 
 	go func() {
 		time.Sleep(time.Second * 1)
@@ -2852,7 +2875,7 @@ func TestLog_taskrun_follow_mode_no_output_provided(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1alpha1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 
 	output, err := fetchLogs(trlo)
 	if err != nil {
@@ -2990,7 +3013,7 @@ func TestLog_taskrun_follow_mode_no_output_provided_v1beta1(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 
-	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, []string{}, dc)
+	trlo := logoptsV1beta1(trName, ns, cs, fake.Streamer(logs), false, true, true, []string{}, dc)
 
 	output, err := fetchLogs(trlo)
 
@@ -3003,7 +3026,7 @@ func TestLog_taskrun_follow_mode_no_output_provided_v1beta1(t *testing.T) {
 }
 
 func logoptsV1alpha1(run, ns string, cs pipelinetest.Clients, streamer stream.NewStreamerFunc,
-	allSteps bool, follow bool, steps []string, dc dynamic.Interface) *options.LogOptions {
+	allSteps bool, follow bool, prefixing bool, steps []string, dc dynamic.Interface) *options.LogOptions {
 	p := test.Params{
 		Kube:    cs.Kube,
 		Tekton:  cs.Pipeline,
@@ -3019,11 +3042,12 @@ func logoptsV1alpha1(run, ns string, cs pipelinetest.Clients, streamer stream.Ne
 		Streamer:    streamer,
 		Limit:       5,
 		Steps:       steps,
+		Prefixing:   prefixing,
 	}
 }
 
 func logoptsV1beta1(run, ns string, cs pipelinev1beta1test.Clients, streamer stream.NewStreamerFunc,
-	allSteps bool, follow bool, steps []string, dc dynamic.Interface) *options.LogOptions {
+	allSteps bool, follow bool, prefixing bool, steps []string, dc dynamic.Interface) *options.LogOptions {
 	p := test.Params{
 		Kube:    cs.Kube,
 		Tekton:  cs.Pipeline,
@@ -3039,6 +3063,7 @@ func logoptsV1beta1(run, ns string, cs pipelinev1beta1test.Clients, streamer str
 		Streamer:    streamer,
 		Limit:       5,
 		Steps:       steps,
+		Prefixing:   prefixing,
 	}
 }
 

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -23,15 +23,17 @@ import (
 
 // Writer helps logging pod"s log
 type Writer struct {
-	fmt     *formatted.Color
-	logType string
+	fmt       *formatted.Color
+	logType   string
+	prefixing bool
 }
 
 // NewWriter returns the new instance of LogWriter
-func NewWriter(logType string) *Writer {
+func NewWriter(logType string, prefixing bool) *Writer {
 	return &Writer{
-		fmt:     formatted.NewColor(),
-		logType: logType,
+		fmt:       formatted.NewColor(),
+		logType:   logType,
+		prefixing: prefixing,
 	}
 }
 
@@ -50,11 +52,13 @@ func (lw *Writer) Write(s *cli.Stream, logC <-chan Log, errC <-chan error) {
 				continue
 			}
 
-			switch lw.logType {
-			case LogTypePipeline:
-				lw.fmt.Rainbow.Fprintf(l.Step, s.Out, "[%s : %s] ", l.Task, l.Step)
-			case LogTypeTask:
-				lw.fmt.Rainbow.Fprintf(l.Step, s.Out, "[%s] ", l.Step)
+			if lw.prefixing {
+				switch lw.logType {
+				case LogTypePipeline:
+					lw.fmt.Rainbow.Fprintf(l.Step, s.Out, "[%s : %s] ", l.Task, l.Step)
+				case LogTypeTask:
+					lw.fmt.Rainbow.Fprintf(l.Step, s.Out, "[%s] ", l.Step)
+				}
 			}
 
 			fmt.Fprintf(s.Out, "%s\n", l.Log)

--- a/pkg/options/logs.go
+++ b/pkg/options/logs.go
@@ -48,7 +48,7 @@ type LogOptions struct {
 	AskOpts         survey.AskOpt
 	Fzf             bool
 	Tail            int64
-
+	Prefixing       bool
 	// ActivityTimeout is the amount of time to wait for some activity
 	// (e.g. Pod ready) before giving up.
 	ActivityTimeout time.Duration


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Following from what `kubectl logs` has (with a different default to true tho),
we allow disabling the prefixing of the task/step when showing the logs with the
option `--prefix=false`

Closes #1280
Closes #105

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->
```release-note
Add option log --prefix to disable prefixing of the task/step name when showing logs.
```