### PR TITLE
Fix eventListener test with latest minimal triggers permissions

### DIFF
--- a/test/e2e/eventListener/eventListener_test.go
+++ b/test/e2e/eventListener/eventListener_test.go
@@ -99,7 +99,7 @@ func createResources(t *testing.T, c *framework.Clients, namespace string) {
 			ObjectMeta: metav1.ObjectMeta{Name: "sa-clusterrole"},
 			Rules: []rbacv1.PolicyRule{{
 				APIGroups: []string{"triggers.tekton.dev"},
-				Resources: []string{"clustertriggerbindings"},
+				Resources: []string{"clustertriggerbindings", "clusterinterceptors"},
 				Verbs:     []string{"get", "list", "watch"},
 			}},
 		}, metav1.CreateOptions{},

--- a/test/resources/eventlistener/eventlistener.yaml
+++ b/test/resources/eventlistener/eventlistener.yaml
@@ -108,7 +108,7 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Without permission to list `triggers` and `clusterinterceptors` e2e eventListener test fails to start listener-interceptor using latest nightly triggers release.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```

