### PR TITLE
Delete runs using resource filter and keep-since

### DIFF
--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -17,6 +17,7 @@ package pipelinerun
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -78,6 +79,10 @@ or
 
 			if (opts.Keep > 0 || opts.KeepSince > 0) && opts.ParentResourceName == "" {
 				opts.DeleteAllNs = true
+			}
+
+			if (opts.Keep > 0 || opts.KeepSince > 0) && opts.DeleteAllNs && opts.ParentResourceName != "" {
+				return fmt.Errorf("--keep or --keep-since, --all and --%s cannot be used together", strings.ToLower(opts.ParentResource))
 			}
 
 			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -376,6 +376,15 @@ func TestPipelineRunDelete(t *testing.T) {
 			wantError:   true,
 			want:        "keep-since option should not be lower than 0",
 		},
+		{
+			name:        "Error --keep-since, --all and --task cannot be used",
+			command:     []string{"delete", "-f", "--keep-since", "1", "--all", "-p", "foobar", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep or --keep-since, --all and --pipeline cannot be used together",
+		},
 	}
 
 	for _, tp := range testParams {
@@ -729,6 +738,15 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "keep-since option should not be lower than 0",
+		},
+		{
+			name:        "Error --keep-since, --all and --task cannot be used",
+			command:     []string{"delete", "-f", "--keep-since", "1", "--all", "-p", "foobar", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep or --keep-since, --all and --pipeline cannot be used together",
 		},
 	}
 

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -131,7 +131,7 @@ func TestPipelineRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -332,15 +332,6 @@ func TestPipelineRunDelete(t *testing.T) {
 			want:        "3 expired PipelineRuns has been deleted in namespace \"ns\", kept 1\n",
 		},
 		{
-			name:        "Only use since with --all",
-			command:     []string{"delete", "-f", "--keep-since", "60", "-n", "ns"},
-			dynamic:     seeds[7].dynamicClient,
-			input:       seeds[7].pipelineClient,
-			inputStream: nil,
-			wantError:   true,
-			want:        "--keep-since option can only be used with --all",
-		},
-		{
 			name:        "No mixing --keep-since and --keep",
 			command:     []string{"delete", "-f", "--keep-since", "60", "--keep", "5", "-n", "ns"},
 			dynamic:     seeds[7].dynamicClient,
@@ -357,6 +348,33 @@ func TestPipelineRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "Are you sure you want to delete all PipelineRuns in namespace \"ns\" (y/n): All PipelineRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all PipelineRuns older than 60mn associated with Pipeline pipeline",
+			command:     []string{"delete", "-f", "--pipeline", "pipeline", "--keep-since", "60", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 3 expired PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete all PipelineRuns older than 60mn associated with Pipeline pipeline",
+			command:     []string{"delete", "-f", "--keep-since", "60", "--all", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "0 expired PipelineRuns has been deleted in namespace \"ns\", kept 1\n",
+		},
+		{
+			name:        "Error --keep-since less than zero",
+			command:     []string{"delete", "-f", "--keep-since", "-1", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "keep-since option should not be lower than 0",
 		},
 	}
 
@@ -504,7 +522,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 7; i++ {
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -684,6 +702,33 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			inputStream: strings.NewReader("y"),
 			wantError:   true,
 			want:        "--keep flag should not have any arguments specified with it",
+		},
+		{
+			name:        "Delete all PipelineRuns older than 60mn associated with Pipeline pipeline",
+			command:     []string{"delete", "-f", "--pipeline", "pipeline", "--keep-since", "60", "-n", "ns"},
+			dynamic:     seeds[6].dynamicClient,
+			input:       seeds[6].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 3 expired PipelineRuns associated with Pipeline \"pipeline\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error on using --keep and --keep-since together",
+			command:     []string{"delete", "-f", "--keep-since", "60", "--keep", "2", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "cannot mix --keep and --keep-since options",
+		},
+		{
+			name:        "Error --keep-since less than zero",
+			command:     []string{"delete", "-f", "--keep-since", "-1", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "keep-since option should not be lower than 0",
 		},
 	}
 

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -17,6 +17,7 @@ package taskrun
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/tektoncd/cli/pkg/formatted"
@@ -97,6 +98,10 @@ or
 
 			if opts.Keep > 0 && opts.KeepSince > 0 {
 				return fmt.Errorf("cannot mix --keep and --keep-since options")
+			}
+
+			if (opts.Keep > 0 || opts.KeepSince > 0) && opts.DeleteAllNs && opts.ParentResourceName != "" {
+				return fmt.Errorf("--keep or --keep-since, --all and --%s cannot be used together", strings.ToLower(opts.ParentResource))
 			}
 
 			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -269,7 +269,7 @@ func TestTaskRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 8; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Tasks: tasks, ClusterTasks: clustertasks, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 		tdc := testDynamic.Options{}
@@ -507,15 +507,6 @@ func TestTaskRunDelete(t *testing.T) {
 			want:        "6 expired Taskruns has been deleted in namespace \"ns\", kept 1\n",
 		},
 		{
-			name:        "Only use since with --all",
-			command:     []string{"delete", "-f", "--keep-since", "60", "-n", "ns"},
-			dynamic:     seeds[6].dynamicClient,
-			input:       seeds[6].pipelineClient,
-			inputStream: nil,
-			wantError:   true,
-			want:        "--keep-since option can only be used with --all",
-		},
-		{
 			name:        "No mixing --keep-since and --keep",
 			command:     []string{"delete", "-f", "--keep-since", "60", "--keep", "5", "-n", "ns"},
 			dynamic:     seeds[6].dynamicClient,
@@ -523,6 +514,24 @@ func TestTaskRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "cannot mix --keep and --keep-since options",
+		},
+		{
+			name:        "Delete all Taskruns older than 60mn associated with random Task",
+			command:     []string{"delete", "-f", "--task", "random", "--keep-since", "60", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 3 expired TaskRuns associated with \"Task\" \"random\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error --keep-since less than zero",
+			command:     []string{"delete", "-f", "--task", "random", "--keep-since", "-1", "-n", "ns"},
+			dynamic:     seeds[6].dynamicClient,
+			input:       seeds[6].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "since option should not be lower than 0",
 		},
 	}
 
@@ -787,7 +796,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 8; i++ {
 		trs := trdata
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{TaskRuns: trs, Tasks: tasks, ClusterTasks: clustertasks, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
@@ -1008,15 +1017,6 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			want:        "6 expired Taskruns has been deleted in namespace \"ns\", kept 1\n",
 		},
 		{
-			name:        "Only use since with --all",
-			command:     []string{"delete", "-f", "--keep-since", "60", "-n", "ns"},
-			dynamic:     seeds[6].dynamicClient,
-			input:       seeds[6].pipelineClient,
-			inputStream: nil,
-			wantError:   true,
-			want:        "--keep-since option can only be used with --all",
-		},
-		{
 			name:        "No mixing --keep-since and --keep",
 			command:     []string{"delete", "-f", "--keep-since", "60", "--keep", "5", "-n", "ns"},
 			dynamic:     seeds[6].dynamicClient,
@@ -1024,6 +1024,24 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "cannot mix --keep and --keep-since options",
+		},
+		{
+			name:        "Delete all Taskruns older than 60mn associated with random Task",
+			command:     []string{"delete", "-f", "--task", "random", "--keep-since", "60", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "All but 3 expired TaskRuns associated with \"Task\" \"random\" deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Error --keep-since less than zero",
+			command:     []string{"delete", "-f", "--task", "random", "--keep-since", "-1", "-n", "ns"},
+			dynamic:     seeds[6].dynamicClient,
+			input:       seeds[6].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "since option should not be lower than 0",
 		},
 	}
 

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -533,6 +533,15 @@ func TestTaskRunDelete(t *testing.T) {
 			wantError:   true,
 			want:        "since option should not be lower than 0",
 		},
+		{
+			name:        "Error --keep-since, --all and --task cannot be used",
+			command:     []string{"delete", "-f", "--task", "random", "--keep-since", "1", "--all", "-n", "ns"},
+			dynamic:     seeds[6].dynamicClient,
+			input:       seeds[6].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep or --keep-since, --all and --task cannot be used together",
+		},
 	}
 
 	for _, tp := range testParams {
@@ -1042,6 +1051,15 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "since option should not be lower than 0",
+		},
+		{
+			name:        "Error --keep-since, --all and --task cannot be used",
+			command:     []string{"delete", "-f", "--task", "random", "--keep-since", "1", "--all", "-n", "ns"},
+			dynamic:     seeds[6].dynamicClient,
+			input:       seeds[6].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "--keep or --keep-since, --all and --task cannot be used together",
 		},
 	}
 

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -71,6 +71,9 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	if o.Keep > 0 {
 		keepStr = fmt.Sprintf(" keeping %d %ss", o.Keep, o.Resource)
 	}
+	if o.KeepSince > 0 {
+		keepStr = fmt.Sprintf(" except for ones created in last %d minutes", o.KeepSince)
+	}
 	switch {
 	case o.DeleteAllNs:
 		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss in namespace %q%s (y/n): ", o.Resource, ns, keepStr)

--- a/pkg/options/delete_test.go
+++ b/pkg/options/delete_test.go
@@ -151,6 +151,14 @@ func TestDeleteOptions(t *testing.T) {
 			wantError:      true,
 			want:           "must provide Condition name(s) or use --all flag with delete",
 		},
+		{
+			name:           "Specify KeepSince, ParentResource, ParentResourceName and Resource",
+			opt:            &DeleteOptions{KeepSince: 20, ParentResource: "Task", ParentResourceName: "foobar", Resource: "TaskRun"},
+			resourcesNames: []string{},
+			wantError:      false,
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			want:           "Are you sure you want to delete all TaskRuns related to Task \"foobar\" except for ones created in last 20 minutes (y/n)",
+		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
# Changes

Deleting the Runs by filtering them with the help of their parent
resource and longer than x minutes. Sample UX

```bash=
$ tkn pr delete -p foobar --keep-since x
$ tkn tr delete -t foobar --keep-since x
$ tkn tr delete --clustertask foobar --keep-since x
```

closes #1442 
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Delete PipelineRun or TaskRun by using --parent-resource and --keep-since together
```