### PR TITLE
Fixes tkn task start to ask for params interactively if not passed

### DIFF
--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -513,8 +513,12 @@ func (opt *startOptions) getInputs() error {
 	}
 
 	params.FilterParamsByType(opt.task.Spec.Params)
-	if len(opt.Params) == 0 && !opt.Last && opt.UseTaskRun == "" {
-		if err := intOpts.TaskParams(opt.task, opt.UseParamDefaults); err != nil {
+	if !opt.Last && opt.UseTaskRun == "" {
+		skipParams, err := params.ParseParams(opt.Params)
+		if err != nil {
+			return err
+		}
+		if err := intOpts.TaskParams(opt.task, skipParams, opt.UseParamDefaults); err != nil {
 			return err
 		}
 		opt.Params = append(opt.Params, intOpts.Params...)

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -173,7 +173,8 @@ func Test_start_has_task_filename_v1alpha1(t *testing.T) {
 	}
 	c := Command(&test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Resource: cs.Resource, Dynamic: dc})
 
-	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task-v1alpha1.yaml", "-i=docker-source=/path", "-o=build-image=image", "-p=pathToDockerFile=path")
+	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task-v1alpha1.yaml",
+		"-i=docker-source=/path", "-o=build-image=image", "-p=pathToDockerFile=path", "--use-param-defaults")
 	if err != nil {
 		t.Errorf("Not expecting an error, but got %s", err.Error())
 	}
@@ -225,7 +226,8 @@ func Test_start_has_task_filename_v1beta1(t *testing.T) {
 	}
 	c := Command(&test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc})
 
-	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task-v1beta1.yaml", "-i=docker-source=/path", "-o=build-image=image", "-p=pathToDockerFile=path")
+	got, err := test.ExecuteCommand(c, "start", "-n", "ns", "--filename=./testdata/task-v1beta1.yaml",
+		"-i=docker-source=/path", "-o=build-image=image", "-p=pathToDockerFile=path", "--use-param-defaults")
 	if err != nil {
 		t.Errorf("Not expecting an error, but got %s", err.Error())
 	}
@@ -3528,6 +3530,8 @@ func Test_start_task_invalid_input_res(t *testing.T) {
 		"-o=some=some",
 		"-p=some=some",
 		"-n", "ns",
+		"-p=myarg=abc",
+		"-p=print=xyz",
 	)
 	expected := "Error: invalid input format for resource parameter: my-repo git-repo\n"
 	test.AssertOutput(t, expected, got)
@@ -3617,6 +3621,8 @@ func Test_start_task_invalid_input_res_v1beta1(t *testing.T) {
 		"-o=some=some",
 		"-p=some=some",
 		"-n", "ns",
+		"-p=myarg=abc",
+		"-p=print=xyz",
 	)
 	expected := "Error: invalid input format for resource parameter: my-repo git-repo\n"
 	test.AssertOutput(t, expected, got)
@@ -3868,6 +3874,8 @@ func Test_start_task_invalid_output_res(t *testing.T) {
 		"-i=my-repo=something",
 		"-p=print=cat",
 		"-n", "ns",
+		"-p=myarg=abc",
+		"-p=print=xyz",
 	)
 	expected := "Error: invalid input format for resource parameter: code-image image-final\n"
 	test.AssertOutput(t, expected, got)
@@ -3955,6 +3963,8 @@ func Test_start_task_invalid_output_res_v1beta1(t *testing.T) {
 		"-i=my-repo=something",
 		"-p=print=cat",
 		"-n", "ns",
+		"-p=myarg=abc",
+		"-p=print=xyz",
 	)
 	expected := "Error: invalid input format for resource parameter: code-image image-final\n"
 	test.AssertOutput(t, expected, got)
@@ -4225,6 +4235,8 @@ func Test_start_task_invalid_label(t *testing.T) {
 		"-o=out=out",
 		"-p=param=param",
 		"-n", "ns",
+		"-p=myarg=abc",
+		"-p=print=xyz",
 	)
 	expected := "Error: invalid input format for label parameter: myarg boom\n"
 	test.AssertOutput(t, expected, got)
