### PR TITLE
Get default sa from configmap defaultconfigs

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -159,6 +159,7 @@ for res in eventlistener triggertemplate triggerbinding clustertriggerbinding; d
 done
 
 # Run the e2e tests
+export SYSTEM_NAMESPACE=${SYSTEM_NAMESPACE:-"tekton-pipelines"}
 header "Running Go e2e tests"
 failed=0
 if [[ -e ./bin/tkn ]];then


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* upstream/midstream tests verifies for default service account while creating namespace, by default it's [hardcoded](https://github.com/tektoncd/cli/blob/main/test/framework/helper.go#L163) to `default`. 

* so if we install pipelines components via operator it sets `default-service-account` to `pipeline` in `config-defaults` config map!

* so it's safe to use this patch both in upstream/downstream as it actually waits for right service account before it actually start the execution of tests  
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
