### PR TITLE
Remove go11modules export instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ brew install tektoncd-cli
   If you have [go](https://golang.org/) installed and you want to compile the CLI from source, you can checkout the [Git repository](https://github.com/tektoncd/cli) and run the following commands:
 
   ```shell
-  export GO111MODULE=on
   make bin/tkn
   ```
 


### PR DESCRIPTION
it's been not needed since around go11 (since auto) and on by default
since go16

see https://maelvls.dev/go111module-everywhere/

## Release Note
```release-note
NONE
```
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
