### PR TITLE
Fix rpm spec file

### DIFF
--- a/tekton/rpmbuild/tekton.spec
+++ b/tekton/rpmbuild/tekton.spec
@@ -638,6 +638,9 @@ ln -s $PWD/cli-%{version} _build/src/%{import_path}
 export GOPATH="$PWD/_build:%{gopath}"
 export LDFLAGS="${LDFLAGS:-} -X %{import_path}/pkg/cmd/version.clientVersion=%{version}"
 export PATH=$PATH:"%{_builddir}"/bin
+go env -w GO111MODULE=off
+go get -u github.com/golang/dep/cmd/dep
+GO111MODULE=on go install
 
 %gobuild -o _bin/tkn %{import_path}/cmd/tkn
 


### PR DESCRIPTION
This will fix the issue of rpm build failing for
centos and fedora 34 because of go mod issue

Error was like working directory is not part of a module

Job https://copr.fedorainfracloud.org/coprs/chmouel/tektoncd-cli/build/2150157/

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
