### PR TITLE
Fix README to point to v0.17.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download the latest binary executable for your operating system.
   brew install tektoncd-cli
 ```
 
-- Use [released tarball](https://github.com/tektoncd/cli/releases/download/v0.17.0/tkn_0.17.0_Darwin_x86_64.tar.gz)
+- Use [released tarball](https://github.com/tektoncd/cli/releases/download/v0.17.2/tkn_0.17.2_Darwin_x86_64.tar.gz)
 
   ```shell
   # Get the tar.xz
@@ -42,13 +42,13 @@ choco install tektoncd-cli --confirm
 scoop install tektoncd-cli
 ```
 
-- Use [Powershell](https://docs.microsoft.com/en-us/powershell) [released zip](https://github.com/tektoncd/cli/releases/download/v0.17.0/tkn_0.17.0_Windows_x86_64.zip)
+- Use [Powershell](https://docs.microsoft.com/en-us/powershell) [released zip](https://github.com/tektoncd/cli/releases/download/v0.17.2/tkn_0.17.2_Windows_x86_64.zip)
 
 ```powershell
 #Create directory
 New-Item -Path "$HOME/tektoncd/cli" -Type Directory
 # Download file
-Start-BitsTransfer -Source https://github.com/tektoncd/cli/releases/download/v0.17.0/tkn_0.17.0_Windows_x86_64.zip -Destination "$HOME/tektoncd/cli/."
+Start-BitsTransfer -Source https://github.com/tektoncd/cli/releases/download/v0.17.2/tkn_0.17.2_Windows_x86_64.zip -Destination "$HOME/tektoncd/cli/."
 # Uncompress zip file
 Expand-Archive $HOME/tektoncd/cli/*.zip -DestinationPath C:\Users\Developer\tektoncd\cli\.
 #Add to Windows `Environment Variables`


### PR DESCRIPTION
# Changes

Due to #1330 binary/installation links started pointing back to v0.17.0
which is an older release.

This commit fixed the README to point back to latest release ie v0.17.2.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```