### PR TITLE
List cancelled taskruns in pr describe Message section

### DIFF
--- a/pkg/pipelinerun/description/description.go
+++ b/pkg/pipelinerun/description/description.go
@@ -17,6 +17,7 @@ package description
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"text/tabwriter"
 	"text/template"
 
@@ -224,6 +225,7 @@ func hasFailed(pr *v1beta1.PipelineRun) string {
 	}
 
 	if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
+		trMessages := []string{}
 		for _, tr := range pr.Status.TaskRuns {
 			if tr.Status == nil {
 				continue
@@ -232,9 +234,12 @@ func hasFailed(pr *v1beta1.PipelineRun) string {
 				continue
 			}
 			if tr.Status.Conditions[0].Status == corev1.ConditionFalse {
-				return fmt.Sprintf("%s (%s)", pr.Status.Conditions[0].Message,
-					tr.Status.Conditions[0].Message)
+				trMessages = append(trMessages, tr.Status.Conditions[0].Message)
 			}
+		}
+		if len(trMessages) != 0 {
+			return fmt.Sprintf("%s (%s)", pr.Status.Conditions[0].Message,
+				strings.Join(trMessages, ", "))
 		}
 		return pr.Status.Conditions[0].Message
 	}


### PR DESCRIPTION
Previously only the first cancelled PipelineRun was listed under Message
heading.

Issue: #1216

Signed-off-by: Brandon Hartshorn <brandon.hartshorn@ibm.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `Message` section of `tkn pr describe` has been updated to include status messages from all failed TaskRuns started by the PipelineRun.

Then:
```
💌 Message

PipelineRun "parallel-tasks-pipelinerun" was cancelled (TaskRun "parallel-tasks-pipelinerun-sleep-4-zhrkm" was cancelled)
```

Now:
```
💌 Message

PipelineRun "parallel-tasks-pipelinerun" was cancelled (TaskRun "parallel-tasks-pipelinerun-sleep-1-mc2j5" was cancelled, TaskRun "parallel-tasks-pipelinerun-sleep-2-2xs9n" was cancelled, TaskRun "parallel-tasks-pipelinerun-sleep-3-j4hfv" was cancelled, TaskRun "parallel-tasks-pipelinerun-sleep-4-zhrkm" was cancelled, TaskRun "parallel-tasks-pipelinerun-sleep-0-lk5tn" was cancelled)
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Message section of output from `pr describe` now includes failure messages from dependent TaskRuns
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
