### PR TITLE
Skips to ask specifications for optional workspace

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -44,22 +44,23 @@ For passing the workspaces via flags:
 ### Options
 
 ```
-      --dry-run                  preview TaskRun without running it
-  -h, --help                     help for start
-  -i, --inputresource strings    pass the input resource name and ref as name=ref
-  -l, --labels strings           pass labels as label=value.
-  -L, --last                     re-run the ClusterTask using last TaskRun values
-      --output string            format of TaskRun (yaml or json)
-  -o, --outputresource strings   pass the output resource name and ref as name=ref
-  -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
-      --pod-template string      local or remote file containing a PodTemplate definition
-      --prefix-name string       specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
-  -s, --serviceaccount string    pass the serviceaccount name
-      --showlog                  show logs right after starting the ClusterTask
-      --timeout string           timeout for TaskRun
-      --use-param-defaults       use default parameter values without prompting for input
-      --use-taskrun string       specify a TaskRun name to use its values to re-run the TaskRun
-  -w, --workspace stringArray    pass one or more workspaces to map to the corresponding physical volumes
+      --dry-run                   preview TaskRun without running it
+  -h, --help                      help for start
+  -i, --inputresource strings     pass the input resource name and ref as name=ref
+  -l, --labels strings            pass labels as label=value.
+  -L, --last                      re-run the ClusterTask using last TaskRun values
+      --output string             format of TaskRun (yaml or json)
+  -o, --outputresource strings    pass the output resource name and ref as name=ref
+  -p, --param stringArray         pass the param as key=value for string type, or key=value1,value2,... for array type
+      --pod-template string       local or remote file containing a PodTemplate definition
+      --prefix-name string        specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
+  -s, --serviceaccount string     pass the serviceaccount name
+      --showlog                   show logs right after starting the ClusterTask
+      --skip-optional-workspace   skips the prompt for optional workspaces
+      --timeout string            timeout for TaskRun
+      --use-param-defaults        use default parameter values without prompting for input
+      --use-taskrun string        specify a TaskRun name to use its values to re-run the TaskRun
+  -w, --workspace stringArray     pass one or more workspaces to map to the corresponding physical volumes
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -63,6 +63,7 @@ my-secret, my-empty-dir and my-volume-claim-template)
   -r, --resource strings              pass the resource name and ref as name=ref
   -s, --serviceaccount string         pass the serviceaccount name
       --showlog                       show logs right after starting the Pipeline
+      --skip-optional-workspace       skips the prompt for optional workspaces
       --task-serviceaccount strings   pass the service account corresponding to the task
       --timeout string                timeout for PipelineRun
       --use-param-defaults            use default parameter values without prompting for input

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -43,23 +43,24 @@ For passing the workspaces via flags:
 ### Options
 
 ```
-      --dry-run                  preview TaskRun without running it
-  -f, --filename string          local or remote file name containing a Task definition to start a TaskRun
-  -h, --help                     help for start
-  -i, --inputresource strings    pass the input resource name and ref as name=ref
-  -l, --labels strings           pass labels as label=value.
-  -L, --last                     re-run the Task using last TaskRun values
-      --output string            format of TaskRun (yaml or json)
-  -o, --outputresource strings   pass the output resource name and ref as name=ref
-  -p, --param stringArray        pass the param as key=value for string type, or key=value1,value2,... for array type
-      --pod-template string      local or remote file containing a PodTemplate definition
-      --prefix-name string       specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
-  -s, --serviceaccount string    pass the serviceaccount name
-      --showlog                  show logs right after starting the Task
-      --timeout string           timeout for TaskRun
-      --use-param-defaults       use default parameter values without prompting for input
-      --use-taskrun string       specify a TaskRun name to use its values to re-run the TaskRun
-  -w, --workspace stringArray    pass one or more workspaces to map to the corresponding physical volumes
+      --dry-run                   preview TaskRun without running it
+  -f, --filename string           local or remote file name containing a Task definition to start a TaskRun
+  -h, --help                      help for start
+  -i, --inputresource strings     pass the input resource name and ref as name=ref
+  -l, --labels strings            pass labels as label=value.
+  -L, --last                      re-run the Task using last TaskRun values
+      --output string             format of TaskRun (yaml or json)
+  -o, --outputresource strings    pass the output resource name and ref as name=ref
+  -p, --param stringArray         pass the param as key=value for string type, or key=value1,value2,... for array type
+      --pod-template string       local or remote file containing a PodTemplate definition
+      --prefix-name string        specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
+  -s, --serviceaccount string     pass the serviceaccount name
+      --showlog                   show logs right after starting the Task
+      --skip-optional-workspace   skips the prompt for optional workspaces
+      --timeout string            timeout for TaskRun
+      --use-param-defaults        use default parameter values without prompting for input
+      --use-taskrun string        specify a TaskRun name to use its values to re-run the TaskRun
+  -w, --workspace stringArray     pass one or more workspaces to map to the corresponding physical volumes
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -68,6 +68,10 @@ Start ClusterTasks
     show logs right after starting the ClusterTask
 
 .PP
