### PR TITLE
Fix eventlistener describe command crashing without template

### DIFF
--- a/pkg/cmd/eventlistener/describe.go
+++ b/pkg/cmd/eventlistener/describe.go
@@ -59,7 +59,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .EventListener.Name }}
 
  No EventListenerTriggers
 {{- else }}
-{{ " " }}
+{{ "" }}
 {{- range $v := .EventListener.Spec.Triggers }}
 {{decorate "bold" "EventListenerTriggers\n"}}
 
@@ -67,9 +67,11 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .EventListener.Name }}
 {{- else }}
  NAME
  {{decorate "bullet" $v.Name }}
-{{ " " }}
+{{ "" }}
 {{- end }}
 
+{{- if not $v.Bindings }}
+{{- else }}
 {{- if ne (len $v.Bindings) 0 }}
  {{decorate "" "BINDINGS\n"}}
 {{- if isBindingRefExist $v.Bindings }}
@@ -79,7 +81,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .EventListener.Name }}
   {{ decorate "bullet" $b.Ref }}	{{ $b.Kind }}	{{ $b.APIVersion }}
 {{- end }}
 {{- end }}
-{{ " " }}
+{{ "" }}
 {{- end }}
 {{- if isBindingNameExist $v.Bindings }}
   NAME	VALUE
@@ -88,25 +90,38 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .EventListener.Name }}
   {{ decorate "bullet" $b.Name }}	{{ $b.Value }}
 {{- end }}
 {{- end }}
-{{ " " }}
+{{ "" }}
 {{- end }}
 
 {{- end }}
+{{- end }}
+{{- if not $v.Template }}
+{{- else }}
 {{- if isTemplateRefExist $v.Template }}
  TEMPLATE REF	APIVERSION
  {{ decorate "bullet" $v.Template.Ref }}	{{ $v.Template.APIVersion }}
+ {{ "" }}
+{{- end }}
+{{- end }}
+{{- if eq $v.TriggerRef "" }}
+{{- else }}
+ TRIGGER REF
+ {{ decorate "bullet" $v.TriggerRef }}
+ {{ "" }}
 {{- end }}
 {{- if eq $v.ServiceAccountName "" }}
 {{- else }}
-{{ " " }}
  SERVICE ACCOUNT NAME
  {{ decorate "bullet" $v.ServiceAccountName }}
+ {{ "" }}
 {{- end }}
