### PR TITLE
Adds operator verison in output of `tkn version` command

### DIFF
--- a/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline,_triggers,_dashboard_and_operator_installed.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline,_triggers,_dashboard_and_operator_installed.golden
@@ -1,0 +1,5 @@
+Client version: dev
+Pipeline version: v0.10.0
+Triggers version: v0.5.0
+Dashboard version: v0.7.0
+Operator version: v0.54.0

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -90,6 +90,10 @@ func Command(p cli.Params) *cobra.Command {
 					if dashboardVersion != "" {
 						fmt.Fprintf(cmd.OutOrStdout(), "Dashboard version: %s\n", dashboardVersion)
 					}
+					operatorVersion, _ := version.GetOperatorVersion(cs, namespace)
+					if operatorVersion != "" {
+						fmt.Fprintf(cmd.OutOrStdout(), "Operator version: %s\n", operatorVersion)
+					}
 				case "client":
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", clientVersion)
 				case "pipeline":
@@ -110,6 +114,12 @@ func Command(p cli.Params) *cobra.Command {
 						dashboardVersion = "unknown"
 					}
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", dashboardVersion)
+				case "operator":
+					operatorVersion, _ := version.GetOperatorVersion(cs, namespace)
+					if operatorVersion == "" {
+						operatorVersion = "unknown"
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", operatorVersion)
 				default:
 					fmt.Fprintf(cmd.OutOrStdout(), "Invalid component value\n")
 				}
@@ -119,7 +129,7 @@ func Command(p cli.Params) *cobra.Command {
 					fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
 				case "client":
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", clientVersion)
-				case "pipeline", "triggers", "dashboard":
+				case "pipeline", "triggers", "dashboard", "operator":
 					fmt.Fprintf(cmd.OutOrStdout(), "unknown\n")
 				default:
 					fmt.Fprintf(cmd.OutOrStdout(), "Invalid component value\n")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -35,6 +35,7 @@ const (
 	pipelinesInfo                  string = "pipelines-info"
 	triggersInfo                   string = "triggers-info"
 	dashboardInfo                  string = "dashboard-info"
+	operatorInfo                   string = "operators-info"
 )
 
 var defaultNamespaces = []string{"tekton-pipelines", "openshift-pipelines"}
@@ -263,4 +264,24 @@ func findDashboardVersion(deployments []v1.Deployment) string {
 		}
 	}
 	return version
+}
+
+// GetOperatorVersion Get operator version
+func GetOperatorVersion(c *cli.Clients, ns string) (string, error) {
+
+	var version string
+	configMap, err := getConfigMap(c, operatorInfo, ns)
+	if err == nil {
+		version = configMap.Data["version"]
+	}
+
+	if version != "" {
+		return version, nil
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return version, nil
 }


### PR DESCRIPTION
Adds operator verison in output of `tkn version` command

UI Example 
```
$ tkn version
Client version: 0.21.0
Pipeline version: v0.28.2
Triggers version: v0.16.1
Operator version: v0.53.0
```

Fixes: #1473

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
