### PR TITLE
Fixes e2e test for ClusterTask

### DIFF
--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -164,9 +164,9 @@ func GetPipelineRunListWithName(c *framework.Clients, pname string, sortByStartT
 	return pipelineRunList
 }
 
-func GetTaskRunListWithName(c *framework.Clients, tname string, sortByStartTime bool) *v1alpha1.TaskRunList {
+func GetTaskRunListByLabel(c *framework.Clients, tname string, sortByStartTime bool, label string) *v1alpha1.TaskRunList {
 	opts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("tekton.dev/task=%s", tname),
+		LabelSelector: label,
 	}
 
 	time.Sleep(1 * time.Second)
@@ -181,6 +181,16 @@ func GetTaskRunListWithName(c *framework.Clients, tname string, sortByStartTime 
 	}
 
 	return taskRunList
+}
+
+func GetTaskRunListWithTaskName(c *framework.Clients, tname string, sortByStartTime bool) *v1alpha1.TaskRunList {
+	label := fmt.Sprintf("tekton.dev/task=%s", tname)
+	return GetTaskRunListByLabel(c, tname, sortByStartTime, label)
+}
+
+func GetTaskRunListWithClusterTaskName(c *framework.Clients, ctname string, sortByStartTime bool) *v1alpha1.TaskRunList {
+	label := fmt.Sprintf("tekton.dev/clusterTask=%s", ctname)
+	return GetTaskRunListByLabel(c, ctname, sortByStartTime, label)
 }
 
 func GetPipelineRunList(c *framework.Clients) *v1alpha1.PipelineRunList {

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -43,7 +43,6 @@ const (
 )
 
 func TestClusterTaskInteractiveStartE2E(t *testing.T) {
-	t.Skip("TEMPORARY DISABLING THIS, SEE https://github.com/tektoncd/cli/issues/1319.")
 	t.Parallel()
 	c, namespace := framework.Setup(t)
 	knativetest.CleanupOnInterrupt(func() { framework.TearDown(t, c, namespace) }, t.Logf)
@@ -96,11 +95,11 @@ func TestClusterTaskInteractiveStartE2E(t *testing.T) {
 			"-i=source="+tePipelineGitResourceName,
 			"-p=FILEPATH=docs",
 			"-p=FILENAME=README.md",
-			"-w=name=shared-workspace,emptyDir=''",
+			"-w=name=shared-workspace,emptyDir=",
 			"--showlog")
 
 		vars := make(map[string]interface{})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
 		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
@@ -148,7 +147,7 @@ Waiting for logs to be available...
 				c.Close()
 				return nil
 			}})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceed"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}
@@ -161,7 +160,7 @@ Waiting for logs to be available...
 			"-w=name=shared-workspace,emptyDir=",
 			"--use-param-defaults",
 			"--showlog")
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceed"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}
@@ -195,7 +194,7 @@ Waiting for logs to be available...
 				c.Close()
 				return nil
 			}})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceed"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}
@@ -214,7 +213,7 @@ Waiting for logs to be available...
 			"--showlog",
 			"--pod-template="+helper.GetResourcePath("/podtemplate/podtemplate.yaml"))
 
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}
@@ -222,7 +221,7 @@ Waiting for logs to be available...
 
 	t.Run("Start TaskRun using tkn ct start with --last option", func(t *testing.T) {
 		// Get last TaskRun for read-clustertask
-		lastTaskRun := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0]
+		lastTaskRun := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0]
 
 		// Start TaskRun using --last
 		tkn.MustSucceed(t, "ct", "start", clusterTaskName,
@@ -233,7 +232,7 @@ Waiting for logs to be available...
 		time.Sleep(1 * time.Second)
 
 		// Get name of most recent TaskRun and wait for it to succeed
-		taskRunUsingLast := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0]
+		taskRunUsingLast := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0]
 		if err := wait.ForTaskRunState(c, taskRunUsingLast.Name, wait.TaskRunSucceed(taskRunUsingLast.Name), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}
