### PR TITLE
fix error while deleting pr without status

### DIFF
--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -259,6 +259,9 @@ func allPipelineRunNames(cs *cli.Clients, keep, since int, ignoreRunning bool, l
 	if ignoreRunning {
 		var pipelineRunTmps = []v1beta1.PipelineRun{}
 		for _, v := range pipelineRuns.Items {
+			if v.Status.Conditions == nil {
+				continue
+			}
 			for _, v2 := range v.Status.Conditions {
 				if v2.Reason == "Running" || v2.Reason == "Pending" {
 					continue
@@ -282,6 +285,9 @@ func keepPipelineRunsByAge(pipelineRuns *v1beta1.PipelineRunList, keep int) ([]s
 	var todelete, tokeep []string
 
 	for _, run := range pipelineRuns.Items {
+		if run.Status.Conditions == nil {
+			continue
+		}
 		if time.Since(run.Status.CompletionTime.Time) > time.Duration(keep)*time.Minute {
 			todelete = append(todelete, run.Name)
 		} else {


### PR DESCRIPTION
Issue:
tkn gives nil pointer error while deleting a pr which do not have
status.condition with `--ignore-running` flag

This fixes the issue by put a check before checking condition
and avoid deleting the resource with `--ignore-running` flag

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
