### PR TITLE
fix default --prefix=false with p/t/ct start

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -322,6 +322,7 @@ func startClusterTask(opt startOptions, args []string) error {
 		TaskrunName: trCreated.Name,
 		Stream:      opt.stream,
 		Follow:      true,
+		Prefixing:   true,
 		Params:      opt.cliparams,
 		AllSteps:    false,
 	}

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -355,6 +355,7 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 		PipelineRunName: prCreated.Name,
 		Stream:          opt.stream,
 		Follow:          true,
+		Prefixing:       true,
 		Params:          opt.cliparams,
 		AllSteps:        false,
 	}

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -399,6 +399,7 @@ func startTask(opt startOptions, args []string) error {
 		TaskrunName: trCreated.Name,
 		Stream:      opt.stream,
 		Follow:      true,
+		Prefixing:   true,
 		Params:      opt.cliparams,
 		AllSteps:    false,
 	}


### PR DESCRIPTION
fix #1404
this put true as default for --prefix with all the pipeline,
task, and clustertask start command.

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
