### PR TITLE
pass rest config when create tkn clients,fix the default QPS is to low(QPS is 5),can improve the concurrent #1512

### DIFF
--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -24,6 +24,7 @@ import (
 	versionedTriggers "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type Stream struct {
@@ -49,7 +50,7 @@ type Params interface {
 	// SetKubeContext extends the specificity of the above SetKubeConfigPath
 	// by using a context other than the default context in the given kubeconfig
 	SetKubeContext(string)
-	Clients() (*Clients, error)
+	Clients(...*rest.Config) (*Clients, error)
 	KubeClient() (k8s.Interface, error)
 
 	// SetNamespace can be used to store the namespace parameter that is needed

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -108,14 +108,20 @@ func (p *TektonParams) KubeClient() (k8s.Interface, error) {
 	return kube, nil
 }
 
-func (p *TektonParams) Clients() (*Clients, error) {
+func (p *TektonParams) Clients(cfg ...*rest.Config) (*Clients, error) {
 	if p.clients != nil {
 		return p.clients, nil
 	}
+	var config *rest.Config
 
-	config, err := p.config()
-	if err != nil {
-		return nil, err
+	if len(cfg) != 0 && cfg[0] != nil {
+		config = cfg[0]
+	} else {
+		defaultConfig, err := p.config()
+		if err != nil {
+			return nil, err
+		}
+		config = defaultConfig
 	}
 
 	tekton, err := p.tektonClient(config)

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -23,6 +23,7 @@ import (
 	versionedTriggers "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type Params struct {
@@ -80,7 +81,7 @@ func (p *Params) KubeClient() (k8s.Interface, error) {
 	return p.Kube, nil
 }
 
-func (p *Params) Clients() (*cli.Clients, error) {
+func (p *Params) Clients(config ...*rest.Config) (*cli.Clients, error) {
 	if p.Cls != nil {
 		return p.Cls, nil
 	}


### PR DESCRIPTION
pass the k8s config when create log clients , share k8s config.

fix or feature: #1506

```release-note

pass the k8s config when create log clients , share k8s config,  change the default clients QPS 5
```