+\fB\-\-skip\-optional\-workspace\fP[=false]
+    skips the prompt for optional workspaces
+
+.PP
 \fB\-\-timeout\fP=""
     timeout for TaskRun
 

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -76,6 +76,10 @@ Parameters, at least those that have no default value
     show logs right after starting the Pipeline
 
 .PP
+\fB\-\-skip\-optional\-workspace\fP[=false]
+    skips the prompt for optional workspaces
+
+.PP
 \fB\-\-task\-serviceaccount\fP=[]
     pass the service account corresponding to the task
 

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -72,6 +72,10 @@ Start Tasks
     show logs right after starting the Task
 
 .PP
+\fB\-\-skip\-optional\-workspace\fP[=false]
+    skips the prompt for optional workspaces
+
+.PP
 \fB\-\-timeout\fP=""
     timeout for TaskRun
 

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -56,26 +56,27 @@ var (
 const invalidResource = "invalid input format for resource parameter: "
 
 type startOptions struct {
-	cliparams          cli.Params
-	stream             *cli.Stream
-	Params             []string
-	InputResources     []string
-	OutputResources    []string
-	ServiceAccountName string
-	Last               bool
-	Labels             []string
-	ShowLog            bool
-	TimeOut            string
-	DryRun             bool
-	Output             string
-	PrefixName         string
-	Workspaces         []string
-	UseParamDefaults   bool
-	clustertask        *v1beta1.ClusterTask
-	askOpts            survey.AskOpt
-	TektonOptions      flags.TektonOptions
-	PodTemplate        string
-	UseTaskRun         string
+	cliparams             cli.Params
+	stream                *cli.Stream
+	Params                []string
+	InputResources        []string
+	OutputResources       []string
+	ServiceAccountName    string
+	Last                  bool
+	Labels                []string
+	ShowLog               bool
+	TimeOut               string
+	DryRun                bool
+	Output                string
+	PrefixName            string
+	Workspaces            []string
+	UseParamDefaults      bool
+	clustertask           *v1beta1.ClusterTask
+	askOpts               survey.AskOpt
+	TektonOptions         flags.TektonOptions
+	PodTemplate           string
+	UseTaskRun            string
+	SkipOptionalWorkspace bool
 }
 
 // NameArg validates that the first argument is a valid clustertask name
@@ -195,6 +196,7 @@ For passing the workspaces via flags:
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
 	c.Flags().BoolVar(&opt.UseParamDefaults, "use-param-defaults", false, "use default parameter values without prompting for input")
+	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
 
 	return c
 }