@@ -4313,6 +4325,8 @@ func Test_start_task_invalid_label_v1beta1(t *testing.T) {
 		"-o=out=out",
 		"-p=param=param",
 		"-n", "ns",
+		"-p=myarg=abc",
+		"-p=print=xyz",
 	)
 	expected := "Error: invalid input format for label parameter: myarg boom\n"
 	test.AssertOutput(t, expected, got)
@@ -4693,6 +4707,7 @@ func Test_start_task_wrong_param(t *testing.T) {
 		"-i=my-repo=git",
 		"-i=my-image=image",
 		"-p=myar=value1",
+		"-p=myarg=value1",
 		"-p=print=boom,boom",
 		"-l=key=value",
 		"-o=code-image=output-image",
@@ -4784,6 +4799,7 @@ func Test_start_task_wrong_param_v1beta1(t *testing.T) {
 		"-i=my-repo=git",
 		"-i=my-image=image",
 		"-p=myar=value1",
+		"-p=myarg=value1",
 		"-p=print=boom,boom",
 		"-l=key=value",
 		"-o=code-image=output-image",
@@ -5067,6 +5083,8 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-s=svc1",
+				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-n", "ns",
 				"--dry-run",
 				"--output", "invalid"},
@@ -5081,6 +5099,7 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run"},
@@ -5096,6 +5115,8 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-s=svc1",
+				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-n", "ns",
 				"--dry-run"},
 			namespace:  "",
@@ -5190,6 +5211,7 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run",
@@ -5208,7 +5230,8 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-s=svc1",
 				"-i=docker-source=git",
 				"-o=builtImage=image",
-				"-p=myarg=arg",
+				"-p=pathToContext=/context",
+				"-p=pathToDockerFile=/path",
 				"--dry-run",
 				"--output=yaml"},
 			namespace:  "",
@@ -5223,6 +5246,7 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run",
@@ -5239,7 +5263,8 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-f", "./testdata/task-v1alpha1.yaml",
 				"-n", "ns",
 				"-s=svc1",
-				"-p=myarg=arg",
+				"-p=pathToContext=/context",
+				"-p=pathToDockerFile=/path",
 				"-i=docker-source=git",
 				"-o=builtImage=image",
 				"--dry-run",
@@ -5259,7 +5284,8 @@ func TestTaskStart_ExecuteCommand(t *testing.T) {
 				"-i=docker-source=git",
 				"-o=builtImage=image",
 				"--dry-run",
-				"--param=myarg=BomBom",
+				"-p=pathToContext=/context",
+				"-p=pathToDockerFile=/path",
 			},
 			namespace:  "",
 			dynamic:    dc1,
@@ -5388,6 +5414,7 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run",
@@ -5403,6 +5430,7 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run"},
@@ -5500,7 +5528,8 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-s=svc1",
 				"-i=docker-source=git",
 				"-o=builtImage=image",
-				"-p=myarg=arg",
+				"-p=pathToContext=/context",
+				"-p=pathToDockerFile=/path",
 				"--dry-run",
 				"--output=yaml"},
 			namespace:  "",
@@ -5515,6 +5544,7 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run",
@@ -5531,6 +5561,7 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--dry-run",
@@ -5548,7 +5579,8 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-f", "./testdata/task-v1beta1.yaml",
 				"-n", "ns",
 				"-s=svc1",
-				"-p=myarg=arg",
+				"-p=pathToContext=/context",
+				"-p=pathToDockerFile=/path",
 				"-i=docker-source=git",
 				"-o=builtImage=image",
 				"--dry-run",
@@ -5568,7 +5600,8 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-i=docker-source=git",
 				"-o=builtImage=image",
 				"--dry-run",
-				"--param=myarg=BomBom",
+				"-p=pathToContext=/context",
+				"-p=pathToDockerFile=/path",
 			},
 			namespace:  "",
 			dynamic:    dc,
