### PR TITLE
replace t.Errorf %w with %v

### DIFF
--- a/pkg/bundle/builder_test.go
+++ b/pkg/bundle/builder_test.go
@@ -70,7 +70,7 @@ func TestBuildTektonBundle(t *testing.T) {
 
 	rc, err := layers[0].Uncompressed()
 	if err != nil {
-		t.Errorf("Failed to read image layer: %w", err)
+		t.Errorf("Failed to read image layer: %v", err)
 	}
 	defer rc.Close()
 
@@ -84,12 +84,12 @@ func TestBuildTektonBundle(t *testing.T) {
 	contents := make([]byte, header.Size)
 	if _, err := treader.Read(contents); err != nil && err != io.EOF {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
-		t.Errorf("failed to read tar bundle: %w", err)
+		t.Errorf("failed to read tar bundle: %v", err)
 	}
 
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil)
 	if err != nil {
-		t.Errorf("failed to decode layer contents to a Tekton object: %w", err)
+		t.Errorf("failed to decode layer contents to a Tekton object: %v", err)
 	}
 
 	if diff := cmp.Diff(obj, &task); diff != "" {

--- a/pkg/cmd/bundle/push_test.go
+++ b/pkg/cmd/bundle/push_test.go
@@ -116,7 +116,7 @@ func TestPushCommand(t *testing.T) {
 				remoteOptions:      bundle.RemoteOptions{},
 			}
 			if err := opts.Run([]string{ref}); err != nil {
-				t.Errorf("Unexpected failure calling run: %w", err)
+				t.Errorf("Unexpected failure calling run: %v", err)
 			}
 
 			// Fetch and verify the image was published as expected.
@@ -174,7 +174,7 @@ func readTarLayer(t *testing.T, layer v1.Layer) string {
 
 	rc, err := layer.Uncompressed()
 	if err != nil {
-		t.Errorf("Failed to read image layer: %w", err)
+		t.Errorf("Failed to read image layer: %v", err)
 	}
 	defer rc.Close()
 
@@ -189,7 +189,7 @@ func readTarLayer(t *testing.T, layer v1.Layer) string {
 	contents := make([]byte, header.Size)
 	if _, err := treader.Read(contents); err != nil && err != io.EOF {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
-		t.Errorf("failed to read tar bundle: %w", err)
+		t.Errorf("failed to read tar bundle: %v", err)
 	}
 	return string(contents)
 }


### PR DESCRIPTION
# Changes

Replace `%w` format with `%v` since it is not supported.

`printf: (*testing.common).Errorf does not support error-wrapping directive %w`

#1481

Signed-off-by: jbpratt <jbpratt78@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
