### PR TITLE
Fix eventListener e2e test with new RBAC permissions

### DIFF
--- a/test/resources/eventlistener/eventlistener.yaml
+++ b/test/resources/eventlistener/eventlistener.yaml
@@ -109,7 +109,7 @@ rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
     resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]


### PR DESCRIPTION
# Changes

Add ClusterRole/ClusterRoleBinding to make triggers be workable for `eventListener` e2e test, as per [recommendation](https://github.com/tektoncd/triggers/blob/master/docs/eventlisteners.md#serviceaccountname).

Fixes: https://github.com/tektoncd/cli/issues/1314

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```

