### PR TITLE
Adds version in describe command of task

### DIFF
--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -40,6 +40,9 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
 {{- if ne .Task.Spec.Description "" }}
 {{decorate "bold" "Description"}}:	{{ .Task.Spec.Description }}
 {{- end }}
+{{- $v := findVersion .Task.Labels }} {{- if ne $v ""}}
+{{decorate "bold" "Version"}}:    	{{ $v }}
+{{- end }}
 
 {{decorate "inputresources" ""}}{{decorate "underline bold" "Input Resources\n"}}
 
@@ -244,6 +247,7 @@ func printTaskDescription(s *cli.Stream, p cli.Params, tname string) error {
 		"decorate":        formatted.DecorateAttr,
 		"autoStepName":    formatted.AutoStepName,
 		"formatDesc":      formatted.FormatDesc,
+		"findVersion":     formatted.FindVersion,
 	}
 
 	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full.golden
@@ -1,6 +1,7 @@
 Name:          task-1
 Namespace:     ns
 Description:   a test description
+Version:       0.1
 
 Input Resources
 

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_Different_Labels.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_Different_Labels.golden
@@ -1,0 +1,31 @@
+Name:          task-1
+Namespace:     ns
+Description:   a test description
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Steps
+
+ hello
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_Empty_Labels.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_Empty_Labels.golden
@@ -1,0 +1,31 @@
+Name:          task-1
+Namespace:     ns
+Description:   a test description
+
+Input Resources
+
+ No input resources
+
+Output Resources
+
+ No output resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Steps
+
+ hello
+
+Taskruns
+
+ No taskruns

--- a/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
+++ b/pkg/cmd/task/testdata/TestTaskV1beta1Describe_Full.golden
@@ -1,6 +1,7 @@
 Name:          task-1
 Namespace:     ns
 Description:   a test description
+Version:       0.1
 
 Input Resources
 

--- a/pkg/formatted/version.go
+++ b/pkg/formatted/version.go
@@ -1,0 +1,22 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+func FindVersion(version map[string]string) string {
+	if _, ok := version["app.kubernetes.io/version"]; ok {
+		return version["app.kubernetes.io/version"]
+	}
+	return ""
+}

--- a/pkg/formatted/version_test.go
+++ b/pkg/formatted/version_test.go
@@ -1,0 +1,41 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatted
+
+import (
+	"testing"
+
+	"github.com/tektoncd/cli/pkg/test"
+)
+
+func TestVersion(t *testing.T) {
+	version := make(map[string]string)
+
+	version["app.kubernetes.io/version"] = "v1"
+
+	out := FindVersion(version)
+
+	test.AssertOutput(t, "v1", out)
+}
+
+func TestWithoutVersion(t *testing.T) {
+	version := make(map[string]string)
+
+	version["tekton.dev/name:foo"] = "v1"
+
+	out := FindVersion(version)
+
+	test.AssertOutput(t, "", out)
+}


### PR DESCRIPTION
 - This patch adds a version field in the
    describe command of task

 - For e.g.

```
╰─ tkn task describe
Name:          buildah
Namespace:     default
Description:   Buildah task builds source into a container image and then pushes it to a container registry.
Buildah Task builds source into a container image using Project Atomic's Buildah build tool.
Version:   0.2     <------- Version of the resource
```

- If the resource doesn't have a version then it won't show 
 the version field in the output of describe command

Fixes : https://github.com/tektoncd/cli/issues/1264
Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