-{{ " " }}
+{{- if not $v.Interceptors }}
+{{- else }}
 {{- if ne (len $v.Interceptors) 0 }}
  INTERCEPTORS
 {{- $b := getInterceptors $v.Interceptors }}
 {{ $b }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/pkg/cmd/eventlistener/describe_test.go
+++ b/pkg/cmd/eventlistener/describe_test.go
@@ -195,6 +195,53 @@ func TestEventListenerDescribe_TriggerWithTriggerTemplateRef(t *testing.T) {
 	executeEventListenerCommand(t, els)
 }
 
+func TestEventListenerDescribe_TriggerWithTriggerTemplateRefTriggerRef(t *testing.T) {
+	bindingval := "somevalue"
+	tempRef := "someref"
+
+	els := []*v1alpha1.EventListener{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "el1",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{
+					{
+						Bindings: []*v1alpha1.EventListenerBinding{
+							{
+								Name:  "binding",
+								Value: &bindingval,
+							},
+						},
+						Template: &v1alpha1.EventListenerTemplate{
+							Ref:        &tempRef,
+							APIVersion: "v1alpha1",
+						},
+						Name:               "tt1",
+						TriggerRef:         "triggeref",
+						ServiceAccountName: "test-sa",
+						Interceptors: []*v1alpha1.EventInterceptor{
+							{
+								Webhook: &v1alpha1.WebhookInterceptor{
+									ObjectRef: &corev1.ObjectReference{
+										Kind:       "Service",
+										Name:       "testwebhook",
+										APIVersion: "v1",
+										Namespace:  "ns",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeEventListenerCommand(t, els)
+}
+
 func TestEventListenerDescribe_OneTriggerWithEmptyTriggerBinding(t *testing.T) {
 	els := []*v1alpha1.EventListener{
 		el.EventListener("el1", "ns",
@@ -245,6 +292,23 @@ func TestEventListenerDescribe_WithWebhookInterceptorsWithParams(t *testing.T) {
 	els := []*v1alpha1.EventListener{
 		el.EventListener("el1", "ns",
 			el.EventListenerSpec(
+				el.EventListenerTrigger("tt1", "v1alpha1",
+					el.EventListenerTriggerBinding("tb1", "", ""),
+					el.EventListenerTriggerBinding("tb2", "ClusterTriggerBinding", "v1alpha1"),
+					el.EventListenerTriggerBinding("tb3", "", "v1alpha1"),
+					el.EventListenerTriggerName("foo-trig"),
+					el.EventListenerTriggerInterceptor("foo", "v1", "Service", "namespace",
+						el.EventInterceptorParam("header", "value"))))),
+	}
+
+	executeEventListenerCommand(t, els)
+}
+
+func TestEventListenerDescribe_MultipleTriggerWithTriggerRefAndTriggerSpec(t *testing.T) {
+	els := []*v1alpha1.EventListener{
+		el.EventListener("el1", "ns",
+			el.EventListenerSpec(
+				el.EventListenerTriggerRef("test-ref"),
 				el.EventListenerTrigger("tt1", "v1alpha1",
 					el.EventListenerTriggerBinding("tb1", "", ""),
 					el.EventListenerTriggerBinding("tb2", "ClusterTriggerBinding", "v1alpha1"),

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_MultipleTriggerWithTriggerRefAndTriggerSpec.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_MultipleTriggerWithTriggerRefAndTriggerSpec.golden
@@ -3,6 +3,11 @@ Namespace:   ns
 
 EventListenerTriggers
 
+ TRIGGER REF
+ test-ref
+ 
+EventListenerTriggers
+
  NAME
  foo-trig
 

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_MultipleTriggers.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_MultipleTriggers.golden
@@ -1,6 +1,6 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  BINDINGS
@@ -9,7 +9,7 @@ EventListenerTriggers
   tb1   TriggerBinding          
   tb2   ClusterTriggerBinding   v1alpha1
   tb3   TriggerBinding          v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  
@@ -21,7 +21,7 @@ EventListenerTriggers
   tb1   TriggerBinding          
   tb2   ClusterTriggerBinding   v1alpha1
   tb3   TriggerBinding          v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt2            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithEmptyTriggerBinding.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithEmptyTriggerBinding.golden
@@ -1,6 +1,6 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  TEMPLATE REF   APIVERSION

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithMultipleTriggerBinding.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithMultipleTriggerBinding.golden
@@ -1,6 +1,6 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  BINDINGS
@@ -9,7 +9,7 @@ EventListenerTriggers
   tb1   TriggerBinding          
   tb2   ClusterTriggerBinding   v1alpha1
   tb3   TriggerBinding          v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithOneClusterTriggerBinding.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithOneClusterTriggerBinding.golden
@@ -1,13 +1,13 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  BINDINGS
 
   REF   KIND                    APIVERSION
   tb1   ClusterTriggerBinding   v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithOneTriggerBinding.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithOneTriggerBinding.golden
@@ -1,14 +1,14 @@
 Name:              el1
 Namespace:         ns
 Service Account:   trigger-sa
- 
+
 EventListenerTriggers
 
  BINDINGS
 
   REF   KIND             APIVERSION
   tb1   TriggerBinding   
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithTriggerBindingName.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_OneTriggerWithTriggerBindingName.golden
@@ -1,14 +1,13 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  NAME
  tt1
- 
+
  BINDINGS
 
   NAME      VALUE
   binding   somevalue
- 
- 
+

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_TriggerWithTriggerTemplateRef.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_TriggerWithTriggerTemplateRef.golden
@@ -1,16 +1,16 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  NAME
  tt1
- 
+
  BINDINGS
 
   NAME      VALUE
   binding   somevalue
- 
+
  TEMPLATE REF   APIVERSION
  someref        v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_TriggerWithTriggerTemplateRefTriggerRef.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_TriggerWithTriggerTemplateRefTriggerRef.golden
@@ -1,0 +1,30 @@
+Name:        el1
+Namespace:   ns
+
+EventListenerTriggers
+
+ NAME
+ tt1
+
+ BINDINGS
+
+  NAME      VALUE
+  binding   somevalue
+
+ TEMPLATE REF   APIVERSION
+ someref        v1alpha1
+ 
+ TRIGGER REF
+ triggeref
+ 
+ SERVICE ACCOUNT NAME
+ test-sa
+ 
+ INTERCEPTORS
+- webhook:
+    objectRef:
+      apiVersion: v1
+      kind: Service
+      name: testwebhook
+      namespace: ns
+

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithCELInterceptors.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithCELInterceptors.golden
@@ -1,18 +1,18 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  NAME
  foo-trig
- 
+
  BINDINGS
 
   REF   KIND                    APIVERSION
   tb1   TriggerBinding          
   tb2   ClusterTriggerBinding   v1alpha1
   tb3   TriggerBinding          v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithMultipleBindingAndInterceptors.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithMultipleBindingAndInterceptors.golden
@@ -1,17 +1,17 @@
 Name:        el1
 Namespace:   ns
- 
+
 EventListenerTriggers
 
  NAME
  foo-trig
- 
+
  BINDINGS
 
   REF   KIND                    APIVERSION
   tb1   TriggerBinding          
   tb2   ClusterTriggerBinding   v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  
@@ -26,13 +26,13 @@ EventListenerTriggers
 
  NAME
  foo-trig
- 
+
  BINDINGS
 
   REF   KIND                    APIVERSION
   tb4   TriggerBinding          
   tb5   ClusterTriggerBinding   v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt2            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithOutputStatusURLAndName.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithOutputStatusURLAndName.golden
@@ -2,14 +2,14 @@ Name:                      el1
 Namespace:                 ns
 URL:                       http://el-listener.default.svc.cluster.local
 EventListnerServiceName:   el-listener
- 
+
 EventListenerTriggers
 
  BINDINGS
 
   REF   KIND                    APIVERSION
   tb1   ClusterTriggerBinding   v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithWebhookInterceptors.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_WithWebhookInterceptors.golden
@@ -2,19 +2,19 @@ Name:                      el1
 Namespace:                 ns
 URL:                       http://el-listener.default.svc.cluster.local
 EventListnerServiceName:   el-listener
- 
+
 EventListenerTriggers
 
  NAME
  foo-trig
- 
+
  BINDINGS
 
   REF   KIND                    APIVERSION
   tb1   TriggerBinding          
   tb2   ClusterTriggerBinding   v1alpha1
   tb3   TriggerBinding          v1alpha1
- 
+
  TEMPLATE REF   APIVERSION
  tt1            v1alpha1
  


### PR DESCRIPTION
This will fix the issue of eventlistener describe command crashing when not
using binding, template etc and also not showing details for trigger ref

Improve the formatting regarding spacing etc

Fix #1345

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix eventlistener describe command crashing without template
```
