### PR TITLE
Go compile darwin-arm64 in makefile for m1 macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ arm:
 .PHONY: arm64
 arm64:
 	GOOS=linux GOARCH=arm64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-arm64 ./cmd/tkn
+	GOOS=darwin GOARCH=arm64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-darwin-arm64 ./cmd/tkn
 
 .PHONY: s390x
 s390x:


### PR DESCRIPTION
In this simple change I copied the existing format for cross-compiling to different system architectures to output binaries for m1 macs (Darwin-aarch64/arm64). It looks like the rest of the automation will pick this change up automatically in the next release. Please let me know if there is anything else I can do for this PR