@@ -248,7 +247,7 @@ Waiting for logs to be available...
 
 	t.Run("Start TaskRun using tkn ct start with --use-taskrun option", func(t *testing.T) {
 		// Get last TaskRun for read-clustertask
-		lastTaskRun := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0]
+		lastTaskRun := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0]
 
 		// Start TaskRun using --use-taskrun
 		tkn.MustSucceed(t, "ct", "start", clusterTaskName,
@@ -260,7 +259,7 @@ Waiting for logs to be available...
 		time.Sleep(1 * time.Second)
 
 		// Get name of most recent TaskRun and wait for it to succeed
-		taskRunUsingParticularTaskRun := builder.GetTaskRunListWithName(c, clusterTaskName, true).Items[0]
+		taskRunUsingParticularTaskRun := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0]
 		if err := wait.ForTaskRunState(c, taskRunUsingParticularTaskRun.Name, wait.TaskRunSucceed(taskRunUsingParticularTaskRun.Name), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -77,7 +77,7 @@ func TestTaskStartE2E(t *testing.T) {
 			"--showlog")
 
 		vars := make(map[string]interface{})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithTaskName(c, "read-task", true).Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
 		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
@@ -128,7 +128,7 @@ Waiting for logs to be available...
 	})
 
 	t.Run("Get list of TaskRuns from namespace  "+namespace, func(t *testing.T) {
-		taskRuns := builder.GetTaskRunListWithName(c, "read-task", false)
+		taskRuns := builder.GetTaskRunListWithTaskName(c, "read-task", false)
 		taskRun1GeneratedName := taskRuns.Items[0].Name
 		taskRun2GeneratedName := taskRuns.Items[1].Name
 		taskRun3GeneratedName := taskRuns.Items[2].Name
@@ -231,7 +231,7 @@ Waiting for logs to be available...
 			"--workspace=name=read-allowed,volumeClaimTemplateFile="+helper.GetResourcePath("pvc.yaml"))
 
 		vars := make(map[string]interface{})
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "task-with-workspace", true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithTaskName(c, "task-with-workspace", true).Items[0].Name
 		vars["Taskrun"] = taskRunGeneratedName
 		expected := helper.ProcessString(`(TaskRun started: {{.Taskrun}}
 Waiting for logs to be available...
@@ -255,7 +255,7 @@ Waiting for logs to be available...
 			"--showlog",
 			"--pod-template="+helper.GetResourcePath("/podtemplate/podtemplate.yaml"))
 
-		taskRunGeneratedName := builder.GetTaskRunListWithName(c, "read-task", true).Items[0].Name
+		taskRunGeneratedName := builder.GetTaskRunListWithTaskName(c, "read-task", true).Items[0].Name
 		if err := wait.ForTaskRunState(c, taskRunGeneratedName, wait.TaskRunSucceed(taskRunGeneratedName), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}
@@ -263,7 +263,7 @@ Waiting for logs to be available...
 
 	t.Run("Cancel finished TaskRun with tkn taskrun cancel", func(t *testing.T) {
 		// Get last TaskRun for read-task
-		taskRunLast := builder.GetTaskRunListWithName(c, "read-task", true).Items[0]
+		taskRunLast := builder.GetTaskRunListWithTaskName(c, "read-task", true).Items[0]
 
 		// Cancel TaskRun
 		res := tkn.Run("taskrun", "cancel", taskRunLast.Name)
@@ -281,7 +281,7 @@ Waiting for logs to be available...
 		tkn.MustSucceed(t, "task", "start", task, "-p", "seconds=30s")
 
 		// Get name of most recent TaskRun
-		taskRunName := builder.GetTaskRunListWithName(c, task, true).Items[0].Name
+		taskRunName := builder.GetTaskRunListWithTaskName(c, task, true).Items[0].Name
 
 		// Cancel TaskRun
 		res := tkn.MustSucceed(t, "taskrun", "cancel", taskRunName)
@@ -301,7 +301,7 @@ Waiting for logs to be available...
 
 	t.Run("Start TaskRun using tkn task start with --last option", func(t *testing.T) {
 		// Get last TaskRun for read-task
-		lastTaskRun := builder.GetTaskRunListWithName(c, "read-task", true).Items[0]
+		lastTaskRun := builder.GetTaskRunListWithTaskName(c, "read-task", true).Items[0]
 
 		// Start TaskRun using --last
 		tkn.MustSucceed(t, "task", "start", "read-task",
@@ -312,7 +312,7 @@ Waiting for logs to be available...
 		time.Sleep(1 * time.Second)
 
 		// Get name of most recent TaskRun and wait for it to succeed
-		taskRunUsingLast := builder.GetTaskRunListWithName(c, "read-task", true).Items[0]
+		taskRunUsingLast := builder.GetTaskRunListWithTaskName(c, "read-task", true).Items[0]
 		if err := wait.ForTaskRunState(c, taskRunUsingLast.Name, wait.TaskRunSucceed(taskRunUsingLast.Name), "TaskRunSucceeded"); err != nil {
 			t.Errorf("Error waiting for TaskRun to Succeed: %s", err)
 		}


### PR DESCRIPTION
For clustertask test, it use to fetch list of taskruns using label
`tekton.dev/task` instead of `tekton.dev/clusterTask`.

Fixes #1319 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
