### PR TITLE
Fix parseParam with empty array

### DIFF
--- a/pkg/params/mergeparams.go
+++ b/pkg/params/mergeparams.go
@@ -75,7 +75,11 @@ func parseParam(p []string) (map[string]v1beta1.Param, error) {
 		}
 
 		if paramByType[r[0]] == "array" {
-			param.Value.ArrayVal = strings.Split(r[1], ",")
+			if len(r[1]) == 0 {
+				param.Value.ArrayVal = make([]string, 0)
+			} else {
+				param.Value.ArrayVal = strings.Split(r[1], ",")
+			}
 		}
 		params[r[0]] = param
 	}

--- a/pkg/params/mergeparams_test.go
+++ b/pkg/params/mergeparams_test.go
@@ -182,6 +182,38 @@ func Test_parseParam(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
+		name: "Test_parseParam with empty array",
+		args: args{
+			p: []string{"key1=value1", "key2="},
+			pt: []v1beta1.ParamSpec{
+				{
+					Name: "key1",
+					Type: "string",
+				},
+				{
+					Name: "key2",
+					Type: "array",
+				},
+			},
+		},
+		want: map[string]v1beta1.Param{
+			"key1": {
+				Name: "key1",
+				Value: v1beta1.ArrayOrString{
+					Type:      v1beta1.ParamTypeString,
+					StringVal: "value1",
+				},
+			},
+			"key2": {
+				Name: "key2",
+				Value: v1beta1.ArrayOrString{
+					Type:     v1beta1.ParamTypeArray,
+					ArrayVal: make([]string, 0),
+				},
+			},
+		},
+		wantErr: false,
+	}, {
 		name: "Test_parseParam Err",
 		args: args{
 			p: []string{"value1", "value2"},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes #1286 

```go
// Split slices s into all substrings separated by sep and returns a slice of
// the substrings between those separators.
//
// If s does not contain sep and sep is not empty, Split returns a
// slice of length 1 whose only element is s.
//
// If sep is empty, Split splits after each UTF-8 sequence. If both s
// and sep are empty, Split returns an empty slice.
//
// It is equivalent to SplitN with a count of -1.
func Split(s, sep string) []string { return genSplit(s, sep, 0, -1) }
```

According to the documentation, `strings.Split` returns a slice of length 1 if the value is empty and the separator is not empty. As a result, we have to return an empty slice with the empty value. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Fix parseParam with empty array
```
