### PR TITLE
Add utility functions for config and home dirs

### DIFF
--- a/cmd/tkn/main.go
+++ b/cmd/tkn/main.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	pluginDirEnv = "TKN_PLUGINS_DIR"
-	pluginDir    = "~/.config/tkn/plugins"
 )
 
 func main() {
@@ -67,13 +66,13 @@ func getPluginDir() (string, error) {
 	dir := os.Getenv(pluginDirEnv)
 	// if TKN_PLUGINS_DIR is set, follow it
 	if dir != "" {
-		return dir, nil
+		return homedir.Expand(dir)
 	}
-	// Respect XDG_CONFIG_HOME if set
-	if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
-		return filepath.Join(xdgHome, "tkn", "plugins"), nil
+	configDir, err := cli.ConfigDir()
+	if err != nil {
+		return "", err
 	}
-	// Fallback to default pluginDir (~/.config/tkn/plugins)
+	pluginDir := filepath.Join(configDir, "plugins")
 	return homedir.Expand(pluginDir)
 }
 

--- a/docs/cmd/tkn_bundle_list.md
+++ b/docs/cmd/tkn_bundle_list.md
@@ -28,15 +28,16 @@ Authentication:
 	3. Additionally, you can use Basic auth via --remote-username and --remote-password
 
 Caching:
-    By default, bundles will be cached in ~/.tekton/bundles. If you would like to use a different location, set 
-"--cache-dir" and if you would like to skip the cache altogether, set "--no-cache".
+	By default, bundles will be cached in ${XDG_CACHE_HOME}/tekton/bundles. If ${XDG_CACHE_HOME} isn't set then
+	~/.cache/tekton/bundles will be used. If you would like to use a different location, set "--cache-dir" and if
+	you would like to skip the cache altogether, set "--no-cache".
 
 
 ### Options
 
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
-      --cache-dir string              A directory to cache Tekton bundles in. (default "~/.tekton/bundles")
+      --cache-dir string              A directory to cache Tekton bundles in. (default "~/.cache/tkn/bundles")
   -h, --help                          help for list
       --no-cache                      If set to true, pulls a Tekton bundle from the remote even its exact digest is available in the cache.
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.

--- a/docs/man/man1/tkn-bundle-list.1
+++ b/docs/man/man1/tkn-bundle-list.1
@@ -43,8 +43,9 @@ Authentication:
 
 .PP
 Caching:
-    By default, bundles will be cached in \~/.tekton/bundles. If you would like to use a different location, set
-"\-\-cache\-dir" and if you would like to skip the cache altogether, set "\-\-no\-cache".
+    By default, bundles will be cached in ${XDG\_CACHE\_HOME}/tekton/bundles. If ${XDG\_CACHE\_HOME} isn't set then
+    \~/.cache/tekton/bundles will be used. If you would like to use a different location, set "\-\-cache\-dir" and if
+    you would like to skip the cache altogether, set "\-\-no\-cache".
 
 
 .SH OPTIONS
@@ -53,7 +54,7 @@ Caching:
     If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
 
 .PP
-\fB\-\-cache\-dir\fP="\~/.tekton/bundles"
+\fB\-\-cache\-dir\fP="\~/.cache/tkn/bundles"
     A directory to cache Tekton bundles in.
 
 .PP

--- a/pkg/bundle/flags.go
+++ b/pkg/bundle/flags.go
@@ -2,10 +2,12 @@ package bundle
 
 import (
 	"net/http"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/pflag"
+	"github.com/tektoncd/cli/pkg/cli"
 )
 
 // RemoteOptions is a set of flags that are used configure the connection options to a registry.
@@ -61,6 +63,7 @@ type CacheOptions struct {
 
 // AddCacheFlags will define a set of flags to control how Tekton Bundle caching is done.
 func AddCacheFlags(flags *pflag.FlagSet, opts *CacheOptions) {
-	flags.StringVar(&opts.cacheDir, "cache-dir", "~/.tekton/bundles", "A directory to cache Tekton bundles in.")
+	bundleCacheDir := filepath.Join(cli.CacheDir(), "bundles")
+	flags.StringVar(&opts.cacheDir, "cache-dir", bundleCacheDir, "A directory to cache Tekton bundles in.")
 	flags.BoolVar(&opts.noCache, "no-cache", false, "If set to true, pulls a Tekton bundle from the remote even its exact digest is available in the cache.")
 }

--- a/pkg/cli/dirs.go
+++ b/pkg/cli/dirs.go
@@ -1,0 +1,68 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func CacheDir() string {
+	tmpDir, err := os.UserCacheDir()
+	if err != nil {
+		tmpDir = os.TempDir()
+	}
+	tmpDir, err = contractHome(tmpDir)
+	if err != nil {
+		tmpDir = os.TempDir()
+	}
+	return filepath.Join(tmpDir, "tkn")
+}
+
+func ConfigDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	configDir, err = contractHome(configDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "tkn"), err
+}
+
+// opposite of homedir.Expand()
+func contractHome(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] == '~' {
+		return path, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(path, homeDir) {
+		return "", errors.New("cannot contract user-specific home dir")
+	}
+
+	return filepath.Join("~", path[len(homeDir):]), nil
+}

--- a/pkg/cli/dirs_test.go
+++ b/pkg/cli/dirs_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_contractHome_base(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Errorf("Failed to get home: %w", err)
+	}
+	expected := "~"
+	got, err := contractHome(homeDir)
+	if err != nil {
+		t.Errorf("Failed to contract home: %w", err)
+	}
+	if got != expected {
+		t.Errorf("Result should be '%s' != '%s'", expected, got)
+	}
+}
+
+func Test_contractHome_suffix(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Errorf("Failed to get home: %w", err)
+	}
+	suffix := "abc"
+	expected := filepath.Join("~", suffix)
+	got, err := contractHome(filepath.Join(homeDir, suffix))
+	if err != nil {
+		t.Errorf("Failed to contract home: %w", err)
+	}
+	if got != expected {
+		t.Errorf("Result should be '%s' != '%s'", expected, got)
+	}
+}
+
+func Test_contractHome_empty(t *testing.T) {
+	expected := ""
+	got, err := contractHome("")
+	if err != nil {
+		t.Errorf("Failed to contract home: %w", err)
+	}
+	if got != expected {
+		t.Errorf("Result should be empty")
+	}
+}
+
+func Test_contractHome_root(t *testing.T) {
+	got, err := contractHome("/")
+	if err == nil {
+		t.Errorf("Error expected here, got this result: '%s'", got)
+	}
+}

--- a/pkg/cmd/bundle/list.go
+++ b/pkg/cmd/bundle/list.go
@@ -67,8 +67,9 @@ Authentication:
 	3. Additionally, you can use Basic auth via --remote-username and --remote-password
 
 Caching:
-    By default, bundles will be cached in ~/.tekton/bundles. If you would like to use a different location, set 
-"--cache-dir" and if you would like to skip the cache altogether, set "--no-cache".
+	By default, bundles will be cached in ${XDG_CACHE_HOME}/tekton/bundles. If ${XDG_CACHE_HOME} isn't set then
+	~/.cache/tekton/bundles will be used. If you would like to use a different location, set "--cache-dir" and if
+	you would like to skip the cache altogether, set "--no-cache".
 `
 
 	c := &cobra.Command{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Add utils functions for getting Config and Cache dirs

Might want to also standardize the dirs on `tkn` rather than config using `tkn` and cache using `tekton`

Resolves #1363

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Move bundle cache to XDG_CACHE_DIR
```
