### PR TITLE
Support --keep and --keep-since together in tr/pr delete

### DIFF
--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -75,6 +75,9 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 	if o.KeepSince > 0 {
 		keepStr = fmt.Sprintf(" except for ones created in last %d minutes", o.KeepSince)
 	}
+	if o.Keep > 0 && o.KeepSince > 0 {
+		keepStr = fmt.Sprintf(" except for ones created in last %d minutes and keeping %d %ss", o.KeepSince, o.Keep, o.Resource)
+	}
 	switch {
 	case o.DeleteAllNs:
 		fmt.Fprintf(s.Out, "Are you sure you want to delete all %ss in namespace %q%s (y/n): ", o.Resource, ns, keepStr)

--- a/pkg/options/delete_test.go
+++ b/pkg/options/delete_test.go
@@ -159,6 +159,22 @@ func TestDeleteOptions(t *testing.T) {
 			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
 			want:           "Are you sure you want to delete all TaskRuns related to Task \"foobar\" except for ones created in last 20 minutes (y/n)",
 		},
+		{
+			name:           "Specify Keep, ParentResource, ParentResourceName and Resource",
+			opt:            &DeleteOptions{Keep: 5, ParentResource: "Task", ParentResourceName: "foobar", Resource: "TaskRun"},
+			resourcesNames: []string{},
+			wantError:      false,
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			want:           "Are you sure you want to delete all TaskRuns related to Task \"foobar\" keeping 5 TaskRuns (y/n)",
+		},
+		{
+			name:           "Specify KeepSince, Keep, ParentResource, ParentResourceName and Resource",
+			opt:            &DeleteOptions{KeepSince: 20, Keep: 5, ParentResource: "Task", ParentResourceName: "foobar", Resource: "TaskRun"},
+			resourcesNames: []string{},
+			wantError:      false,
+			stream:         &cli.Stream{In: strings.NewReader("y"), Out: os.Stdout},
+			want:           "Are you sure you want to delete all TaskRuns related to Task \"foobar\" except for ones created in last 20 minutes and keeping 5 TaskRuns (y/n)",
+		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
While deleting a TaskRun/PipelineRun, this adds support of
using --keep and --keep-since together.

Also fix pipelineRun/Taskrun deletion when few pr/tr is in
running state and `--keep-since` is used along with `--ignore-running=false`
Closes: #1471 #1552 

Signed-off-by: divyansh42 <diagrawa@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Support --keep and --keep-since together in tkn tr delete/ tkn pr delete
```
