### PR TITLE
Get tekton components version from configmap

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tektoncd/cli/pkg/cli"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,17 +32,34 @@ const (
 	oldTriggersControllerSelector  string = "app.kubernetes.io/component=controller,app.kubernetes.io/name=tekton-triggers"
 	dashboardControllerSelector    string = "app.kubernetes.io/part-of=tekton-dashboard,app.kubernetes.io/component=dashboard,app.kubernetes.io/name=dashboard"
 	oldDashboardControllerSelector string = "app=tekton-dashboard"
+	pipelinesInfo                  string = "pipelines-info"
+	triggersInfo                   string = "triggers-info"
+	dashboardInfo                  string = "dashboard-info"
 )
+
+var defaultNamespaces = []string{"tekton-pipelines", "openshift-pipelines"}
 
 // GetPipelineVersion Get pipeline version, functions imported from Dashboard
 func GetPipelineVersion(c *cli.Clients, ns string) (string, error) {
+
+	var version string
+	// for Tekton Pipelines version 0.25.0+
+	configMap, err := getConfigMap(c, pipelinesInfo, ns)
+	if err == nil {
+		version = configMap.Data["version"]
+	}
+
+	if version != "" {
+		return version, nil
+	}
+
 	deploymentsList, err := getDeployments(c, pipelinesControllerSelector, oldPipelinesControllerSelector, ns)
 
 	if err != nil {
 		return "", err
 	}
 
-	version := findPipelineVersion(deploymentsList.Items)
+	version = findPipelineVersion(deploymentsList.Items)
 
 	if version == "" {
 		return "", fmt.Errorf("error getting the tekton pipelines deployment version. Version is unknown")
@@ -53,9 +71,8 @@ func GetPipelineVersion(c *cli.Clients, ns string) (string, error) {
 // Get deployments for either Tekton Triggers, Tekton Dashboard or Tekton Pipelines
 func getDeployments(c *cli.Clients, newLabel, oldLabel, ns string) (*v1.DeploymentList, error) {
 	var (
-		err               error
-		deployments       *v1.DeploymentList
-		defaultNamespaces = []string{"tekton-pipelines", "openshift-pipelines"}
+		err         error
+		deployments *v1.DeploymentList
 	)
 	if ns != "" {
 		deployments, err = getDeploy(c, newLabel, oldLabel, ns)
@@ -95,6 +112,37 @@ func getDeploy(c *cli.Clients, newLabel, oldLabel, ns string) (*v1.DeploymentLis
 	return deployments, err
 }
 
+func getConfigMap(c *cli.Clients, name, ns string) (*corev1.ConfigMap, error) {
+
+	var (
+		err       error
+		configMap *corev1.ConfigMap
+	)
+
+	if ns != "" {
+		configMap, err = c.Kube.CoreV1().ConfigMaps(ns).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return configMap, nil
+	}
+
+	for _, n := range defaultNamespaces {
+		configMap, err = c.Kube.CoreV1().ConfigMaps(n).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if configMap != nil {
+			break
+		}
+	}
+
+	if configMap == nil {
+		return nil, fmt.Errorf("ConfigMap with name %s not found in the namespace %s", name, ns)
+	}
+	return configMap, nil
+}
+
 func findPipelineVersion(deployments []v1.Deployment) string {
 	version := ""
 	for _, deployment := range deployments {
@@ -131,13 +179,26 @@ func findPipelineVersion(deployments []v1.Deployment) string {
 
 // GetTriggerVersion Get triggers version.
 func GetTriggerVersion(c *cli.Clients, ns string) (string, error) {
+
+	var version string
+
+	// for latest pipelines version
+	configMap, err := getConfigMap(c, triggersInfo, ns)
+	if err == nil {
+		version = configMap.Data["version"]
+	}
+
+	if version != "" {
+		return version, nil
+	}
+
 	deploymentsList, err := getDeployments(c, triggersControllerSelector, oldTriggersControllerSelector, ns)
 
 	if err != nil {
 		return "", err
 	}
 
-	version := findTriggersVersion(deploymentsList.Items)
+	version = findTriggersVersion(deploymentsList.Items)
 
 	if version == "" {
 		return "", fmt.Errorf("error getting the tekton triggers deployment version. Version is unknown")
@@ -162,13 +223,26 @@ func findTriggersVersion(deployments []v1.Deployment) string {
 
 // GetDashboardVersion Get dashboard version.
 func GetDashboardVersion(c *cli.Clients, ns string) (string, error) {
+
+	var version string
+
+	// for latest pipelines version
+	configMap, err := getConfigMap(c, dashboardInfo, ns)
+	if err == nil {
+		version = configMap.Data["version"]
+	}
+
+	if version != "" {
+		return version, nil
+	}
+
 	deploymentsList, err := getDeployments(c, dashboardControllerSelector, oldDashboardControllerSelector, ns)
 
 	if err != nil {
 		return "", err
 	}
 
-	version := findDashboardVersion(deploymentsList.Items)
+	version = findDashboardVersion(deploymentsList.Items)
 	if version == "" {
 		return "", fmt.Errorf("error getting the tekton dashboard deployment version. Version is unknown")
 	}


### PR DESCRIPTION
# Changes

As per the [TEP-0041](https://github.com/tektoncd/community/blob/main/teps/0041-tekton-component-versioning.md)
a ConfigMap is being added in tekton components such as Pipelines,
Triggers which can be given special permissions and any user
authenticated to the cluster can fetch the version from ConfigMap.

This patch fetches version from ConfigMap and if ConfigMap doesn't
exists then it checks for the version label present on the controller
deployment(backward compatible). Added tests for the same.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Fetch the version of installed tekton components from the ConfigMap and if configmap is not present then fetch from the deployment controller
```