### PR TITLE
Handle graceful termination of Pipeline

### DIFF
--- a/docs/cmd/tkn_pipelinerun_cancel.md
+++ b/docs/cmd/tkn_pipelinerun_cancel.md
@@ -22,7 +22,12 @@ Cancel the PipelineRun named 'foo' from namespace 'bar':
 ### Options
 
 ```
-  -h, --help   help for cancel
+      --grace string   Gracefully cancel a PipelineRun
+                       To use this, you need to change the feature-flags configmap enable-api-fields to alpha instead of stable.
+                       Set to 'CancelledRunFinally' if you want to cancel the current running task and directly run the finally tasks.
+                       Set to 'StoppedRunFinally' if you want to cancel the remaining non-final task and directly run the finally tasks.
+                       
+  -h, --help           help for cancel
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-pipelinerun-cancel.1
+++ b/docs/man/man1/tkn-pipelinerun-cancel.1
@@ -20,6 +20,13 @@ Cancel a PipelineRun in a namespace
 
 .SH OPTIONS
 .PP
+\fB\-\-grace\fP=""
+    Gracefully cancel a PipelineRun
+To use this, you need to change the feature\-flags configmap enable\-api\-fields to alpha instead of stable.
+Set to 'CancelledRunFinally' if you want to cancel the current running task and directly run the finally tasks.
+Set to 'StoppedRunFinally' if you want to cancel the remaining non\-final task and directly run the finally tasks.
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for cancel
 

--- a/pkg/pipelinerun/pipelinerun.go
+++ b/pkg/pipelinerun/pipelinerun.go
@@ -149,12 +149,11 @@ type patchStringValue struct {
 	Value string `json:"value"`
 }
 
-func Cancel(c *cli.Clients, prname string, opts metav1.PatchOptions, ns string) (*v1beta1.PipelineRun, error) {
+func Cancel(c *cli.Clients, prname string, opts metav1.PatchOptions, cancelStatus, ns string) (*v1beta1.PipelineRun, error) {
 	payload := []patchStringValue{{
-		Op:   "replace",
-		Path: "/spec/status",
-		// nolint: staticcheck
-		Value: v1beta1.PipelineRunSpecStatusCancelledDeprecated,
+		Op:    "replace",
+		Path:  "/spec/status",
+		Value: cancelStatus,
 	}}
 
 	data, _ := json.Marshal(payload)


### PR DESCRIPTION
# Changes

With tektoncd/pipeline#3915, there is now a
possibility to graceful cancel. As of today, the cli only supports
force cancelling.

In this patch, a new flag is introduced `--grace` which handles all the
scenarios as follows

--grace string   Gracefully cancel a PipelineRun
              To use this, you need to change the feature-flags configmap enable-api-fields to alpha instead of stable.
              Set to 'CancelledRunFinally' if you want to cancel the current running task and directly run the finally tasks.
              Set to 'StoppedRunFinally' if you want to cancel the remaining non-final task and directly run the finally tasks.


closes #1416 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Handle graceful termination of the Pipeline
```