### PR TITLE
Add --use-workspace-defaults

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -60,6 +60,7 @@ For passing the workspaces via flags:
       --timeout string            timeout for TaskRun
       --use-param-defaults        use default parameter values without prompting for input
       --use-taskrun string        specify a TaskRun name to use its values to re-run the TaskRun
+      --use-workspace-defaults    use default workspace configuration without prompting for input
   -w, --workspace stringArray     pass one or more workspaces to map to the corresponding physical volumes
 ```
 

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -68,6 +68,7 @@ my-secret, my-empty-dir and my-volume-claim-template)
       --timeout string                timeout for PipelineRun
       --use-param-defaults            use default parameter values without prompting for input
       --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
+      --use-workspace-defaults        use default workspace configuration without prompting for input
   -w, --workspace stringArray         pass one or more workspaces to map to the corresponding physical volumes
 ```
 

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -60,6 +60,7 @@ For passing the workspaces via flags:
       --timeout string            timeout for TaskRun
       --use-param-defaults        use default parameter values without prompting for input
       --use-taskrun string        specify a TaskRun name to use its values to re-run the TaskRun
+      --use-workspace-defaults    use default workspace configuration without prompting for input
   -w, --workspace stringArray     pass one or more workspaces to map to the corresponding physical volumes
 ```
 

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -84,6 +84,10 @@ Start ClusterTasks
     specify a TaskRun name to use its values to re\-run the TaskRun
 
 .PP
+\fB\-\-use\-workspace\-defaults\fP[=false]
+    use default workspace configuration without prompting for input
+
+.PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
     pass one or more workspaces to map to the corresponding physical volumes
 

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -96,6 +96,10 @@ Parameters, at least those that have no default value
     use this pipelinerun values to re\-run the pipeline.
 
 .PP
+\fB\-\-use\-workspace\-defaults\fP[=false]
+    use default workspace configuration without prompting for input
+
+.PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
     pass one or more workspaces to map to the corresponding physical volumes
 

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -88,6 +88,10 @@ Start Tasks
     specify a TaskRun name to use its values to re\-run the TaskRun
 
 .PP
+\fB\-\-use\-workspace\-defaults\fP[=false]
+    use default workspace configuration without prompting for input
+
+.PP
 \fB\-w\fP, \fB\-\-workspace\fP=[]
     pass one or more workspaces to map to the corresponding physical volumes
 

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -71,6 +71,7 @@ type startOptions struct {
 	PrefixName            string
 	Workspaces            []string
 	UseParamDefaults      bool
+	UseWorkspaceDefaults  bool
 	clustertask           *v1beta1.ClusterTask
 	askOpts               survey.AskOpt
 	TektonOptions         flags.TektonOptions
@@ -196,6 +197,7 @@ For passing the workspaces via flags:
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
 	c.Flags().BoolVar(&opt.UseParamDefaults, "use-param-defaults", false, "use default parameter values without prompting for input")
+	c.Flags().BoolVarP(&opt.UseWorkspaceDefaults, "use-workspace-defaults", "", false, "use default workspace configuration without prompting for input")
 	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
 
 	return c
@@ -472,7 +474,7 @@ func (opt *startOptions) getInputs() error {
 		opt.Params = append(opt.Params, intOpts.Params...)
 	}
 
-	if len(opt.Workspaces) == 0 && !opt.Last && opt.UseTaskRun == "" {
+	if len(opt.Workspaces) == 0 && !opt.Last && opt.UseTaskRun == "" && !opt.UseWorkspaceDefaults {
 		if err := intOpts.ClusterTaskWorkspaces(opt.clustertask); err != nil {
 			return err
 		}

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -79,6 +79,7 @@ type startOptions struct {
 	Filename              string
 	Workspaces            []string
 	UseParamDefaults      bool
+	UseWorkspaceDefaults  bool
 	TektonOptions         flags.TektonOptions
 	PodTemplate           string
 	SkipOptionalWorkspace bool
@@ -191,6 +192,7 @@ For passing the workspaces via flags:
 	c.Flags().StringVarP(&opt.TimeOut, "timeout", "", "", "timeout for PipelineRun")
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a Pipeline definition to start a PipelineRun")
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
+	c.Flags().BoolVarP(&opt.UseWorkspaceDefaults, "use-workspace-defaults", "", false, "use default workspace configuration without prompting for input")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
 	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
 
@@ -404,7 +406,7 @@ func (opt *startOptions) getInput(pipeline *v1beta1.Pipeline) error {
 		}
 	}
 
-	if len(opt.Workspaces) == 0 && !opt.Last && opt.UsePipelineRun == "" {
+	if len(opt.Workspaces) == 0 && !opt.Last && opt.UsePipelineRun == "" && !opt.UseWorkspaceDefaults {
 		if err = opt.getInputWorkspaces(pipeline); err != nil {
 			return err
 		}

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -77,6 +77,7 @@ type startOptions struct {
 	askOpts               survey.AskOpt
 	TektonOptions         flags.TektonOptions
 	UseParamDefaults      bool
+	UseWorkspaceDefaults  bool
 	PodTemplate           string
 	SkipOptionalWorkspace bool
 }
@@ -218,6 +219,7 @@ For passing the workspaces via flags:
 	c.Flags().StringVarP(&opt.Output, "output", "", "", "format of TaskRun (yaml or json)")
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)")
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
+	c.Flags().BoolVarP(&opt.UseWorkspaceDefaults, "use-workspace-defaults", "", false, "use default workspace configuration without prompting for input")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
 	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
 	return c
@@ -554,7 +556,7 @@ func (opt *startOptions) getInputs() error {
 		opt.Params = append(opt.Params, intOpts.Params...)
 	}
 
-	if len(opt.Workspaces) == 0 && !opt.Last && opt.UseTaskRun == "" {
+	if len(opt.Workspaces) == 0 && !opt.Last && opt.UseTaskRun == "" && !opt.UseWorkspaceDefaults {
 		if err := intOpts.TaskWorkspaces(opt.task); err != nil {
 			return err
 		}


### PR DESCRIPTION
* tkn task start always asks for the configuration of the workspaces,
even if you have:

```yaml
  default-task-run-workspace-binding: |
    emptyDir: {}
```

In the config-defaults.

If there is another way to achieve this, please let me know.

```release-note
Add a new flag `--use-workspace-default` to use the configured default workspace for the task run
```