@@ -5582,6 +5615,7 @@ func TestTaskStart_ExecuteCommand_v1beta1(t *testing.T) {
 				"-i=my-repo=git-repo",
 				"-o=code-image=output-image",
 				"-p=myarg=arg",
+				"-p=task-param=arg",
 				"-s=svc1",
 				"-n", "ns",
 				"--pod-template", "./testdata/podtemplate.yaml",

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--param_-f_v1alpha1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--param_-f_v1alpha1.golden
@@ -7,8 +7,10 @@ metadata:
 spec:
   inputs:
     params:
-    - name: myarg
-      value: BomBom
+    - name: pathToContext
+      value: /context
+    - name: pathToDockerFile
+      value: /path
     resources:
     - name: docker-source
       resourceRef:

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
@@ -9,6 +9,8 @@ spec:
     params:
     - name: myarg
       value: arg
+    - name: task-param
+      value: arg
     resources:
     - name: my-repo
       resourceRef:

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f_v1alpha1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f_v1alpha1.golden
@@ -7,8 +7,10 @@ metadata:
 spec:
   inputs:
     params:
-    - name: myarg
-      value: arg
+    - name: pathToContext
+      value: /context
+    - name: pathToDockerFile
+      value: /path
     resources:
     - name: docker-source
       resourceRef:

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -9,6 +9,8 @@ spec:
     params:
     - name: myarg
       value: arg
+    - name: task-param
+      value: arg
     resources:
     - name: my-repo
       resourceRef:

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified_v1beta1.golden
@@ -5,6 +5,11 @@ metadata:
   generateName: task-1-run-
   namespace: ns
 spec:
+  params:
+  - name: myarg
+    value: arg
+  - name: task-param
+    value: arg
   resources:
     inputs:
     - name: my-repo

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -24,6 +24,10 @@
 				{
 					"name": "myarg",
 					"value": "arg"
+				},
+				{
+					"name": "task-param",
+					"value": "arg"
 				}
 			]
 		},

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json_-f_v1alpha1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json_-f_v1alpha1.golden
@@ -72,8 +72,12 @@
 			],
 			"params": [
 				{
-					"name": "myarg",
-					"value": "arg"
+					"name": "pathToContext",
+					"value": "/context"
+				},
+				{
+					"name": "pathToDockerFile",
+					"value": "/path"
 				}
 			]
 		},

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_--param_-f_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_--param_-f_v1beta1.golden
@@ -6,8 +6,10 @@ metadata:
   namespace: ns
 spec:
   params:
-  - name: myarg
-    value: BomBom
+  - name: pathToContext
+    value: /context
+  - name: pathToDockerFile
+    value: /path
   resources:
     inputs:
     - name: docker-source

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_--timeout_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_--timeout_specified.golden
@@ -8,6 +8,8 @@ spec:
   params:
   - name: myarg
     value: arg
+  - name: task-param
+    value: arg
   resources:
     inputs:
     - name: my-repo

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_-f_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_-f_v1beta1.golden
@@ -6,8 +6,10 @@ metadata:
   namespace: ns
 spec:
   params:
-  - name: myarg
-    value: arg
+  - name: pathToContext
+    value: /context
+  - name: pathToDockerFile
+    value: /path
   resources:
     inputs:
     - name: docker-source

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_PodTemplate.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_PodTemplate.golden
@@ -8,6 +8,8 @@ spec:
   params:
   - name: myarg
     value: arg
+  - name: task-param
+    value: arg
   podTemplate:
     schedulerName: SchedulerName
     securityContext:

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_only_--dry-run_specified.golden
@@ -8,6 +8,8 @@ spec:
   params:
   - name: myarg
     value: arg
