### PR TITLE
Common Description for workspace flag in start command

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -25,6 +25,21 @@ or
 For params value, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
 
+For passing the workspaces via flags:
+
+- In case of emptyDir, you can pass it like -w name=my-empty-dir,emptyDir=
+- In case of configMap, you can pass it like -w name=my-config,config=rpg,item=ultimav=1
+- In case of secrets, you can pass it like -w name=my-secret,secret=secret-name
+- In case of pvc, you can pass it like -w name=my-pvc,claimName=pvc1
+- In case of volumeClaimTemplate, you can pass it like -w name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+  but before you need to create a workspace-template.yaml file. Sample contents of the file are as follows:
+  spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
+
 
 ### Options
 
@@ -44,7 +59,7 @@ like cat,foo,bar
       --timeout string           timeout for TaskRun
       --use-param-defaults       use default parameter values without prompting for input
       --use-taskrun string       specify a TaskRun name to use its values to re-run the TaskRun
-  -w, --workspace stringArray    pass one or more workspaces to map to the corresponding physical volumes as name=name,claimName=pvcName or name=name,emptyDir=
+  -w, --workspace stringArray    pass one or more workspaces to map to the corresponding physical volumes
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -22,9 +22,20 @@ To run a Pipeline that has one git resource and no parameter.
 	$ tkn pipeline start --resource source=samples-git
 
 
+To create a workspace-template.yaml
+
+	$ cat <<EOF > workspace-template.yaml
+	spec:
+  		accessModes:
+  			- ReadWriteOnce
+  		resources:
+    		requests:
+      			storage: 1Gi
+	EOF
+
 To run a Pipeline that has one git resource, one image resource,
 two parameters (foo and bar) and four workspaces (my-config, my-pvc,
-my-secret and my-empty-dir)
+my-secret, my-empty-dir and my-volume-claim-template)
 
 
 	$ tkn pipeline start --resource source=samples-git \
@@ -35,6 +46,7 @@ my-secret and my-empty-dir)
 		--workspace name=my-config,config=rpg,item=ultimav=1 \
 		--workspace name=my-empty-dir,emptyDir="" \
 		--workspace name=my-pvc,claimName=pvc1,subPath=dir
+		--workspace name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
 
 ### Options
 
@@ -55,7 +67,7 @@ my-secret and my-empty-dir)
       --timeout string                timeout for PipelineRun
       --use-param-defaults            use default parameter values without prompting for input
       --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
-  -w, --workspace stringArray         pass the workspace.
+  -w, --workspace stringArray         pass one or more workspaces to map to the corresponding physical volumes
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -24,6 +24,21 @@ or in a file using the --filename argument.
 For params values, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
 
+For passing the workspaces via flags:
+
+- In case of emptyDir, you can pass it like -w name=my-empty-dir,emptyDir=
+- In case of configMap, you can pass it like -w name=my-config,config=rpg,item=ultimav=1
+- In case of secrets, you can pass it like -w name=my-secret,secret=secret-name
+- In case of pvc, you can pass it like -w name=my-pvc,claimName=pvc1
+- In case of volumeClaimTemplate, you can pass it like -w name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+  but before you need to create a workspace-template.yaml file. Sample contents of the file are as follows:
+  spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
+
 
 ### Options
 
@@ -44,7 +59,7 @@ like cat,foo,bar
       --timeout string           timeout for TaskRun
       --use-param-defaults       use default parameter values without prompting for input
       --use-taskrun string       specify a TaskRun name to use its values to re-run the TaskRun
-  -w, --workspace stringArray    pass the workspace.
+  -w, --workspace stringArray    pass one or more workspaces to map to the corresponding physical volumes
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -81,7 +81,7 @@ Start ClusterTasks
 
 .PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
-    pass one or more workspaces to map to the corresponding physical volumes as name=name,claimName=pvcName or name=name,emptyDir=
+    pass one or more workspaces to map to the corresponding physical volumes
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -126,6 +126,35 @@ tkn ct start foo \-n bar
 .PP
 For params value, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
