### PR TITLE
Fix TaskRun order in `tkn pr logs`

### DIFF
--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -443,11 +443,12 @@ func TestPipelinerunLog_completed_taskrun_only(t *testing.T) {
 		prstart      = clockwork.NewFakeClock()
 		ns           = "namespace"
 
-		task1Name    = "output-task"
-		tr1Name      = "output-task-1"
-		tr1StartTime = prstart.Now().Add(20 * time.Second)
-		tr1Pod       = "output-task-pod-123456"
-		tr1Step1Name = "writefile-step"
+		task1Name         = "output-task"
+		tr1Name           = "output-task-1"
+		tr1StartTime      = prstart.Now().Add(20 * time.Second)
+		tr1CompletionTime = prstart.Now().Add(30 * time.Second)
+		tr1Pod            = "output-task-pod-123456"
+		tr1Step1Name      = "writefile-step"
 
 		// these are pipeline tasks for which pipeline has not
 		// scheduled any taskrun
@@ -501,6 +502,7 @@ func TestPipelinerunLog_completed_taskrun_only(t *testing.T) {
 			tb.PipelineRunNamespace(ns),
 			tb.PipelineRunLabel("tekton.dev/pipeline", prName),
 			tb.PipelineRunSpec(pipelineName),
+
 			tb.PipelineRunStatus(
 				tb.PipelineRunStatusCondition(apis.Condition{
 					Status: corev1.ConditionTrue,
@@ -508,6 +510,13 @@ func TestPipelinerunLog_completed_taskrun_only(t *testing.T) {
 				}),
 				tb.PipelineRunTaskRunsStatus(tr1Name, &v1alpha1.PipelineRunTaskRunStatus{
 					PipelineTaskName: task1Name,
+					Status: &v1alpha1.TaskRunStatus{
+						Status: duckv1beta1.Status{},
+						TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+							StartTime:      &metav1.Time{Time: tr1StartTime},
+							CompletionTime: &metav1.Time{Time: tr1CompletionTime},
+						},
+					},
 				}),
 			),
 		),
@@ -583,6 +592,13 @@ func TestPipelinerunLog_completed_taskrun_only(t *testing.T) {
 				}),
 				tb.PipelineRunTaskRunsStatus("output-taskrun2", &v1alpha1.PipelineRunTaskRunStatus{
 					PipelineTaskName: "output-task2",
+					Status: &v1alpha1.TaskRunStatus{
+						Status: duckv1beta1.Status{},
+						TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+							StartTime:      &metav1.Time{Time: tr1StartTime},
+							CompletionTime: &metav1.Time{Time: tr1CompletionTime},
+						},
+					},
 				}),
 			),
 		),
@@ -1332,11 +1348,12 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 		prstart      = clockwork.NewFakeClock()
 		ns           = "namespace"
 
-		task1Name    = "output-task"
-		tr1Name      = "output-task-1"
-		tr1StartTime = prstart.Now().Add(20 * time.Second)
-		tr1Pod       = "output-task-pod-123456"
-		tr1Step1Name = "writefile-step"
+		task1Name         = "output-task"
+		tr1Name           = "output-task-1"
+		tr1StartTime      = prstart.Now().Add(20 * time.Second)
+		tr1CompletionTime = prstart.Now().Add(30 * time.Second)
+		tr1Pod            = "output-task-pod-123456"
+		tr1Step1Name      = "writefile-step"
 
 		// these are pipeline tasks for which pipeline has not
 		// scheduled any taskrun
@@ -1455,6 +1472,15 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 					TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
 						tr1Name: {
 							PipelineTaskName: task1Name,
+							Status: &v1beta1.TaskRunStatus{
+								Status: duckv1beta1.Status{},
+								TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+									StartTime:      &metav1.Time{Time: tr1StartTime},
+									CompletionTime: &metav1.Time{Time: tr1CompletionTime},
+								},
+							},
+							ConditionChecks: nil,
+							WhenExpressions: nil,
 						},
 					},
 				},
@@ -1578,6 +1604,15 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 					TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
 						"output-taskrun2": {
 							PipelineTaskName: "output-task2",
+							Status: &v1beta1.TaskRunStatus{
+								Status: duckv1beta1.Status{},
+								TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+									StartTime:      &metav1.Time{Time: tr1StartTime},
+									CompletionTime: &metav1.Time{Time: tr1CompletionTime},
+								},
+							},
+							ConditionChecks: nil,
+							WhenExpressions: nil,
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #1372

Add a sort to TaskRun list in a finished PipelineRun, to print
logs from TaskRun as per the execution order.

example pipeline: 
- [pipeline definition](https://gist.github.com/nikhil-thomas/290cd46353060d438f706cdd4026e0ac)

<img width="676" alt="Screenshot 2021-06-04 at 3 51 52 PM" src="https://user-images.githubusercontent.com/3650655/120788724-49ba5000-c54e-11eb-8ca6-e911d8c8ca1c.png">

- [Live log](https://gist.github.com/nikhil-thomas/be56f5c658b054781abb1e3a81aac541)

- Log after completion:
   - [log - existing behavior](https://gist.github.com/nikhil-thomas/d735ea47ba3198e0f047ec360f83be6a)
   - [log - new behavior](https://gist.github.com/nikhil-thomas/56cdad75e987300380af42fe8fbac596)

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
- TaskRun Logs are listed in the appropriate order in `tkn pipelinerun logs` command. Fixes: #1372 ```
