### PR TITLE
Fix clustertask describe and delete, task lastrun

### DIFF
--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/cli/pkg/deleter"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/options"
-	"github.com/tektoncd/cli/pkg/task"
 	trlist "github.com/tektoncd/cli/pkg/taskrun/list"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -116,14 +115,12 @@ func deleteClusterTasks(opts *options.DeleteOptions, s *cli.Stream, p cli.Params
 func taskRunLister(cs *cli.Clients, p cli.Params) func(string) ([]string, error) {
 	return func(taskName string) ([]string, error) {
 		lOpts := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("tekton.dev/task=%s", taskName),
+			LabelSelector: fmt.Sprintf("tekton.dev/clusterTask=%s", taskName),
 		}
 		taskRuns, err := trlist.TaskRuns(cs, lOpts, p.Namespace())
 		if err != nil {
 			return nil, err
 		}
-		// this is required as the same label is getting added for both task and ClusterTask
-		taskRuns.Items = task.FilterByRef(taskRuns.Items, "ClusterTask")
 		var names []string
 		for _, tr := range taskRuns.Items {
 			names = append(names, tr.Name)

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -69,7 +69,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "ns",
 				Name:      "task-run-1",
-				Labels:    map[string]string{"tekton.dev/task": "tomatoes"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "tomatoes"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
 				TaskRef: &v1alpha1.TaskRef{
@@ -92,7 +92,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "ns",
 				Name:      "task-run-2",
-				Labels:    map[string]string{"tekton.dev/task": "tomatoes"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "tomatoes"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
 				TaskRef: &v1alpha1.TaskRef{
@@ -358,7 +358,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "ns",
 				Name:      "task-run-1",
-				Labels:    map[string]string{"tekton.dev/task": "tomatoes"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "tomatoes"},
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{
@@ -381,7 +381,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "ns",
 				Name:      "task-run-2",
-				Labels:    map[string]string{"tekton.dev/task": "tomatoes"},
+				Labels:    map[string]string{"tekton.dev/clusterTask": "tomatoes"},
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{

--- a/pkg/cmd/clustertask/describe.go
+++ b/pkg/cmd/clustertask/describe.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tektoncd/cli/pkg/clustertask"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/options"
-	"github.com/tektoncd/cli/pkg/task"
 	"github.com/tektoncd/cli/pkg/taskrun/list"
 	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -212,15 +211,12 @@ func printClusterTaskDescription(s *cli.Stream, p cli.Params, tname string) erro
 	}
 
 	opts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("tekton.dev/task=%s", tname),
+		LabelSelector: fmt.Sprintf("tekton.dev/clusterTask=%s", tname),
 	}
 	taskRuns, err := list.TaskRuns(cs, opts, p.Namespace())
 	if err != nil {
 		return fmt.Errorf("failed to get TaskRuns for ClusterTask %s", tname)
 	}
-
-	// this is required as the same label is getting added for both task and ClusterTask
-	taskRuns.Items = task.FilterByRef(taskRuns.Items, "ClusterTask")
 
 	trsort.SortByStartTime(taskRuns.Items)
 

--- a/pkg/cmd/clustertask/describe_test.go
+++ b/pkg/cmd/clustertask/describe_test.go
@@ -167,7 +167,7 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 				Name:      "taskrun-1",
 				Namespace: "ns",
 				Labels: map[string]string{
-					"tekton.dev/task": "clustertask-full",
+					"tekton.dev/clusterTask": "clustertask-full",
 				},
 			},
 			Spec: v1alpha1.TaskRunSpec{
@@ -235,7 +235,7 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 				Name:      "taskrun-2",
 				Namespace: "ns",
 				Labels: map[string]string{
-					"tekton.dev/task": "clustertask-one-everything",
+					"tekton.dev/clusterTask": "clustertask-one-everything",
 				},
 			},
 			Spec: v1alpha1.TaskRunSpec{
@@ -286,7 +286,7 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 				Name:      "taskrun-3",
 				Namespace: "ns",
 				Labels: map[string]string{
-					"tekton.dev/task": "clustertask-full",
+					"tekton.dev/clusterTask": "clustertask-full",
 				},
 			},
 			Spec: v1alpha1.TaskRunSpec{

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -48,6 +48,10 @@ func LastRun(cs *cli.Clients, resourceName, ns, kind string) (*v1beta1.TaskRun, 
 		return nil, fmt.Errorf("no TaskRuns related to %s %s found in namespace %s", kind, resourceName, ns)
 	}
 
+	if kind == "Task" {
+		runs.Items = FilterByRef(runs.Items, kind)
+	}
+
 	latest := runs.Items[0]
 	for _, run := range runs.Items {
 		if run.CreationTimestamp.Time.After(latest.CreationTimestamp.Time) {


### PR DESCRIPTION
This will fix the clustertask describe and delete cmd because of the
tekton.dev/task label being removed from taskruns of clustertasks

Also fix the lastrun func in case of task, because for older version
tekton.dev/task label will be there on taskruns of both task and clustertask

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix clustertask describe and delete, task lastrun
```