+
+.PP
+For passing the workspaces via flags:
+
+.RS
+.IP \(bu 2
+In case of emptyDir, you can pass it like \-w name=my\-empty\-dir,emptyDir=
+.IP \(bu 2
+In case of configMap, you can pass it like \-w name=my\-config,config=rpg,item=ultimav=1
+.IP \(bu 2
+In case of secrets, you can pass it like \-w name=my\-secret,secret=secret\-name
+.IP \(bu 2
+In case of pvc, you can pass it like \-w name=my\-pvc,claimName=pvc1
+.IP \(bu 2
+In case of volumeClaimTemplate, you can pass it like \-w name=my\-volume\-claim\-template,volumeClaimTemplateFile=workspace\-template.yaml
+but before you need to create a workspace\-template.yaml file. Sample contents of the file are as follows:
+spec:
+accessModes:
+
+.RS
+.IP \(bu 2
+ReadWriteOnce
+resources:
+requests:
+storage: 1Gi
+
+.RE
+
+.RE
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -93,7 +93,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
-    pass the workspace.
+    pass one or more workspaces to map to the corresponding physical volumes
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -128,9 +128,28 @@ $ tkn pipeline start \-\-resource source=samples\-git
 .RE
 
 .PP
+To create a workspace\-template.yaml
+
+.PP
+.RS
+
+.nf
+$ cat <<EOF > workspace\-template.yaml
+spec:
+    accessModes:
+        \- ReadWriteOnce
+    resources:
+        requests:
+            storage: 1Gi
+EOF
+
+.fi
+.RE
+
+.PP
 To run a Pipeline that has one git resource, one image resource,
 two parameters (foo and bar) and four workspaces (my\-config, my\-pvc,
-my\-secret and my\-empty\-dir)
+my\-secret, my\-empty\-dir and my\-volume\-claim\-template)
 
 .PP
 .RS
@@ -144,6 +163,7 @@ $ tkn pipeline start \-\-resource source=samples\-git \\
     \-\-workspace name=my\-config,config=rpg,item=ultimav=1 \\
     \-\-workspace name=my\-empty\-dir,emptyDir="" \\
     \-\-workspace name=my\-pvc,claimName=pvc1,subPath=dir
+    \-\-workspace name=my\-volume\-claim\-template,volumeClaimTemplateFile=workspace\-template.yaml
 
 .fi
 .RE

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -85,7 +85,7 @@ Start Tasks
 
 .PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
-    pass the workspace.
+    pass one or more workspaces to map to the corresponding physical volumes
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -126,6 +126,35 @@ or in a file using the \-\-filename argument.
 .PP
 For params values, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
+
+.PP
+For passing the workspaces via flags:
+
+.RS
+.IP \(bu 2
+In case of emptyDir, you can pass it like \-w name=my\-empty\-dir,emptyDir=
+.IP \(bu 2
+In case of configMap, you can pass it like \-w name=my\-config,config=rpg,item=ultimav=1
+.IP \(bu 2
+In case of secrets, you can pass it like \-w name=my\-secret,secret=secret\-name
+.IP \(bu 2
+In case of pvc, you can pass it like \-w name=my\-pvc,claimName=pvc1
+.IP \(bu 2
+In case of volumeClaimTemplate, you can pass it like \-w name=my\-volume\-claim\-template,volumeClaimTemplateFile=workspace\-template.yaml
+but before you need to create a workspace\-template.yaml file. Sample contents of the file are as follows:
+spec:
+accessModes:
+
+.RS
+.IP \(bu 2
+ReadWriteOnce
+resources:
+requests:
+storage: 1Gi
+
+.RE
+
+.RE
 
 
 .SH SEE ALSO

--- a/docs/reference/cmd/pipeline_start.md
+++ b/docs/reference/cmd/pipeline_start.md
@@ -14,9 +14,20 @@ To run a Pipeline that has one git resource and no parameter.
 	$ tkn pipeline start --resource source=samples-git
 
 
+To create a workspace-template.yaml
+
+	$ cat <<EOF > workspace-template.yaml
+	spec:
+  		accessModes:
+  			- ReadWriteOnce
+  		resources:
+    		requests:
+      			storage: 1Gi
+	EOF
+
 To run a Pipeline that has one git resource, one image resource,
 two parameters (foo and bar) and four workspaces (my-config, my-pvc,
-my-secret and my-empty-dir)
+my-secret, my-empty-dir and my-volume-claim-template)
 
 
 	$ tkn pipeline start --resource source=samples-git \
@@ -27,3 +38,4 @@ my-secret and my-empty-dir)
 		--workspace name=my-config,config=rpg,item=ultimav=1 \
 		--workspace name=my-empty-dir,emptyDir="" \
 		--workspace name=my-pvc,claimName=pvc1,subPath=dir
+		--workspace name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -124,6 +124,21 @@ or
 
 For params value, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
+
+For passing the workspaces via flags:
+
+- In case of emptyDir, you can pass it like -w name=my-empty-dir,emptyDir=
+- In case of configMap, you can pass it like -w name=my-config,config=rpg,item=ultimav=1
+- In case of secrets, you can pass it like -w name=my-secret,secret=secret-name
+- In case of pvc, you can pass it like -w name=my-pvc,claimName=pvc1
+- In case of volumeClaimTemplate, you can pass it like -w name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+  but before you need to create a workspace-template.yaml file. Sample contents of the file are as follows:
+  spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
 `
 
 	c := &cobra.Command{
@@ -170,7 +185,7 @@ like cat,foo,bar
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the ClusterTask using last TaskRun values")
 	c.Flags().StringVarP(&opt.UseTaskRun, "use-taskrun", "", "", "specify a TaskRun name to use its values to re-run the TaskRun")
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
-	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass one or more workspaces to map to the corresponding physical volumes as name=name,claimName=pvcName or name=name,emptyDir=")
+	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass one or more workspaces to map to the corresponding physical volumes")
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the ClusterTask")
 	c.Flags().StringVar(&opt.TimeOut, "timeout", "", "timeout for TaskRun")
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview TaskRun without running it")

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -117,6 +117,21 @@ func startCommand(p cli.Params) *cobra.Command {
 
 For params value, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
+
+For passing the workspaces via flags:
+
+- In case of emptyDir, you can pass it like -w name=my-empty-dir,emptyDir=
+- In case of configMap, you can pass it like -w name=my-config,config=rpg,item=ultimav=1
+- In case of secrets, you can pass it like -w name=my-secret,secret=secret-name
+- In case of pvc, you can pass it like -w name=my-pvc,claimName=pvc1
+- In case of volumeClaimTemplate, you can pass it like -w name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+  but before you need to create a workspace-template.yaml file. Sample contents of the file are as follows:
+  spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
 `,
 		SilenceUsage: true,
 
@@ -167,7 +182,7 @@ like cat,foo,bar
 	)
 
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
-	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass the workspace.")
+	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass one or more workspaces to map to the corresponding physical volumes")
 	c.Flags().BoolVarP(&opt.DryRun, "dry-run", "", false, "preview PipelineRun without running it")
 	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of PipelineRun dry-run (yaml or json)")
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)")

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -132,6 +132,21 @@ or in a file using the --filename argument.
 
 For params values, if you want to provide multiple values, provide them comma separated
 like cat,foo,bar
+
+For passing the workspaces via flags:
+
+- In case of emptyDir, you can pass it like -w name=my-empty-dir,emptyDir=
+- In case of configMap, you can pass it like -w name=my-config,config=rpg,item=ultimav=1
+- In case of secrets, you can pass it like -w name=my-secret,secret=secret-name
+- In case of pvc, you can pass it like -w name=my-pvc,claimName=pvc1
+- In case of volumeClaimTemplate, you can pass it like -w name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+  but before you need to create a workspace-template.yaml file. Sample contents of the file are as follows:
+  spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 1Gi
 `,
 		SilenceUsage:      true,
 		ValidArgsFunction: formatted.ParentCompletion,
@@ -192,7 +207,7 @@ like cat,foo,bar
 		},
 	)
 	c.Flags().StringSliceVarP(&opt.Labels, "labels", "l", []string{}, "pass labels as label=value.")
-	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass the workspace.")
+	c.Flags().StringArrayVarP(&opt.Workspaces, "workspace", "w", []string{}, "pass one or more workspaces to map to the corresponding physical volumes")
 	c.Flags().BoolVarP(&opt.ShowLog, "showlog", "", false, "show logs right after starting the Task")
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a Task definition to start a TaskRun")
 	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for TaskRun")


### PR DESCRIPTION
# Changes

As of now the --workspace flag was showing different description for tkn
clustertask start command and tkn task/pipeline start was showing
something different.

Maintained the consistency in the description of tkn
clustertask/pipeline/task start subcommand for --workspace flag.

Closes #1281 
Closes #1169

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```