### PR TITLE
Support `output` option for pipeline/task `start` command

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -49,7 +49,7 @@ For passing the workspaces via flags:
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.
   -L, --last                     re-run the ClusterTask using last TaskRun values
-      --output string            format of TaskRun dry-run (yaml or json)
+      --output string            format of TaskRun (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
       --pod-template string      local or remote file containing a PodTemplate definition

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -56,7 +56,7 @@ my-secret, my-empty-dir and my-volume-claim-template)
   -h, --help                          help for start
   -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the Pipeline using last PipelineRun values
-      --output string                 format of PipelineRun dry-run (yaml or json)
+      --output string                 format of PipelineRun (yaml or json)
   -p, --param stringArray             pass the param as key=value for string type, or key=value1,value2,... for array type
       --pod-template string           local or remote file containing a PodTemplate definition
       --prefix-name string            specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -49,7 +49,7 @@ For passing the workspaces via flags:
   -i, --inputresource strings    pass the input resource name and ref as name=ref
   -l, --labels strings           pass labels as label=value.
   -L, --last                     re-run the Task using last TaskRun values
-      --output string            format of TaskRun dry-run (yaml or json)
+      --output string            format of TaskRun (yaml or json)
   -o, --outputresource strings   pass the output resource name and ref as name=ref
   -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
       --pod-template string      local or remote file containing a PodTemplate definition

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -41,7 +41,7 @@ Start ClusterTasks
 
 .PP
 \fB\-\-output\fP=""
-    format of TaskRun dry\-run (yaml or json)
+    format of TaskRun (yaml or json)
 
 .PP
 \fB\-o\fP, \fB\-\-outputresource\fP=[]

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -49,7 +49,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-\-output\fP=""
-    format of PipelineRun dry\-run (yaml or json)
+    format of PipelineRun (yaml or json)
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -45,7 +45,7 @@ Start Tasks
 
 .PP
 \fB\-\-output\fP=""
-    format of TaskRun dry\-run (yaml or json)
+    format of TaskRun (yaml or json)
 
 .PP
 \fB\-o\fP, \fB\-\-outputresource\fP=[]


### PR DESCRIPTION
# Changes

Support `output` option for pipeline/task `start` command.

Current `start` command output returns human friendly message, which can make other programs to hard to parse created resource.

This can be useful in CI environment, for example, 
after resource is created, we can use jq or yq for parsing created resource and wait until resource is terminated without using `showlog` option.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Support `output` option for pipeline/task `start` command which allows to parse created resource by other programs
```