### PR TITLE
Show all cancelled taskruns in message section

### DIFF
--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun.golden
@@ -1,0 +1,42 @@
+Name:           pipeline-run
+Namespace:      ns
+Pipeline Ref:   pipeline
+Timeout:        1h0m0s
+Labels:
+ tekton.dev/pipeline=pipeline
+
+Status
+
+STARTED          DURATION    STATUS
+10 minutes ago   5 minutes   Cancelled(PipelineRunCancelled)
+
+Message
+
+PipelineRun "pipeline-run" was cancelled
+TaskRun(s) cancelled: tr-1, tr-2
+
+Resources
+
+ No resources
+
+Params
+
+ No params
+
+Results
+
+ No results
+
+Workspaces
+
+ No workspaces
+
+Taskruns
+
+ NAME   TASK NAME   STARTED         DURATION    STATUS
+ tr-2   t-2         8 minutes ago   2 minutes   Cancelled(TaskRunCancelled)
+ tr-1   t-1         9 minutes ago   2 minutes   Cancelled(TaskRunCancelled)
+
+Skipped Tasks
+
+ No Skipped Tasks

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
@@ -13,7 +13,8 @@ STARTED          DURATION    STATUS
 
 Message
 
-Resource test-resource not found in the pipelinerun (Testing tr failed)
+Resource test-resource not found in the pipelinerun
+TaskRun(s) cancelled: tr-1
 
 Resources
 


### PR DESCRIPTION
# Changes

When a pipelinerun was cancelled along with multiple taskruns being
going into cancelled state, the message section of describe command was
showing only one taskrun instead of multiple.

This PR handles the showing of list of multiple cancelled taskruns in
the message section of the pipelinerun describe command. Also added
tests.

closes #1216 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```