### PR TITLE
Print status in `tkn p start` if it is not nil

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -398,7 +398,9 @@ func (opt *startOptions) getInputResources(resources resourceOptionsFilter, pipe
 			if err != nil {
 				return err
 			}
-			fmt.Printf("resource status %s\n\n", newres.Status)
+			if newres.Status != nil {
+				fmt.Printf("resource status %s\n\n", newres.Status)
+			}
 			opt.Resources = append(opt.Resources, res.Name+"="+newres.Name)
 			continue
 		}


### PR DESCRIPTION
# Changes

When doing an interactive `tkn pipeline start pipelinename`,
a `PipelineResource` is created interactively and after the
`PipelineResource` is created successfully it should not
give any resource status since it would be `nil`.

Added an `if` condition which will print the status iff the status is
not `nil`.

Signed-off-by: vinamra28 <vinjain@redhat.com>

Closes #1337 
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```