### PR TITLE
Fix e2e test failing

### DIFF
--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -117,7 +117,7 @@ Waiting for logs to be available...
 				if _, err := c.ExpectString("Choose the git resource to use for source:"); err != nil {
 					return err
 				}
-				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold#main)"); err != nil {
 					return err
 				}
 				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -609,7 +609,7 @@ func getGitResource(rname string, namespace string) *v1alpha1.PipelineResource {
 	return tb.PipelineResource(rname, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("url", "https://github.com/GoogleContainerTools/skaffold"),
-		tb.PipelineResourceSpecParam("revision", "master"),
+		tb.PipelineResourceSpecParam("revision", "main"),
 	))
 }
 
@@ -617,7 +617,7 @@ func getFaultGitResource(rname string, namespace string) *v1alpha1.PipelineResou
 	return tb.PipelineResource(rname, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("url", "https://github.com/GoogleContainerTools/skaffold-1"),
-		tb.PipelineResourceSpecParam("revision", "master"),
+		tb.PipelineResourceSpecParam("revision", "main"),
 	))
 }
 

--- a/test/e2e/pipeline/start_test.go
+++ b/test/e2e/pipeline/start_test.go
@@ -51,7 +51,7 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold#main)"); err != nil {
 					return err
 				}
 
@@ -97,7 +97,7 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold#main)"); err != nil {
 					return err
 				}
 
@@ -131,7 +131,7 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold#main)"); err != nil {
 					return err
 				}
 
@@ -166,7 +166,7 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold)"); err != nil {
+				if _, err := c.ExpectString("skaffold-git (https://github.com/GoogleContainerTools/skaffold#main)"); err != nil {
 					return err
 				}
 
@@ -246,7 +246,7 @@ func TestPipelineInteractiveStartWithNewResourceE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.SendLine("master"); err != nil {
+				if _, err := c.SendLine("main"); err != nil {
 					return err
 				}
 

--- a/test/resources/git-resource.yaml
+++ b/test/resources/git-resource.yaml
@@ -20,6 +20,6 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: main
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold

--- a/test/resources/output-pipelinerun.yaml
+++ b/test/resources/output-pipelinerun.yaml
@@ -21,7 +21,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: main
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---


### PR DESCRIPTION
This will fix the e2e test failing as the master branch
of https://github.com/GoogleContainerTools/skaffold is not
available anymore. Now the default branch is main

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix e2e test failing
```