### PR TITLE
Update plumbing dep to pin gke version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/hub/api v0.0.0-20210208113044-f2a63f81502c
 	github.com/tektoncd/pipeline v0.22.0
-	github.com/tektoncd/plumbing v0.0.0-20210202164343-2c1808d75b38
+	github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9
 	github.com/tektoncd/triggers v0.12.0
 	github.com/tidwall/gjson v1.6.0 // indirect
 	go.opencensus.io v0.22.5

--- a/go.sum
+++ b/go.sum
@@ -949,6 +949,8 @@ github.com/tektoncd/pipeline v0.22.0/go.mod h1:QcD1kMaXVIHA/V7RCi4NQUCR6z3plBVjm
 github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
 github.com/tektoncd/plumbing v0.0.0-20210202164343-2c1808d75b38 h1:WJj0wS+5FPoWeO9Ii4H29OTbSb4amvkVSQfRynsIaF4=
 github.com/tektoncd/plumbing v0.0.0-20210202164343-2c1808d75b38/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
+github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9 h1:ZLPo8/vilaxvpdvvdd9ZgIhhQJPkHyS5GeKK8UH4/Yo=
+github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
 github.com/tektoncd/triggers v0.12.0 h1:saRI8knol6MWP2uAaIplprwycXwusXThyUb4+vLtFGM=
 github.com/tektoncd/triggers v0.12.0/go.mod h1:WaVu+zfTS8Wa1F53FAI8ywR4oueye/OfXqtANuA00cE=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=

--- a/vendor/github.com/tektoncd/plumbing/scripts/README.md
+++ b/vendor/github.com/tektoncd/plumbing/scripts/README.md
@@ -235,7 +235,7 @@ Prerequisites:
 
 Usage:
 
-`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]`
+`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g post-file]`
 
 Where:
 
@@ -248,5 +248,7 @@ Where:
 - `extra-path` is the root path within the bucket where release are stored, empty by default
 
 - `file` is the name of the release file, `release.yaml` by default
+
+- `post-file` is the name of the 2nd release file, none by default, `interceptors.yaml` by default for triggers
 
 To summarize, the deployment job will look for the release file into `<bucket>/<extra-path>/<project>/previous/<version>/<file>`

--- a/vendor/github.com/tektoncd/plumbing/scripts/deploy-release.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/deploy-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE
+declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE POST_RELEASE_FILE
 
 # This script allows to deploy a Tekton release to the dogfooding cluster
 # by creating a job in the robocat cluster. The complete flow is:
@@ -13,7 +13,7 @@ declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELE
 # - cluster gke_tekton-nightly_europe-north1-a_robocat defined in the local kubeconfig
 
 # Read command line options
-while getopts ":p:v:b:e:f:" opt; do
+while getopts ":p:v:b:e:f:g:c:r:" opt; do
   case ${opt} in
     p )
       TEKTON_PROJECT=$OPTARG
@@ -30,10 +30,19 @@ while getopts ":p:v:b:e:f:" opt; do
     f )
       RELEASE_FILE=$OPTARG
       ;;
+    g )
+      POST_RELEASE_FILE=$OPTARG
+      ;;
+    c )
+      CONTEXT=$OPTARG
+      ;;
+    r )
+      CLUSTER_RESOURCE=$OPTARG
+      ;;
     \? )
       echo "Invalid option: $OPTARG" 1>&2
       echo 1>&2
-      echo "Usage:  deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]" 1>&2
+      echo "Usage:  deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g file] [-c context] [-r cluster-resource]" 1>&2
       ;;
     : )
       echo "Invalid option: $OPTARG requires an argument" 1>&2
@@ -59,13 +68,21 @@ if [ -z "$RELEASE_FILE" ]; then
         RELEASE_FILE="release.yaml"
     fi
 fi
+if [ -z "$POST_RELEASE_FILE" ]; then
+    if [ "$TEKTON_PROJECT" == "triggers" ]; then
+        POST_RELEASE_FILE="interceptors.yaml"
+    fi
+fi
+CONTEXT=${CONTEXT:-gke_tekton-nightly_europe-north1-a_robocat}
+CLUSTER_RESOURCE=${CLUSTER_RESOURCE:-dogfooding-tekton-deployer}
 
 # Deploy the release
-cat <<EOF | kubectl create --cluster gke_tekton-nightly_europe-north1-a_robocat -f-
+# cat <<EOF | tee
+cat <<EOF | kubectl create --cluster ${CONTEXT} -f-
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: tekton-deploy-${TEKTON_PROJECT}-${TEKTON_VERSION}-to-dogfooding-
+  generateName: tekton-deploy-${TEKTON_PROJECT}-${TEKTON_VERSION}-${CLUSTER_RESOURCE%%-*}-
   namespace: default
 spec:
   template:
@@ -88,7 +105,7 @@ spec:
             "params": {
               "target": {
                 "namespace": "tekton-pipelines",
-                "cluster-resource": "dogfooding-tekton-deployer"
+                "cluster-resource": "$CLUSTER_RESOURCE"
               },
               "tekton": {
                 "project": "$TEKTON_PROJECT",
@@ -96,11 +113,12 @@ spec:
                 "environment": "dogfooding",
                 "bucket": "$RELEASE_BUCKET",
                 "file": "$RELEASE_FILE",
+                "post-file": "$POST_RELEASE_FILE",
                 "extra-path": "$RELEASE_EXTRA_PATH"
               },
               "plumbing": {
                 "repository": "github.com/tektoncd/plumbing",
-                "revision": "master"
+                "revision": "main"
               }
             }
           }

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Default GKE version to be used with Tekton Serving
-readonly SERVING_GKE_VERSION=gke-latest
+readonly SERVING_GKE_VERSION=gke-channel-regular
 readonly SERVING_GKE_IMAGE=cos
 
 # Conveniently set GOPATH if unset

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,7 +455,7 @@ github.com/tektoncd/pipeline/pkg/remote/oci
 github.com/tektoncd/pipeline/pkg/substitution
 github.com/tektoncd/pipeline/test
 github.com/tektoncd/pipeline/test/v1alpha1
-# github.com/tektoncd/plumbing v0.0.0-20210202164343-2c1808d75b38
+# github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9
 github.com/tektoncd/plumbing/scripts
 # github.com/tektoncd/triggers v0.12.0
 github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit pins plumbing test env to gke 1.18 for the next six months
while basic auth is removed. This fixes an issue where integration
tests simply could not run because 1.19 was being used for the test
cluster env.

Major hat-tip to @jmcshane for doing the work to resolve this
problem!

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
