### PR TITLE
remove unnecessary filepath join

### DIFF
--- a/pkg/bundle/keychain_test.go
+++ b/pkg/bundle/keychain_test.go
@@ -88,7 +88,7 @@ func TestGetPathToPodmanAuth(t *testing.T) {
 		assert.Equal(t, getPathToPodmanAuth(), authPath)
 	default:
 		os.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
-		assert.Equal(t, getPathToPodmanAuth(), filepath.Join("/run/user/1000/containers/auth.json"))
+		assert.Equal(t, getPathToPodmanAuth(), "/run/user/1000/containers/auth.json")
 		os.Unsetenv("XDG_RUNTIME_DIR")
 		assert.Equal(t, getPathToPodmanAuth(), fmt.Sprintf("/run/containers/%d/auth.json", os.Getuid()))
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

remove filepath.Join call

```
pkg/bundle/keychain_test.go:91:42: badCall: suspicious Join on 1 argument (gocritic)
		assert.Equal(t, getPathToPodmanAuth(), filepath.Join("/run/user/1000/containers/auth.json"))
```

#1481

Signed-off-by: jbpratt <jbpratt78@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
-->

```release-note
NONE
```
