### PR TITLE
Fix clustertask start command with --last flag

### DIFF
--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -322,7 +322,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "taskrun-123",
 				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/task": "clustertask-1"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "clustertask-1"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
 				Params: []v1alpha1.Param{
@@ -1095,7 +1095,7 @@ func Test_ClusterTask_Start_v1beta1(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "taskrun-123",
 				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/task": "clustertask-1"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "clustertask-1"},
 			},
 			Spec: v1beta1.TaskRunSpec{
 				Params: []v1beta1.Param{
@@ -1966,7 +1966,7 @@ func Test_start_clustertask_last_override_timeout(t *testing.T) {
 
 			ObjectMeta: v1.ObjectMeta{
 				Name:      trName,
-				Labels:    map[string]string{"tekton.dev/clustertask": "clustertask"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "clustertask"},
 				Namespace: "ns",
 			},
 			Spec: v1beta1.TaskRunSpec{

--- a/pkg/task/tasklastrun_test.go
+++ b/pkg/task/tasklastrun_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 const (
@@ -134,4 +136,189 @@ func TestTaskrunLatest_no_run(t *testing.T) {
 
 	expected := "no TaskRuns related to Task task found in namespace ns"
 	test.AssertOutput(t, expected, err.Error())
+}
+
+func TestTaskrunLatestForClusterTask_two_run(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	var (
+		taskCreated = clock.Now().Add(5 * time.Minute)
+
+		firstRunCreated   = clock.Now().Add(10 * time.Minute)
+		firstRunStarted   = firstRunCreated.Add(2 * time.Second)
+		firstRunCompleted = firstRunStarted.Add(10 * time.Minute)
+
+		secondRunCreated   = firstRunCreated.Add(1 * time.Minute)
+		secondRunStarted   = secondRunCreated.Add(2 * time.Second)
+		secondRunCompleted = secondRunStarted.Add(5 * time.Minute)
+	)
+	clustertasks := []*v1alpha1.ClusterTask{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "task",
+				CreationTimestamp: v1.Time{Time: taskCreated},
+			},
+		},
+	}
+	taskruns := []*v1alpha1.TaskRun{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "tr-1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: firstRunCreated},
+				Labels:            map[string]string{"tekton.dev/clusterTask": "task"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "task",
+					Kind: v1alpha1.ClusterTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &v1.Time{Time: firstRunStarted},
+					CompletionTime: &v1.Time{Time: firstRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "tr-2",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: secondRunCompleted},
+				Labels:            map[string]string{"tekton.dev/clusterTask": "task"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "task",
+					Kind: v1alpha1.ClusterTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &v1.Time{Time: secondRunStarted},
+					CompletionTime: &v1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+	}
+	cs, _ := test.SeedTestData(t, pipelinetest.Data{
+		ClusterTasks: clustertasks,
+		TaskRuns:     taskruns,
+	})
+	cs.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"clustertask", "taskrun"})
+	tdc := testDynamic.Options{}
+	dc, _ := tdc.Client(
+		cb.UnstructuredCT(clustertasks[0], versionA1),
+		cb.UnstructuredTR(taskruns[0], versionA1),
+		cb.UnstructuredTR(taskruns[1], versionA1),
+	)
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Dynamic: dc}
+	client, err := p.Clients()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	lastRun, err := LastRun(client, "task", "ns", "ClusterTask")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	test.AssertOutput(t, "tr-2", lastRun.Name)
+}
+
+func TestFilterByRef(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	var (
+		firstRunCreated   = clock.Now().Add(10 * time.Minute)
+		firstRunStarted   = firstRunCreated.Add(2 * time.Second)
+		firstRunCompleted = firstRunStarted.Add(10 * time.Minute)
+
+		secondRunCreated   = firstRunCreated.Add(1 * time.Minute)
+		secondRunStarted   = secondRunCreated.Add(2 * time.Second)
+		secondRunCompleted = secondRunStarted.Add(5 * time.Minute)
+	)
+	taskruns := []v1beta1.TaskRun{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "tr-1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: firstRunCreated},
+				Labels:            map[string]string{"tekton.dev/task": "task"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "task",
+					Kind: v1alpha1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &v1.Time{Time: firstRunStarted},
+					CompletionTime: &v1.Time{Time: firstRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "tr-2",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: secondRunCompleted},
+				Labels:            map[string]string{"tekton.dev/clusterTask": "task"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
+					Name: "task",
+					Kind: v1alpha1.ClusterTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &v1.Time{Time: secondRunStarted},
+					CompletionTime: &v1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+	}
+
+	filteredClusterTask := FilterByRef(taskruns, "ClusterTask")
+
+	test.AssertOutput(t, "tr-2", filteredClusterTask[0].Name)
+
+	filteredTask := FilterByRef(taskruns, "Task")
+
+	test.AssertOutput(t, "tr-1", filteredTask[0].Name)
 }


### PR DESCRIPTION
# Changes

`tkn clustertask start` command with `--last` flag was checking for the
label `tekton.dev/task=name` in the created taskruns since any taskrun
created from clustertask had the labels `tekton.dev/clusterTask=name`
and `tekton.dev/task=name`.

Since pipelines 0.22 release the label `tekton.dev/task=name` has been
removed from the taskruns which were created from clustertasks.
See: https://github.com/tektoncd/pipeline/pull/3764

Fixing this in pkg/task/tasklastrun.go and adding corresponding tests.

Closes #1331 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```