### PR TITLE
Fix tektoncd docs installation instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,11 +23,10 @@ it from the source, or set it up as a [`kubectl` plugin](https://kubernetes.io/d
 {{% tabs %}}
 
 {{% tab "macOS" %}}
-`tkn` is available on macOS via [`brew`](https://brew.sh/):
+`tkn` is available on macOS via [`brew`](https://formulae.brew.sh/formula/tektoncd-cli):
 
 ```bash
-brew tap tektoncd/tools
-brew install tektoncd/tools/tektoncd-cli
+brew install tektoncd-cli
 ```
 
 You can also download it as a tarball from the [`tkn` Releases page](https://github.com/tektoncd/cli/releases).
@@ -95,9 +94,8 @@ rpm-based distros).
     rpm -Uvh LINK-TO-THE-PACKAGE
     ```
 
-    If you are using Fedora 30/31, CentOS 7/8, EPEL, or RHEL 8, @chmouel
-    provides an unofficial `copr` package repository for installing the
-    package:
+    If you are using the latest releases of Fedora or RHEL or CentOS, you may use the
+    TektonCD CLI unofficial `copr` package repository instead:
 
     ```bash
     dnf copr enable chmouel/tektoncd-cli
@@ -153,4 +151,4 @@ Run `tkn help` to see the list of available commands.
 
 ## What's next
 
-[A manual for using Tekton CLI is available on GitHub](https://github.com/tektoncd/cli/tree/main/docs).
+[A manual for Tekton CLI commands is available on GitHub](https://github.com/tektoncd/cli/tree/main/docs/man/man1).


### PR DESCRIPTION
# Changes

* We had outdated version of RPM based distros
* Use default brew formula tektoncd-cli, since the other repo is
  deprecated.
* links to manpages since other links was linking to itself on github.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
