### PR TITLE
Add section of Skipped tasks in tkn pr describe

### DIFF
--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -32,6 +32,7 @@ import (
 	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
@@ -2064,6 +2065,195 @@ func TestPipelineRunDescribeV1beta1_withoutNameOfOnlyOnePipelineRunPresent(t *te
 
 	pipelinerun := Command(p)
 	got, err := test.ExecuteCommand(pipelinerun, "desc")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineRunDescribeWithSkippedTasksV1beta1(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelinerunname := "pipeline-run"
+	taskRuns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "tr-1",
+				Labels:    map[string]string{"tekton.dev/task": "task-1"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task-1",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionFalse,
+							Reason: v1beta1.PipelineRunReasonFailed.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now()},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(5 * time.Minute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "tr-2",
+				Labels:    map[string]string{"tekton.dev/task": "task-1"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task-1",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(17 * time.Minute)},
+				},
+			},
+		},
+	}
+
+	prun := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pipelinerunname,
+				Namespace: "ns",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name: "res-1",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "test-res",
+						},
+					},
+					{
+						Name: "res-2",
+						ResourceRef: &v1beta1.PipelineResourceRef{
+							Name: "test-res2",
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "p-1",
+						Value: v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+					{
+						Name: "p-2",
+						Value: v1beta1.ArrayOrString{
+							Type:     v1beta1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status:  corev1.ConditionTrue,
+							Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
+							Message: "Completed",
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now()},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(20 * time.Minute)},
+					TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+						"tr-1": {
+							PipelineTaskName: "t-1",
+							Status:           &taskRuns[0].Status,
+						},
+						"tr-2": {
+							PipelineTaskName: "t-2",
+							Status:           &taskRuns[1].Status,
+						},
+					},
+					SkippedTasks: []v1beta1.SkippedTask{
+						{
+							Name: "task-should-be-skipped-1",
+							WhenExpressions: []v1beta1.WhenExpression{
+								{
+									Input:    "yes",
+									Operator: selection.In,
+									Values:   []string{"missing"},
+								},
+							},
+						},
+						{
+							Name: "task-should-be-skipped-2",
+							WhenExpressions: []v1beta1.WhenExpression{
+								{
+									Input:    "README.md",
+									Operator: selection.NotIn,
+									Values:   []string{"README.md"},
+								},
+							},
+						},
+						{
+							Name: "task-should-be-skipped-3",
+							WhenExpressions: []v1beta1.WhenExpression{
+								{
+									Input:    "monday",
+									Operator: selection.NotIn,
+									Values:   []string{"friday"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1PR(prun[0], version),
+		cb.UnstructuredV1beta1TR(taskRuns[0], version),
+		cb.UnstructuredV1beta1TR(taskRuns[1], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: namespaces, PipelineRuns: prun, TaskRuns: taskRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+
+	pipelinerun := Command(p)
+	got, err := test.ExecuteCommand(pipelinerun, "desc", "-n", "ns", pipelinerunname)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1.golden
@@ -32,3 +32,7 @@ Taskruns
  NAME   TASK NAME   STARTED           DURATION    STATUS
  tr-2   t-2         -10 minutes ago   7 minutes   Succeeded
  tr-1   t-1         0 seconds ago     5 minutes   Failed
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_withoutNameOfOnlyOnePipelineRunPresent.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeV1beta1_withoutNameOfOnlyOnePipelineRunPresent.golden
@@ -25,3 +25,7 @@ Workspaces
 Taskruns
 
  No taskruns
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithSkippedTasksV1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithSkippedTasksV1beta1.golden
@@ -29,9 +29,13 @@ Workspaces
 
 Taskruns
 
- NAME   TASK NAME   STARTED         DURATION    STATUS
- tr-1   t-1         0 seconds ago   5 minutes   Failed
+ NAME   TASK NAME   STARTED           DURATION    STATUS
+ tr-2   t-2         -10 minutes ago   7 minutes   Succeeded
+ tr-1   t-1         0 seconds ago     5 minutes   Failed
 
 Skipped Tasks
 
- No Skipped Tasks
+ NAME
+ task-should-be-skipped-1
+ task-should-be-skipped-2
+ task-should-be-skipped-3

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
@@ -34,3 +34,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_custom_timeout.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_custom_timeout.golden
@@ -27,3 +27,7 @@ Workspaces
 Taskruns
 
  No taskruns
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
@@ -35,3 +35,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   Failed
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutPRCondition.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutPRCondition.golden
@@ -31,3 +31,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   ---
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutTRCondition.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutTRCondition.golden
@@ -35,3 +35,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   ---
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last.golden
@@ -31,3 +31,7 @@ Taskruns
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-2   t-2         5 minutes ago   4 minutes   Succeeded
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_lastV1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_lastV1beta1.golden
@@ -32,3 +32,7 @@ Taskruns
  NAME   TASK NAME   STARTED          DURATION    STATUS
  tr-1   t-1         0 seconds ago    5 minutes   Failed
  tr-2   t-2         10 minutes ago   7 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_ordering.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_ordering.golden
@@ -31,3 +31,7 @@ Taskruns
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-2   t-2         5 minutes ago   4 minutes   Succeeded
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_without_status.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_without_status.golden
@@ -30,3 +30,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref.golden
@@ -33,3 +33,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_only_taskrun.golden
@@ -30,3 +30,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1_with_results.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1_with_results.golden
@@ -31,3 +31,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         0 seconds ago   5 minutes   Failed
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1_with_workspaces.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1_with_workspaces.golden
@@ -34,3 +34,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         0 seconds ago   5 minutes   Failed
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun.golden
@@ -33,3 +33,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED         DURATION    STATUS
  tr-1   t-1         8 minutes ago   3 minutes   Succeeded
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent.golden
@@ -27,3 +27,7 @@ Workspaces
 Taskruns
 
  No taskruns
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_pipelineref.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_pipelineref.golden
@@ -27,3 +27,7 @@ Workspaces
 Taskruns
 
  No taskruns
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_start_time.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_start_time.golden
@@ -29,3 +29,7 @@ Workspaces
 Taskruns
 
  No taskruns
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_tr_start_time.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_tr_start_time.golden
@@ -30,3 +30,7 @@ Taskruns
 
  NAME   TASK NAME   STARTED   DURATION   STATUS
  tr-1   t-1         ---       ---        Running
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_zero_timeout.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_zero_timeout.golden
@@ -26,3 +26,7 @@ Workspaces
 Taskruns
 
  No taskruns
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -72,6 +72,8 @@ func DecorateAttr(attrString, message string) string {
 		return "📝 "
 	case "workspaces":
 		return "📂 "
+	case "skippedtasks":
+		return "⏭️  "
 	}
 
 	attr := color.Reset

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -82,13 +82,13 @@ func TestDecoration(t *testing.T) {
 	funcMap := template.FuncMap{
 		"decorate": DecorateAttr,
 	}
-	aTemplate := `{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "workspaces" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
+	aTemplate := `{{decorate "skippedtasks" ""}}{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "workspaces" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
 	processed := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(aTemplate))
 	buf := new(bytes.Buffer)
 
 	if err := processed.Execute(buf, nil); err != nil {
 		t.Error("Could not process the template.")
 	}
-	test.AssertOutput(t, "∙ Foo ✔ ️📦 ⚓ 📝 📂 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
+	test.AssertOutput(t, "⏭️  ∙ Foo ✔ ️📦 ⚓ 📝 📂 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
 
 }

--- a/pkg/pipelinerun/description/description.go
+++ b/pkg/pipelinerun/description/description.go
@@ -122,6 +122,17 @@ STARTED	DURATION	STATUS
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{decorate "skippedtasks" ""}}{{decorate "underline bold" "Skipped Tasks\n"}}
+
+{{- $l := len .PipelineRun.Status.SkippedTasks }}{{ if eq $l 0 }}
+ No Skipped Tasks
+{{- else }}
+ NAME
+{{- range $skippedTask := .PipelineRun.Status.SkippedTasks }}
+ {{decorate "bullet" $skippedTask.Name }}
+{{- end }}
+{{- end }}
 `
 
 type tkr struct {


### PR DESCRIPTION
# Changes

Since when expressions are now supported in Tekton Pipelines for
guarding the execution of `Pipeline` so a new section of Skipped Tasks
is introduced which will display the list of all Skipped Tasks which
did not satisfy the conditions specified in when expressions.

Part of #1222 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Display list of Skipped Tasks in tkn pr describe command which we get when the conditions in when expressions are not met
```