### PR TITLE
Auto-select EventListener in describe if only one is present

### DIFF
--- a/pkg/cmd/eventlistener/describe_test.go
+++ b/pkg/cmd/eventlistener/describe_test.go
@@ -430,6 +430,42 @@ func TestEventListenerDescribe_OutputStatusURL_WithNoURL(t *testing.T) {
 	test.AssertOutput(t, "Error: "+err.Error()+"\n", out)
 }
 
+func TestEventListenerDescribe_AutoSelect(t *testing.T) {
+	triggerTemplateRef := "tt1"
+	els := []*v1alpha1.EventListener{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "el1",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{
+					{
+						Template: &v1alpha1.TriggerSpecTemplate{
+							Ref:        &triggerTemplateRef,
+							APIVersion: "v1alpha1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els, Namespaces: []*corev1.Namespace{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+		},
+	}}})
+	p := &test.Params{Triggers: cs.Triggers, Kube: cs.Kube}
+
+	eventListener := Command(p)
+	out, err := test.ExecuteCommand(eventListener, "desc", "-n", "ns")
+	if err != nil {
+		t.Errorf("Error expected here")
+	}
+	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
+}
+
 func executeEventListenerCommand(t *testing.T, els []*v1alpha1.EventListener) {
 	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els, Namespaces: []*corev1.Namespace{{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_AutoSelect.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_AutoSelect.golden
@@ -1,0 +1,8 @@
+Name:        el1
+Namespace:   ns
+
+EventListenerTriggers
+
+ TEMPLATE REF   APIVERSION
+ tt1            v1alpha1
+ 

--- a/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_NoArgProvided.golden
+++ b/pkg/cmd/eventlistener/testdata/TestEventListenerDescribe_NoArgProvided.golden
@@ -1,1 +1,1 @@
-Error: requires at least 1 arg(s), only received 0
+Error: no EventListeners found

--- a/pkg/eventlistener/eventlistener.go
+++ b/pkg/eventlistener/eventlistener.go
@@ -1,0 +1,55 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventlistener
+
+import (
+	"context"
+
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func GetAllEventListenerNames(client versioned.Interface, namespace string) ([]string, error) {
+
+	ps, err := List(client, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []string{}
+	for _, item := range ps.Items {
+		ret = append(ret, item.ObjectMeta.Name)
+	}
+	return ret, nil
+}
+
+func List(client versioned.Interface, namespace string) (*v1alpha1.EventListenerList, error) {
+	els, err := client.TriggersV1alpha1().EventListeners(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: this is required for -o json|yaml to work properly since
+	// tektoncd go client fails to set these; probably a bug
+	els.GetObjectKind().SetGroupVersionKind(
+		schema.GroupVersionKind{
+			Version: "triggers.tekton.dev/v1alpha1",
+			Kind:    "EventListenerList",
+		})
+
+	return els, nil
+}

--- a/pkg/eventlistener/eventlistener_test.go
+++ b/pkg/eventlistener/eventlistener_test.go
@@ -1,0 +1,180 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventlistener
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggertest "github.com/tektoncd/triggers/test"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEventListener_GetAllEventListenerNames(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	els := []*v1alpha1.EventListener{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "el1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+	}
+
+	els2 := []*v1alpha1.EventListener{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "el1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "el2",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+	}
+
+	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els, Namespaces: []*corev1.Namespace{{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "ns",
+		},
+	}}})
+	cs2 := test.SeedTestResources(t, triggertest.Resources{EventListeners: els2, Namespaces: []*corev1.Namespace{{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "ns",
+		},
+	}}})
+	p := &test.Params{Triggers: cs.Triggers, Kube: cs.Kube}
+	p2 := &test.Params{Triggers: cs2.Triggers, Kube: cs2.Kube}
+	p3 := &test.Params{Triggers: cs2.Triggers, Kube: cs2.Kube}
+	p3.SetNamespace("unknown")
+
+	testParams := []struct {
+		name   string
+		params *test.Params
+		want   []string
+	}{
+		{
+			name:   "Single EventListener",
+			params: p,
+			want:   []string{"el1"},
+		},
+		{
+			name:   "Multi EventListeners",
+			params: p2,
+			want:   []string{"el1", "el2"},
+		},
+		{
+			name:   "Unknown namespace",
+			params: p3,
+			want:   []string{},
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			got, err := GetAllEventListenerNames(tp.params.Triggers, tp.params.Namespace())
+			if err != nil {
+				t.Errorf("unexpected Error")
+			}
+			test.AssertOutput(t, tp.want, got)
+		})
+	}
+}
+
+func TestEventListener_List(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	els := []*v1alpha1.EventListener{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "el1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+	}
+
+	els2 := []*v1alpha1.EventListener{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "el1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "el2",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+	}
+
+	cs := test.SeedTestResources(t, triggertest.Resources{EventListeners: els, Namespaces: []*corev1.Namespace{{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "ns",
+		},
+	}}})
+	cs2 := test.SeedTestResources(t, triggertest.Resources{EventListeners: els2, Namespaces: []*corev1.Namespace{{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "ns",
+		},
+	}}})
+	p := &test.Params{Triggers: cs.Triggers, Kube: cs.Kube}
+	p2 := &test.Params{Triggers: cs2.Triggers, Kube: cs2.Kube}
+
+	testParams := []struct {
+		name   string
+		params *test.Params
+		want   []string
+	}{
+		{
+			name:   "Single EventListener",
+			params: p,
+			want:   []string{"el1"},
+		},
+		{
+			name:   "Multi EventListeners",
+			params: p2,
+			want:   []string{"el1", "el2"},
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			got, err := List(tp.params.Triggers, "ns")
+			if err != nil {
+				t.Errorf("unexpected Error")
+			}
+			elnames := []string{}
+			for _, el := range got.Items {
+				elnames = append(elnames, el.Name)
+			}
+			test.AssertOutput(t, tp.want, elnames)
+		})
+	}
+}

--- a/pkg/options/describe.go
+++ b/pkg/options/describe.go
@@ -40,6 +40,7 @@ type DescribeOptions struct {
 	Tasks                     []string
 	TriggerTemplateName       string
 	TriggerBindingName        string
+	EventListenerName         string
 	ClusterTriggerBindingName string
 	Limit                     int
 	AskOpts                   survey.AskOpt
@@ -103,6 +104,8 @@ func (opts *DescribeOptions) Ask(resource string, options []string) error {
 		opts.TriggerBindingName = ans
 	case ResourceNameClusterTriggerBinding:
 		opts.ClusterTriggerBindingName = ans
+	case ResourceNameEventListener:
+		opts.EventListenerName = ans
 	}
 
 	return nil
@@ -165,6 +168,8 @@ func (opts *DescribeOptions) FuzzyAsk(resource string, options []string) error {
 		opts.TriggerBindingName = ans
 	case ResourceNameClusterTriggerBinding:
 		opts.ClusterTriggerBindingName = ans
+	case ResourceNameEventListener:
+		opts.EventListenerName = ans
 	}
 
 	return nil

--- a/pkg/options/describe_test.go
+++ b/pkg/options/describe_test.go
@@ -94,10 +94,17 @@ func TestDescribeOptions_Ask(t *testing.T) {
 		"pipeline-resource2",
 		"pipeline-resource3",
 	}
+
 	options6 := []string{
 		"clustertask1",
 		"clustertask2",
 		"clustertask3",
+	}
+
+	options7 := []string{
+		"eventlistener1",
+		"eventlistener2",
+		"eventlistener3",
 	}
 
 	options8 := []string{
@@ -151,6 +158,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -179,6 +187,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -207,6 +216,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -235,6 +245,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -263,6 +274,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -291,6 +303,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -319,6 +332,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -347,6 +361,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -375,6 +390,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -403,6 +419,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -431,6 +448,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -458,6 +476,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				ClusterTaskName:           "clustertask3",
 				TriggerTemplateName:       "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -486,6 +505,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "triggertemplate3",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -514,6 +534,7 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "triggerbinding3",
 				ClusterTriggerBindingName: "",
+				EventListenerName:         "",
 			},
 		},
 		{
@@ -542,6 +563,33 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
 				ClusterTriggerBindingName: "clustertriggerbinding3",
+				EventListenerName:         "",
+			},
+		},
+		{
+			name:     "select eventlistener name option 3",
+			resource: ResourceNameEventListener,
+			prompt: prompt.Prompt{
+				CmdArgs: []string{},
+				Procedure: func(c *goexpect.Console) error {
+					if _, err := c.ExpectString("Select eventlistener:"); err != nil {
+						return err
+					}
+					if _, err := c.SendLine(options7[2]); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			options: options7,
+			want: DescribeOptions{
+				PipelineName:         "",
+				PipelineRunName:      "",
+				TaskName:             "",
+				TaskrunName:          "",
+				PipelineResourceName: "",
+				ClusterTaskName:      "",
+				EventListenerName:    "eventlistener3",
 			},
 		},
 	}
@@ -576,6 +624,12 @@ func TestDescribeOptions_Ask(t *testing.T) {
 			}
 			if opts.ClusterTriggerBindingName != tp.want.ClusterTriggerBindingName {
 				t.Errorf("Unexpected ClusterTriggerBinding Name")
+			}
+			if opts.ClusterTaskName != tp.want.ClusterTaskName {
+				t.Errorf("Unexpected ClusterTask Name")
+			}
+			if opts.EventListenerName != tp.want.EventListenerName {
+				t.Errorf("Unexpected EventListener Name")
 			}
 		})
 	}

--- a/pkg/options/resource_names.go
+++ b/pkg/options/resource_names.go
@@ -10,4 +10,5 @@ const (
 	ResourceNameTriggerTemplate       = "triggertemplate"
 	ResourceNameTriggerBinding        = "triggerbinding"
 	ResourceNameClusterTriggerBinding = "clustertriggerbinding"
+	ResourceNameEventListener         = "eventlistener"
 )


### PR DESCRIPTION
# Changes

- When only one EventListener is present on the cluster then it should
be auto-selected when executing the `eventlistener describe` command.

- When there are more than one EventListener then user will get an
interactive option to select and describe it.

- Created a package `pkg/eventlistener/eventlistener.go` which contains
the helper functions for EventListener and also added the tests for
same.

- Moved the `list` function from `pkg/cmd/eventlistener/list.go` to
`pkg/eventlistener/eventlistener.go`.

closes #1346 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Interactively select the EventListener if more than one is present and if only one is present then auto-select that
```