@@ -436,10 +438,11 @@ func convertedTrVersion(c *cli.Clients, tr *v1beta1.TaskRun) (interface{}, error
 
 func (opt *startOptions) getInputs() error {
 	intOpts := options.InteractiveOpts{
-		Stream:    opt.stream,
-		CliParams: opt.cliparams,
-		AskOpts:   opt.askOpts,
-		Ns:        opt.cliparams.Namespace(),
+		Stream:                opt.stream,
+		CliParams:             opt.cliparams,
+		AskOpts:               opt.askOpts,
+		Ns:                    opt.cliparams.Namespace(),
+		SkipOptionalWorkspace: opt.SkipOptionalWorkspace,
 	}
 
 	if opt.clustertask.Spec.Resources != nil && !opt.Last && opt.UseTaskRun == "" {

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -61,26 +61,27 @@ const (
 )
 
 type startOptions struct {
-	cliparams          cli.Params
-	stream             *cli.Stream
-	askOpts            survey.AskOpt
-	Params             []string
-	Resources          []string
-	ServiceAccountName string
-	ServiceAccounts    []string
-	Last               bool
-	UsePipelineRun     string
-	Labels             []string
-	ShowLog            bool
-	DryRun             bool
-	Output             string
-	PrefixName         string
-	TimeOut            string
-	Filename           string
-	Workspaces         []string
-	UseParamDefaults   bool
-	TektonOptions      flags.TektonOptions
-	PodTemplate        string
+	cliparams             cli.Params
+	stream                *cli.Stream
+	askOpts               survey.AskOpt
+	Params                []string
+	Resources             []string
+	ServiceAccountName    string
+	ServiceAccounts       []string
+	Last                  bool
+	UsePipelineRun        string
+	Labels                []string
+	ShowLog               bool
+	DryRun                bool
+	Output                string
+	PrefixName            string
+	TimeOut               string
+	Filename              string
+	Workspaces            []string
+	UseParamDefaults      bool
+	TektonOptions         flags.TektonOptions
+	PodTemplate           string
+	SkipOptionalWorkspace bool
 }
 
 type resourceOptionsFilter struct {
@@ -191,6 +192,7 @@ For passing the workspaces via flags:
 	c.Flags().StringVarP(&opt.Filename, "filename", "f", "", "local or remote file name containing a Pipeline definition to start a PipelineRun")
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
+	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
 
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	_ = c.RegisterFlagCompletionFunc("serviceaccount",
@@ -802,6 +804,9 @@ func parsePipeline(pipelineLocation string, httpClient http.Client) (*v1beta1.Pi
 
 func (opt *startOptions) getInputWorkspaces(pipeline *v1beta1.Pipeline) error {
 	for _, ws := range pipeline.Spec.Workspaces {
+		if ws.Optional && opt.SkipOptionalWorkspace {
+			continue
+		}
 		if ws.Optional {
 			isOptional, err := askParam(fmt.Sprintf("Do you want to give specifications for the optional workspace `%s`: (y/N)", ws.Name), opt.askOpts)
 			if err != nil {

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -57,27 +57,28 @@ var (
 const invalidResource = "invalid input format for resource parameter: "
 
 type startOptions struct {
-	cliparams          cli.Params
-	stream             *cli.Stream
-	Params             []string
-	InputResources     []string
-	OutputResources    []string
-	ServiceAccountName string
-	Last               bool
-	Labels             []string
-	ShowLog            bool
-	Filename           string
-	TimeOut            string
-	DryRun             bool
-	Output             string
-	UseTaskRun         string
-	PrefixName         string
-	Workspaces         []string
-	task               *v1beta1.Task
-	askOpts            survey.AskOpt
-	TektonOptions      flags.TektonOptions
-	UseParamDefaults   bool
-	PodTemplate        string
+	cliparams             cli.Params
+	stream                *cli.Stream
+	Params                []string
+	InputResources        []string
+	OutputResources       []string
+	ServiceAccountName    string
+	Last                  bool
+	Labels                []string
+	ShowLog               bool
+	Filename              string
+	TimeOut               string
+	DryRun                bool
+	Output                string
+	UseTaskRun            string
+	PrefixName            string
+	Workspaces            []string
+	task                  *v1beta1.Task
+	askOpts               survey.AskOpt
+	TektonOptions         flags.TektonOptions
+	UseParamDefaults      bool
+	PodTemplate           string
+	SkipOptionalWorkspace bool
 }
 
 // NameArg validates that the first argument is a valid task name
@@ -218,7 +219,7 @@ For passing the workspaces via flags:
 	c.Flags().StringVarP(&opt.PrefixName, "prefix-name", "", "", "specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)")
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
-
+	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
 	return c
 }
 
@@ -519,10 +520,11 @@ func (opt *startOptions) getInputs() error {
 	}
 
 	intOpts := options.InteractiveOpts{
-		Stream:    opt.stream,
-		CliParams: opt.cliparams,
-		AskOpts:   opt.askOpts,
-		Ns:        opt.cliparams.Namespace(),
+		Stream:                opt.stream,
+		CliParams:             opt.cliparams,
+		AskOpts:               opt.askOpts,
+		Ns:                    opt.cliparams.Namespace(),
+		SkipOptionalWorkspace: opt.SkipOptionalWorkspace,
 	}
 
 	if opt.task.Spec.Resources != nil && !opt.Last && opt.UseTaskRun == "" {

--- a/pkg/options/start.go
+++ b/pkg/options/start.go
@@ -16,14 +16,15 @@ import (
 )
 
 type InteractiveOpts struct {
-	Stream          *cli.Stream
-	CliParams       cli.Params
-	InputResources  []string
-	OutputResources []string
-	Params          []string
-	Workspaces      []string
-	AskOpts         survey.AskOpt
-	Ns              string
+	Stream                *cli.Stream
+	CliParams             cli.Params
+	InputResources        []string
+	OutputResources       []string
+	Params                []string
+	Workspaces            []string
+	AskOpts               survey.AskOpt
+	Ns                    string
+	SkipOptionalWorkspace bool
 }
 
 type TaskRunOpts struct {
@@ -327,6 +328,9 @@ func (intOpts *InteractiveOpts) TaskParams(task *v1beta1.Task, skipParams map[st
 
 func (intOpts *InteractiveOpts) TaskWorkspaces(task *v1beta1.Task) error {
 	for _, ws := range task.Spec.Workspaces {
+		if ws.Optional && intOpts.SkipOptionalWorkspace {
+			continue
+		}
 		if ws.Optional {
 			isOptional, err := askParam(fmt.Sprintf("Do you want to give specifications for the optional workspace `%s`: (y/N)", ws.Name), intOpts.AskOpts)
 			if err != nil {
@@ -565,6 +569,9 @@ func (intOpts *InteractiveOpts) ClusterTaskParams(clustertask *v1beta1.ClusterTa
 
 func (intOpts *InteractiveOpts) ClusterTaskWorkspaces(clustertask *v1beta1.ClusterTask) error {
 	for _, ws := range clustertask.Spec.Workspaces {
+		if ws.Optional && intOpts.SkipOptionalWorkspace {
+			continue
+		}
 		if ws.Optional {
 			isOptional, err := askParam(fmt.Sprintf("Do you want to give specifications for the optional workspace `%s`: (y/N)", ws.Name), intOpts.AskOpts)
 			if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This patch skips to ask specifications for optional workspace in an interactive mode  if workspace of t/p/ct is optional and optional workspace skip flag(--skip-optional-workspace)is passed  with `tkn t/p/ct start` command 

Closes: #1444 

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