+  - name: task-param
+    value: arg
   resources:
     inputs:
     - name: my-repo

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_output=json_-f_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand_v1beta1-Dry_Run_with_output=json_-f_v1beta1.golden
@@ -9,8 +9,12 @@
 	"spec": {
 		"params": [
 			{
-				"name": "myarg",
-				"value": "arg"
+				"name": "pathToContext",
+				"value": "/context"
+			},
+			{
+				"name": "pathToDockerFile",
+				"value": "/path"
 			}
 		],
 		"resources": {

--- a/pkg/options/start.go
+++ b/pkg/options/start.go
@@ -287,9 +287,12 @@ func (intOpts *InteractiveOpts) TaskOutputResources(task *v1beta1.Task, f func(v
 	return nil
 }
 
-func (intOpts *InteractiveOpts) TaskParams(task *v1beta1.Task, useParamDefaults bool) error {
+func (intOpts *InteractiveOpts) TaskParams(task *v1beta1.Task, skipParams map[string]string, useParamDefaults bool) error {
 	for _, param := range task.Spec.Params {
 		if param.Default == nil && useParamDefaults || !useParamDefaults {
+			if _, toSkip := skipParams[param.Name]; toSkip {
+				continue
+			}
 			var ans, ques, defaultValue string
 			ques = fmt.Sprintf("Value for param `%s` of type `%s`?", param.Name, param.Type)
 			input := &survey.Input{}

--- a/pkg/params/mergeparams.go
+++ b/pkg/params/mergeparams.go
@@ -95,3 +95,16 @@ func FilterParamsByType(params []v1beta1.ParamSpec) {
 		paramByType[p.Name] = v1beta1.ParamTypeArray
 	}
 }
+
+// ParseParams parse the params and return as map
+func ParseParams(params []string) (map[string]string, error) {
+	parsedParams := make(map[string]string)
+	for _, p := range params {
+		r := strings.SplitN(p, "=", 2)
+		if len(r) != 2 {
+			return nil, errors.New(invalidParam + p)
+		}
+		parsedParams[r[0]] = r[1]
+	}
+	return parsedParams, nil
+}

--- a/pkg/params/mergeparams_test.go
+++ b/pkg/params/mergeparams_test.go
@@ -235,3 +235,17 @@ func Test_parseParam(t *testing.T) {
 		})
 	}
 }
+
+func Test_ParseParams(t *testing.T) {
+
+	pass := []string{"abc=bcd", "one=two"}
+	got, _ := ParseParams(pass)
+	test.AssertOutput(t, "bcd", got["abc"])
+
+	pass = []string{"abc"}
+	_, err := ParseParams(pass)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+	test.AssertOutput(t, "invalid input format for param parameter: abc", err.Error())
+}

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -167,6 +167,35 @@ Waiting for logs to be available...
 		})
 	})
 
+	t.Run("Start TaskRun using tkn task start command with passing one param and tkn will ask for other", func(t *testing.T) {
+		tkn.RunInteractiveTests(t, &cli.Prompt{
+			CmdArgs: []string{"task", "start", "read-task",
+				"-i=source=" + tePipelineGitResourceName,
+				"-p=FILEPATH=docs",
+				"--showlog"},
+			Procedure: func(c *expect.Console) error {
+
+				if _, err := c.ExpectString("Value for param `FILENAME` of type `string`?"); err != nil {
+					return err
+				}
+
+				if _, err := c.SendLine("README.md"); err != nil {
+					return err
+				}
+
+				if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
+					return err
+				}
+
+				if _, err := c.ExpectEOF(); err != nil {
+					return err
+				}
+
+				c.Close()
+				return nil
+			}})
+	})
+
 	t.Run("Validate interactive task logs, with  follow mode (-f) ", func(t *testing.T) {
 		tkn.RunInteractiveTests(t, &cli.Prompt{
 			CmdArgs: []string{"task", "logs", "-f"},


### PR DESCRIPTION
Previoulsy, If there are multiple params in a task and user passes only a few, then
others were not asked by tkn due to which taskrun use to fail.
Now, if a param is not passed by user then they are asked for that
param unless there is default value defined and --use-param-defaults
is used.

Issue: #1180

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
