### PR TITLE
Add --keep-since flag to pipelinerun delete

### DIFF
--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -33,6 +33,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
       --keep int                      Keep n most recent number of PipelineRuns
+      --keep-since int                When deleting all PipelineRuns keep the ones that has been completed since n minutes
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
   -p, --pipeline string               The name of a Pipeline whose PipelineRuns should be deleted (does not delete the Pipeline)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -40,6 +40,10 @@ Delete PipelineRuns in a namespace
     Keep n most recent number of PipelineRuns
 
 .PP
+\fB\-\-keep\-since\fP=0
+    When deleting all PipelineRuns keep the ones that has been completed since n minutes
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-as\-json|jsonpath\-file.
 

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -32,6 +32,7 @@ type DeleteOptions struct {
 	DeleteAllNs        bool
 	DeleteAll          bool
 	Keep               int
+	KeepSince          int
 }
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns string) error {


### PR DESCRIPTION
# Changes

Add a `--keep-since=Minutes` flag to `tkn pipelinerun delete`.

This allows deleting all pipeline but the one younger than X minutes.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com

# Release Notes

```release-note
add option --keep-since to tkn pr delete --all to allow keeping some prs that are younger than X minutes when deleting all pipelineruns. 
```


