### PR TITLE
fix rpm build

### DIFF
--- a/tekton/rpmbuild/tekton.spec
+++ b/tekton/rpmbuild/tekton.spec
@@ -638,9 +638,7 @@ ln -s $PWD/cli-%{version} _build/src/%{import_path}
 export GOPATH="$PWD/_build:%{gopath}"
 export LDFLAGS="${LDFLAGS:-} -X %{import_path}/pkg/cmd/version.clientVersion=%{version}"
 export PATH=$PATH:"%{_builddir}"/bin
-go env -w GO111MODULE=off
-go get -u github.com/golang/dep/cmd/dep
-GO111MODULE=on go install
+export GO111MODULE=off
 
 %gobuild -o _bin/tkn %{import_path}/cmd/tkn
 


### PR DESCRIPTION
this removes all the go module configs from tekton.spec
and just adds export GO111MODULE=off.

Not very sure how it fixes, but all jobs for rpm build passes
with this

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
