### PR TITLE
Refactoring in triggertemplate and triggerbinding

### DIFF
--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -82,7 +82,7 @@ func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string, delete
 	})
 
 	if deleteAll {
-		tbNames, err = allTriggerBindingNames(cs, p.Namespace())
+		tbNames, err = triggerbinding.GetAllTriggerBindingNames(cs, p.Namespace())
 		if err != nil {
 			return err
 		}
@@ -97,16 +97,4 @@ func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string, delete
 		}
 	}
 	return d.Errors()
-}
-
-func allTriggerBindingNames(cs *cli.Clients, ns string) ([]string, error) {
-	tbs, err := triggerbinding.List(cs, metav1.ListOptions{}, ns)
-	if err != nil {
-		return nil, err
-	}
-	var names []string
-	for _, tb := range tbs.Items {
-		names = append(names, tb.Name)
-	}
-	return names, nil
 }

--- a/pkg/test/builder/unstructured.go
+++ b/pkg/test/builder/unstructured.go
@@ -114,7 +114,7 @@ func UnstructuredV1beta1CT(clustertask *v1beta1.ClusterTask, version string) *un
 
 func UnstructuredV1beta1TT(triggertemplate *triggersv1beta1.TriggerTemplate, version string) *unstructured.Unstructured {
 	triggertemplate.APIVersion = "triggers.tekton.dev/" + version
-	triggertemplate.Kind = "triggertemplate"
+	triggertemplate.Kind = "TriggerTemplate"
 	object, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(triggertemplate)
 	return &unstructured.Unstructured{
 		Object: object,

--- a/pkg/triggertemplate/triggertemplate.go
+++ b/pkg/triggertemplate/triggertemplate.go
@@ -28,13 +28,8 @@ import (
 
 var triggertemplateGroupResource = schema.GroupVersionResource{Group: "triggers.tekton.dev", Resource: "triggertemplates"}
 
-func GetAllTriggerTemplateNames(p cli.Params) ([]string, error) {
-	cs, err := p.Clients()
-	if err != nil {
-		return nil, err
-	}
-
-	ps, err := List(cs, metav1.ListOptions{}, p.Namespace())
+func GetAllTriggerTemplateNames(client *cli.Clients, namespace string) ([]string, error) {
+	ps, err := List(client, metav1.ListOptions{}, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/triggertemplate/triggertemplate_test.go
+++ b/pkg/triggertemplate/triggertemplate_test.go
@@ -119,7 +119,11 @@ func TestTriggerTemplate_GetAllTriggerTemplate(t *testing.T) {
 
 	for _, tp := range testParams {
 		t.Run(tp.name, func(t *testing.T) {
-			got, err := GetAllTriggerTemplateNames(tp.params)
+			cs, err := tp.params.Clients()
+			if err != nil {
+				t.Errorf("unexpected Error, not able to get clients")
+			}
+			got, err := GetAllTriggerTemplateNames(cs, tp.params.Namespace())
 			if err != nil {
 				t.Errorf("unexpected Error")
 			}
@@ -229,4 +233,52 @@ func TestTriggerTemplate_List(t *testing.T) {
 			test.AssertOutput(t, tp.want, ttnames)
 		})
 	}
+}
+
+func TestTriggerTemplate_Get(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	tt := []*v1beta1.TriggerTemplate{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "tt1",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "tt2",
+				Namespace:         "ns",
+				CreationTimestamp: v1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+	}
+
+	cs := test.SeedTestResources(t, triggertest.Resources{TriggerTemplates: tt, Namespaces: []*corev1.Namespace{{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "ns",
+		},
+	}}})
+
+	cs.Triggers.Resources = cb.TriggersAPIResourceList("v1beta1", []string{"triggertemplate"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredV1beta1TT(tt[0], "v1beta1"),
+		cb.UnstructuredV1beta1TT(tt[1], "v1beta1"),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	p := &test.Params{Triggers: cs.Triggers, Kube: cs.Kube, Clock: clock, Dynamic: dc}
+	c, err := p.Clients()
+	if err != nil {
+		t.Errorf("unable to create client: %v", err)
+	}
+	got, err := Get(c, "tt2", v1.GetOptions{}, "ns")
+	if err != nil {
+		t.Errorf("unexpected Error")
+	}
+	test.AssertOutput(t, "tt2", got.Name)
 }


### PR DESCRIPTION
Fix hardcoded resource version in desc
This will fix the hardcoded apiversion getting output in
tt desc command, and some more refactoring code

Add tests for get function

Remove duplicate in triggerbinding

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
