### PR TITLE
Add --keep-since flag to taskrun delete

### DIFF
--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -34,6 +34,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
       --keep int                      Keep n most recent number of TaskRuns
+      --keep-since int                When deleting all TaskRuns keep the ones that has been completed since n minutes
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
   -t, --task string                   The name of a Task whose TaskRuns should be deleted (does not delete the task)
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -44,6 +44,10 @@ Delete TaskRuns in a namespace
     Keep n most recent number of TaskRuns
 
 .PP
+\fB\-\-keep\-since\fP=0
+    When deleting all TaskRuns keep the ones that has been completed since n minutes
+
+.PP
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|name|go\-template|go\-template\-file|template|templatefile|jsonpath|jsonpath\-as\-json|jsonpath\-file.
 

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -87,6 +87,10 @@ or
 				return fmt.Errorf("keep option should not be lower than 0")
 			}
 
+			if opts.KeepSince < 0 {
+				return fmt.Errorf("since option should not be lower than 0")
+			}
+
 			if opts.Keep > 0 && opts.ParentResourceName == "" {
 				opts.DeleteAllNs = true
 			}


### PR DESCRIPTION
# Changes

Add `--keep-since` flag to `taskrun` delete. Keep the ones that has been completed since n minutes when deleting all TaskRuns. 

This PR is basically a copy of #1392.

Issue: #1407 #1388 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
add option --keep-since to tkn tr delete --all to allow keeping some trs that are younger than X minutes when deleting all taskruns. 
```