### PR TITLE
Add framework usage to get kubeconfig and cluster params support

### DIFF
--- a/test/e2e/plugin/plugin_test.go
+++ b/test/e2e/plugin/plugin_test.go
@@ -20,13 +20,20 @@ import (
 	"testing"
 
 	"github.com/tektoncd/cli/test/cli"
+	"github.com/tektoncd/cli/test/framework"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/env"
 	"gotest.tools/v3/icmd"
+	knativetest "knative.dev/pkg/test"
 )
 
 func TestTknPlugin(t *testing.T) {
-	tkn, err := cli.NewTknRunner("any-namespace")
+	t.Parallel()
+	c, namespace := framework.Setup(t)
+	knativetest.CleanupOnInterrupt(func() { framework.TearDown(t, c, namespace) }, t.Logf)
+	defer framework.TearDown(t, c, namespace)
+
+	tkn, err := cli.NewTknRunner(namespace)
 	assert.NilError(t, err)
 	currentpath, err := os.Getwd()
 	assert.NilError(t, err)


### PR DESCRIPTION
# Changes

At this moment usage of `kubeconfig` or `cluster` parameters with `go test ... ./test/e2e/plugin` to point to specific k8s cluster fails with error like `flag provided but not defined: -kubeconfig`

`framework.Setup` usage provides support for this parameters.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
