### PR TITLE
Force cancel when using tkn pipelinerun cancel 👼

### DIFF
--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -108,7 +108,8 @@ func PipelineDescription(desc string) PipelineSpecOp {
 
 // PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
 func PipelineRunCancelled(spec *v1beta1.PipelineRunSpec) {
-	spec.Status = v1beta1.PipelineRunSpecStatusCancelled
+	// nolint: staticcheck
+	spec.Status = v1beta1.PipelineRunSpecStatusCancelledDeprecated
 }
 
 // PipelineDeclaredResource adds a resource declaration to the Pipeline Spec,

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -4538,7 +4538,8 @@ func Test_start_pipeline_use_pipelinerun_cancelled_status_v1beta1(t *testing.T) 
 					},
 				},
 				Timeout: &metav1.Duration{Duration: timeoutDuration},
-				Status:  v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusCancelled),
+				// nolint: staticcheck
+				Status: v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusCancelledDeprecated),
 			},
 			Status: v1beta1.PipelineRunStatus{
 				Status: duckv1beta1.Status{

--- a/pkg/cmd/pipelinerun/cancel.go
+++ b/pkg/cmd/pipelinerun/cancel.go
@@ -74,7 +74,7 @@ func cancelPipelineRun(p cli.Params, s *cli.Stream, prName string) error {
 		}
 	}
 
-	if _, err = pipelinerun.Patch(cs, prName, metav1.PatchOptions{}, p.Namespace()); err != nil {
+	if _, err = pipelinerun.Cancel(cs, prName, metav1.PatchOptions{}, p.Namespace()); err != nil {
 		return fmt.Errorf("failed to cancel PipelineRun: %s: %v", prName, err)
 
 	}

--- a/pkg/pipelinerun/pipelinerun.go
+++ b/pkg/pipelinerun/pipelinerun.go
@@ -149,11 +149,12 @@ type patchStringValue struct {
 	Value string `json:"value"`
 }
 
-func Patch(c *cli.Clients, prname string, opts metav1.PatchOptions, ns string) (*v1beta1.PipelineRun, error) {
+func Cancel(c *cli.Clients, prname string, opts metav1.PatchOptions, ns string) (*v1beta1.PipelineRun, error) {
 	payload := []patchStringValue{{
-		Op:    "replace",
-		Path:  "/spec/status",
-		Value: v1beta1.PipelineRunSpecStatusCancelled,
+		Op:   "replace",
+		Path: "/spec/status",
+		// nolint: staticcheck
+		Value: v1beta1.PipelineRunSpecStatusCancelledDeprecated,
 	}}
 
 	data, _ := json.Marshal(payload)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With https://github.com/tektoncd/pipeline/pull/3915, there is now a
possibility to graceful cancel. As of today, the cli only supports
force cancelling.

When we updated the dependencies, we didn't change the constant we are
using from tektoncd/pipeline and thus, we were using the new value
that is only supported when alpha api are enabled — hence the CI is
broken.

This make the cli use the deprecated field for now, but we need to
follow up to support graceful cancellation.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes


```release-note
Force cancel when using tkn pipelinerun cancel, fixes a problem where, if targeting pipeline 0.25, the cancel feature doesn't work anymore.
```
