### PR TITLE
Checked existence of resources before deletion

### DIFF
--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -140,7 +140,7 @@ func TestClusterTaskDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 6; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			ClusterTasks: clusterTaskData,
 			TaskRuns:     taskRunData,
@@ -211,18 +211,18 @@ func TestClusterTaskDelete(t *testing.T) {
 			command:     []string{"rm", "nonexistent"},
 			dynamic:     seeds[2].dynamicClient,
 			input:       seeds[2].pipelineClient,
-			inputStream: strings.NewReader("y"),
+			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
 			command:     []string{"rm", "nonexistent", "nonexistent2", "-n", "ns"},
 			dynamic:     seeds[2].dynamicClient,
 			input:       seeds[2].pipelineClient,
-			inputStream: strings.NewReader("y"),
+			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found; clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -231,7 +231,7 @@ func TestClusterTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found; clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskrun(s) flag, reply yes",
@@ -280,9 +280,9 @@ func TestClusterTaskDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using clustertask name with --all",
-			command:     []string{"delete", "ct", "--all"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tomatoes2", "--all"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -295,6 +295,15 @@ func TestClusterTaskDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide ClusterTask name(s) or use --all flag with delete",
+		},
+		{
+			name:        "Delete the ClusterTask present and give error for non-existent ClusterTask",
+			command:     []string{"delete", "nonexistent", "tomatoes2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 	}
 
@@ -429,7 +438,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 6; i++ {
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			ClusterTasks: clusterTaskData,
 			TaskRuns:     taskRunData,
@@ -500,18 +509,18 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			command:     []string{"rm", "nonexistent"},
 			dynamic:     seeds[2].dynamicClient,
 			input:       seeds[2].pipelineClient,
-			inputStream: strings.NewReader("y"),
+			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found",
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
 			command:     []string{"rm", "nonexistent", "nonexistent2", "-n", "ns"},
 			dynamic:     seeds[2].dynamicClient,
 			input:       seeds[2].pipelineClient,
-			inputStream: strings.NewReader("y"),
+			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found; clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -520,7 +529,7 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTask \"nonexistent\": clustertasks.tekton.dev \"nonexistent\" not found; failed to delete ClusterTask \"nonexistent2\": clustertasks.tekton.dev \"nonexistent2\" not found",
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found; clustertasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskrun(s) flag, reply yes",
@@ -569,9 +578,9 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Error from using clustertask name with --all",
-			command:     []string{"delete", "ct", "--all"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tomatoes2", "--all"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -584,6 +593,15 @@ func TestClusterTaskDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide ClusterTask name(s) or use --all flag with delete",
+		},
+		{
+			name:        "Delete the ClusterTask present and give error for non-existent ClusterTask",
+			command:     []string{"delete", "nonexistent", "tomatoes2"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "clustertasks.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/clustertriggerbinding/delete_test.go
+++ b/pkg/cmd/clustertriggerbinding/delete_test.go
@@ -126,7 +126,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTriggerBinding \"nonexistent\": clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -134,7 +134,7 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete ClusterTriggerBinding \"nonexistent\": clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found; failed to delete ClusterTriggerBinding \"nonexistent2\": clustertriggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found; clustertriggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -154,8 +154,8 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using clustertriggerbinding name with --all",
-			command:     []string{"delete", "ctb", "--all"},
-			input:       seeds[4],
+			command:     []string{"delete", "ctb-2", "--all"},
+			input:       seeds[1],
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -167,6 +167,14 @@ func TestClusterTriggerBindingDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide clustertriggerbinding name(s) or use --all flag with delete",
+		},
+		{
+			name:        "Delete the ClusterTriggerBinding present and give error for non-existent ClusterTriggerBinding",
+			command:     []string{"delete", "nonexistent", "ctb-2"},
+			input:       seeds[1],
+			inputStream: nil,
+			wantError:   true,
+			want:        "clustertriggerbindings.triggers.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/eventlistener/delete_test.go
+++ b/pkg/cmd/eventlistener/delete_test.go
@@ -90,7 +90,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete EventListener \"el-1\": eventlisteners.triggers.tekton.dev \"el-1\" not found",
+			want:        "failed to get EventListener el-1: eventlisteners.triggers.tekton.dev \"el-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -146,7 +146,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete EventListener \"nonexistent\": eventlisteners.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "failed to get EventListener nonexistent: eventlisteners.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -154,7 +154,7 @@ func TestEventListenerDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete EventListener \"nonexistent\": eventlisteners.triggers.tekton.dev \"nonexistent\" not found; failed to delete EventListener \"nonexistent2\": eventlisteners.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "failed to get EventListener nonexistent: eventlisteners.triggers.tekton.dev \"nonexistent\" not found; failed to get EventListener nonexistent2: eventlisteners.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -174,8 +174,8 @@ func TestEventListenerDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using eventlistener name with --all",
-			command:     []string{"delete", "el", "--all", "-n", "ns"},
-			input:       seeds[4],
+			command:     []string{"delete", "el-2", "--all", "-n", "ns"},
+			input:       seeds[1],
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -187,6 +187,14 @@ func TestEventListenerDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide eventlistener name(s) or use --all flag with delete",
+		},
+		{
+			name:        "Delete the EventListener present and give error for non-existent EventListener",
+			command:     []string{"delete", "nonexistent", "el-2"},
+			input:       seeds[1],
+			inputStream: nil,
+			wantError:   true,
+			want:        "failed to get EventListener nonexistent: eventlisteners.triggers.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -123,7 +123,7 @@ func TestPipelineDelete(t *testing.T) {
 	}
 	seeds := make([]clients, 0)
 
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -167,7 +167,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"pipeline\": pipelines.tekton.dev \"pipeline\" not found",
+			want:        "pipelines.tekton.dev \"pipeline\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -212,7 +212,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found",
+			want:        "pipelines.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -221,7 +221,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "pipelines.tekton.dev \"nonexistent\" not found; pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --prs flag",
@@ -230,7 +230,7 @@ func TestPipelineDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "pipelines.tekton.dev \"nonexistent\" not found; pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With --prs flag, reply yes",
@@ -271,8 +271,8 @@ func TestPipelineDelete(t *testing.T) {
 		{
 			name:        "Error from using pipeline name with --all",
 			command:     []string{"delete", "pipeline", "--all", "-n", "ns"},
-			dynamic:     seeds[6].dynamicClient,
-			input:       seeds[6].pipelineClient,
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -294,6 +294,15 @@ func TestPipelineDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "Pipelines deleted: \"pipeline\", \"pipeline2\"\n",
+		},
+		{
+			name:        "Delete the Pipeline present and give error for non-existent Pipeline",
+			command:     []string{"delete", "nonexistent", "pipeline", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "pipelines.tekton.dev \"nonexistent\" not found",
 		},
 	}
 
@@ -412,7 +421,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 	}
 	seeds := make([]clients, 0)
 
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -456,7 +465,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"pipeline\": pipelines.tekton.dev \"pipeline\" not found",
+			want:        "pipelines.tekton.dev \"pipeline\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -501,7 +510,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found",
+			want:        "pipelines.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -510,7 +519,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "pipelines.tekton.dev \"nonexistent\" not found; pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --prs flag",
@@ -519,7 +528,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Pipeline \"nonexistent\": pipelines.tekton.dev \"nonexistent\" not found; failed to delete Pipeline \"nonexistent2\": pipelines.tekton.dev \"nonexistent2\" not found",
+			want:        "pipelines.tekton.dev \"nonexistent\" not found; pipelines.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete all flag, reply yes",
@@ -560,8 +569,8 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 		{
 			name:        "Error from using pipeline name with --all",
 			command:     []string{"delete", "pipeline", "--all", "-n", "ns"},
-			dynamic:     seeds[6].dynamicClient,
-			input:       seeds[6].pipelineClient,
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -583,6 +592,15 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "Pipelines deleted: \"pipeline\", \"pipeline2\"\n",
+		},
+		{
+			name:        "Delete the Pipeline present and give error for non-existent Pipeline",
+			command:     []string{"delete", "nonexistent", "pipeline2", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "pipelines.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -182,7 +182,7 @@ func TestPipelineRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 9; i++ {
+	for i := 0; i < 10; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -218,7 +218,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete PipelineRun \"pipeline-run-1\": pipelineruns.tekton.dev \"pipeline-run-1\" not found",
+			want:        "pipelineruns.tekton.dev \"pipeline-run-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -263,7 +263,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
+			want:        "pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -272,7 +272,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found; failed to delete PipelineRun \"nonexistent2\": pipelineruns.tekton.dev \"nonexistent2\" not found",
+			want:        "pipelineruns.tekton.dev \"nonexistent\" not found; pipelineruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include pipelinerun names",
@@ -339,18 +339,18 @@ func TestPipelineRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using pipelinerun name with --all",
-			command:     []string{"delete", "pipelinerun", "--all", "-n", "ns"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "pipeline-run-1", "--all", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 		{
 			name:        "Error from deleting PipelineRun with non-existing Pipeline",
-			command:     []string{"delete", "pipelinerun", "-p", "non-existing-pipeline"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "pipeline-run-1", "-p", "non-existing-pipeline", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "no PipelineRuns associated with Pipeline \"non-existing-pipeline\"",
@@ -366,7 +366,7 @@ func TestPipelineRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using argument with --keep",
-			command:     []string{"rm", "pipelinerun", "--keep", "2"},
+			command:     []string{"rm", "pipeline-run-1", "--keep", "2", "-n", "ns"},
 			dynamic:     seeds[6].dynamicClient,
 			input:       seeds[6].pipelineClient,
 			inputStream: nil,
@@ -462,6 +462,15 @@ func TestPipelineRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "--keep or --keep-since, --all and --pipeline cannot be used together",
+		},
+		{
+			name:        "Delete the PipelineRun present and give error for non-existent PipelineRun",
+			command:     []string{"delete", "nonexistent", "pipeline-run-1", "-n", "ns"},
+			dynamic:     seeds[9].dynamicClient,
+			input:       seeds[9].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
 	}
 
@@ -609,7 +618,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 8; i++ {
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			Pipelines:    pdata,
 			PipelineRuns: prdata,
@@ -644,7 +653,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete PipelineRun \"pipeline-run-1\": pipelineruns.tekton.dev \"pipeline-run-1\" not found",
+			want:        "pipelineruns.tekton.dev \"pipeline-run-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -689,7 +698,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found",
+			want:        "pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -698,7 +707,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete PipelineRun \"nonexistent\": pipelineruns.tekton.dev \"nonexistent\" not found; failed to delete PipelineRun \"nonexistent2\": pipelineruns.tekton.dev \"nonexistent2\" not found",
+			want:        "pipelineruns.tekton.dev \"nonexistent\" not found; pipelineruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include pipelinerun names",
@@ -756,18 +765,18 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Error from using pipelinerun name with --all",
-			command:     []string{"delete", "pipelinerun", "--all", "-n", "ns"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "pipeline-run-1", "--all", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 		{
 			name:        "Error from deleting PipelineRun with non-existing Pipeline",
-			command:     []string{"delete", "pipelinerun", "-p", "non-existing-pipeline"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "pipeline-run-1", "-p", "non-existing-pipeline", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "no PipelineRuns associated with Pipeline \"non-existing-pipeline\"",
@@ -783,10 +792,10 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Error from using argument with --keep",
-			command:     []string{"rm", "pipelinerun", "--keep", "2"},
+			command:     []string{"rm", "pipeline-run-1", "--keep", "2", "-n", "ns"},
 			dynamic:     seeds[5].dynamicClient,
 			input:       seeds[5].pipelineClient,
-			inputStream: strings.NewReader("y"),
+			inputStream: nil,
 			wantError:   true,
 			want:        "--keep flag should not have any arguments specified with it",
 		},
@@ -852,6 +861,15 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "Are you sure you want to delete all PipelineRuns in namespace \"ns\" (y/n): All PipelineRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete the PipelineRun present and give error for non-existent PipelineRun",
+			command:     []string{"delete", "nonexistent", "pipeline-run-1", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "pipelineruns.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -137,7 +137,7 @@ func TestTaskDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{
 			Tasks:    tdata,
@@ -219,7 +219,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found",
+			want:        "tasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -228,7 +228,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "tasks.tekton.dev \"nonexistent\" not found; tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -237,7 +237,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "tasks.tekton.dev \"nonexistent\" not found; tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskruns flag, reply yes",
@@ -264,7 +264,7 @@ func TestTaskDelete(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"task\": tasks.tekton.dev \"task\" not found",
+			want:        "tasks.tekton.dev \"task\" not found",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -285,11 +285,10 @@ func TestTaskDelete(t *testing.T) {
 			want:        "All Tasks deleted in namespace \"ns\"\n",
 		},
 		{
-			name:    "Error from using task name with --all",
-			command: []string{"delete", "task", "--all", "-n", "ns"},
-			dynamic: seeds[6].dynamicClient,
-			input:   seeds[6].pipelineClient,
-
+			name:        "Error from using task name with --all",
+			command:     []string{"delete", "task", "--all", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -311,6 +310,15 @@ func TestTaskDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "Tasks deleted: \"task\", \"task2\"\n",
+		},
+		{
+			name:        "Delete the Task present and give error for non-existent Task",
+			command:     []string{"delete", "nonexistent", "task", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "tasks.tekton.dev \"nonexistent\" not found",
 		},
 	}
 
@@ -442,7 +450,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 			Tasks:    tdata,
@@ -524,7 +532,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found",
+			want:        "tasks.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -533,7 +541,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "tasks.tekton.dev \"nonexistent\" not found; tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources with --trs flag",
@@ -542,7 +550,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"nonexistent\": tasks.tekton.dev \"nonexistent\" not found; failed to delete Task \"nonexistent2\": tasks.tekton.dev \"nonexistent2\" not found",
+			want:        "tasks.tekton.dev \"nonexistent\" not found; tasks.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "With delete taskruns flag, reply yes",
@@ -569,7 +577,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			input:       seeds[4].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete Task \"task\": tasks.tekton.dev \"task\" not found",
+			want:        "tasks.tekton.dev \"task\" not found",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -590,11 +598,10 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			want:        "All Tasks deleted in namespace \"ns\"\n",
 		},
 		{
-			name:    "Error from using task name with --all",
-			command: []string{"delete", "task", "--all", "-n", "ns"},
-			dynamic: seeds[6].dynamicClient,
-			input:   seeds[6].pipelineClient,
-
+			name:        "Error from using task name with --all",
+			command:     []string{"delete", "task", "--all", "-n", "ns"},
+			dynamic:     seeds[7].dynamicClient,
+			input:       seeds[7].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -616,6 +623,15 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "Tasks deleted: \"task\", \"task2\"\n",
+		},
+		{
+			name:        "Delete the Task present and give error for non-existent Task",
+			command:     []string{"delete", "nonexistent", "task", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "tasks.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -20,17 +20,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tektoncd/cli/pkg/formatted"
-	taskpkg "github.com/tektoncd/cli/pkg/task"
-	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/deleter"
+	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/options"
+	taskpkg "github.com/tektoncd/cli/pkg/task"
+	"github.com/tektoncd/cli/pkg/taskrun"
 	trlist "github.com/tektoncd/cli/pkg/taskrun/list"
+	trsort "github.com/tektoncd/cli/pkg/taskrun/sort"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/multierr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -39,6 +40,27 @@ import (
 type deleteOptions struct {
 	ClusterTaskName string
 	TaskName        string
+}
+
+// trExists validates that the arguments are valid TaskRun names
+func trExists(args []string, p cli.Params) ([]string, error) {
+
+	availableTrs := make([]string, 0)
+	c, err := p.Clients()
+	if err != nil {
+		return availableTrs, err
+	}
+	var errorList error
+	ns := p.Namespace()
+	for _, name := range args {
+		_, err := taskrun.Get(c, name, metav1.GetOptions{}, ns)
+		if err != nil {
+			errorList = multierr.Append(errorList, err)
+			continue
+		}
+		availableTrs = append(availableTrs, name)
+	}
+	return availableTrs, errorList
 }
 
 func deleteCommand(p cli.Params) *cobra.Command {
@@ -104,11 +126,19 @@ or
 				return fmt.Errorf("--keep or --keep-since, --all and --%s cannot be used together", strings.ToLower(opts.ParentResource))
 			}
 
-			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
+			availableTrs, errs := trExists(args, p)
+			if len(availableTrs) == 0 && errs != nil {
+				return errs
+			}
+
+			if err := opts.CheckOptions(s, availableTrs, p.Namespace()); err != nil {
 				return err
 			}
 
-			return deleteTaskRuns(s, p, args, opts)
+			if err := deleteTaskRuns(s, p, availableTrs, opts); err != nil {
+				return err
+			}
+			return errs
 		},
 	}
 	f.AddFlags(c)

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -269,7 +269,7 @@ func TestTaskRunDelete(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 		cs, _ := test.SeedTestData(t, pipelinetest.Data{TaskRuns: trs, Tasks: tasks, ClusterTasks: clustertasks, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
 		tdc := testDynamic.Options{}
@@ -306,7 +306,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TaskRun \"tr0-1\": taskruns.tekton.dev \"tr0-1\" not found",
+			want:        "taskruns.tekton.dev \"tr0-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -351,7 +351,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
+			want:        "taskruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -360,7 +360,7 @@ func TestTaskRunDelete(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete TaskRun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
+			want:        "taskruns.tekton.dev \"nonexistent\" not found; taskruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include taskrun names",
@@ -427,18 +427,18 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using taskrun name with --all",
-			command:     []string{"delete", "taskrun", "--all", "-n", "ns"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tr0-7", "--all", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 		{
 			name:        "Error from deleting TaskRun with non-existing Task",
-			command:     []string{"delete", "taskrun", "-t", "non-existing-task"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tr0-7", "-t", "non-existing-task", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "no TaskRuns associated with Task \"non-existing-task\"",
@@ -454,7 +454,7 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using argument with --keep",
-			command:     []string{"rm", "taskrun", "--keep", "2"},
+			command:     []string{"rm", "tr0-7", "--keep", "2", "-n", "ns"},
 			dynamic:     seeds[5].dynamicClient,
 			input:       seeds[5].pipelineClient,
 			inputStream: nil,
@@ -481,9 +481,9 @@ func TestTaskRunDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from deleting TaskRun with non-existing ClusterTask",
-			command:     []string{"delete", "taskrun", "--clustertask", "non-existing-clustertask"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tr0-7", "--clustertask", "non-existing-clustertask", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "no TaskRuns associated with ClusterTask \"non-existing-clustertask\"",
@@ -568,6 +568,15 @@ func TestTaskRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "All TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete the Task present and give error for non-existent Task",
+			command:     []string{"delete", "nonexistent", "tr0-1", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "taskruns.tekton.dev \"nonexistent\" not found",
 		},
 	}
 
@@ -832,7 +841,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 	}
 
 	seeds := make([]clients, 0)
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 9; i++ {
 		trs := trdata
 		cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{TaskRuns: trs, Tasks: tasks, ClusterTasks: clustertasks, Namespaces: ns})
 		cs.Pipeline.Resources = cb.APIResourceList(version, []string{"taskrun"})
@@ -870,7 +879,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[0].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TaskRun \"tr0-1\": taskruns.tekton.dev \"tr0-1\" not found",
+			want:        "taskruns.tekton.dev \"tr0-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -915,7 +924,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found",
+			want:        "taskruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -924,7 +933,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[2].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TaskRun \"nonexistent\": taskruns.tekton.dev \"nonexistent\" not found; failed to delete TaskRun \"nonexistent2\": taskruns.tekton.dev \"nonexistent2\" not found",
+			want:        "taskruns.tekton.dev \"nonexistent\" not found; taskruns.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Attempt remove forgetting to include taskrun names",
@@ -982,18 +991,18 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Error from using taskrun name with --all",
-			command:     []string{"delete", "taskrun", "--all", "-n", "ns"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tr0-7", "--all", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
 		},
 		{
 			name:        "Error from deleting TaskRun with non-existing Task",
-			command:     []string{"delete", "taskrun", "-t", "non-existing-task"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tr0-7", "-t", "non-existing-task", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "no TaskRuns associated with Task \"non-existing-task\"",
@@ -1009,7 +1018,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Error from using argument with --keep",
-			command:     []string{"rm", "taskrun", "--keep", "2"},
+			command:     []string{"rm", "tr0-7", "-n", "ns", "--keep", "2"},
 			dynamic:     seeds[5].dynamicClient,
 			input:       seeds[5].pipelineClient,
 			inputStream: nil,
@@ -1027,9 +1036,9 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 		},
 		{
 			name:        "Error from deleting TaskRun with non-existing ClusterTask",
-			command:     []string{"delete", "taskrun", "--clustertask", "non-existing-clustertask"},
-			dynamic:     seeds[4].dynamicClient,
-			input:       seeds[4].pipelineClient,
+			command:     []string{"delete", "tr0-7", "--clustertask", "non-existing-clustertask", "-n", "ns"},
+			dynamic:     seeds[5].dynamicClient,
+			input:       seeds[5].pipelineClient,
 			inputStream: nil,
 			wantError:   true,
 			want:        "no TaskRuns associated with ClusterTask \"non-existing-clustertask\"",
@@ -1114,6 +1123,15 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "All TaskRuns deleted in namespace \"ns\"\n",
+		},
+		{
+			name:        "Delete the Task present and give error for non-existent Task",
+			command:     []string{"delete", "nonexistent", "tr0-1", "-n", "ns"},
+			dynamic:     seeds[8].dynamicClient,
+			input:       seeds[8].pipelineClient,
+			inputStream: nil,
+			wantError:   true,
+			want:        "taskruns.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/triggerbinding/delete_test.go
+++ b/pkg/cmd/triggerbinding/delete_test.go
@@ -89,7 +89,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TriggerBinding \"tb-1\": triggerbindings.triggers.tekton.dev \"tb-1\" not found",
+			want:        "triggerbindings.triggers.tekton.dev \"tb-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -145,7 +145,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TriggerBinding \"nonexistent\": triggerbindings.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "triggerbindings.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -153,7 +153,7 @@ func TestTriggerBindingDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TriggerBinding \"nonexistent\": triggerbindings.triggers.tekton.dev \"nonexistent\" not found; failed to delete TriggerBinding \"nonexistent2\": triggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "triggerbindings.triggers.tekton.dev \"nonexistent\" not found; triggerbindings.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -173,8 +173,8 @@ func TestTriggerBindingDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using triggerbinding name with --all",
-			command:     []string{"delete", "tb", "--all", "-n", "ns"},
-			input:       seeds[4],
+			command:     []string{"delete", "tb-2", "--all", "-n", "ns"},
+			input:       seeds[1],
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -186,6 +186,14 @@ func TestTriggerBindingDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide triggerbinding name(s) or use --all flag with delete",
+		},
+		{
+			name:        "Delete the TriggerBinding present and give error for non-existent TriggerBinding",
+			command:     []string{"delete", "nonexistent", "tb-2"},
+			input:       seeds[1],
+			inputStream: nil,
+			wantError:   true,
+			want:        "triggerbindings.triggers.tekton.dev \"nonexistent\" not found",
 		},
 	}
 

--- a/pkg/cmd/triggertemplate/delete_test.go
+++ b/pkg/cmd/triggertemplate/delete_test.go
@@ -89,7 +89,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TriggerTemplate \"tt-1\": triggertemplates.triggers.tekton.dev \"tt-1\" not found",
+			want:        "triggertemplates.triggers.tekton.dev \"tt-1\" not found",
 		},
 		{
 			name:        "With force delete flag (shorthand)",
@@ -145,7 +145,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TriggerTemplate \"nonexistent\": triggertemplates.triggers.tekton.dev \"nonexistent\" not found",
+			want:        "triggertemplates.triggers.tekton.dev \"nonexistent\" not found",
 		},
 		{
 			name:        "Remove multiple non existent resources",
@@ -153,7 +153,7 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: nil,
 			wantError:   true,
-			want:        "failed to delete TriggerTemplate \"nonexistent\": triggertemplates.triggers.tekton.dev \"nonexistent\" not found; failed to delete TriggerTemplate \"nonexistent2\": triggertemplates.triggers.tekton.dev \"nonexistent2\" not found",
+			want:        "triggertemplates.triggers.tekton.dev \"nonexistent\" not found; triggertemplates.triggers.tekton.dev \"nonexistent2\" not found",
 		},
 		{
 			name:        "Delete all with prompt",
@@ -173,8 +173,8 @@ func TestTriggerTemplateDelete(t *testing.T) {
 		},
 		{
 			name:        "Error from using triggertemplate name with --all",
-			command:     []string{"delete", "tt", "--all", "-n", "ns"},
-			input:       seeds[4],
+			command:     []string{"delete", "tt-2", "--all", "-n", "ns"},
+			input:       seeds[1],
 			inputStream: nil,
 			wantError:   true,
 			want:        "--all flag should not have any arguments or flags specified with it",
@@ -186,6 +186,14 @@ func TestTriggerTemplateDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   true,
 			want:        "must provide triggertemplate name(s) or use --all flag with delete",
+		},
+		{
+			name:        "Delete the TriggerTemplate present and give error for non-existent TriggerTemplate",
+			command:     []string{"delete", "nonexistent", "tt-2"},
+			input:       seeds[1],
+			inputStream: nil,
+			wantError:   true,
+			want:        "triggertemplates.triggers.tekton.dev \"nonexistent\" not found",
 		},
 	}
 


### PR DESCRIPTION
Earlier there was a prompt that appeared for deletion before checking
whether the resource exist or not in the cluster. With this PR we are
handling the same.

Signed-off-by: mansi103 <mansiagarwal103@gmail.com>

Fix #1480

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Checked existence of resources before deletion
```
