### PR TITLE
Updates the configMap name for Operator version

### DIFF
--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -259,7 +259,7 @@ func TestGetVersions(t *testing.T) {
 	chainsConfigMap := getConfigMapData("chains-info", "v0.8.0", map[string]string{"app.kubernetes.io/part-of": "tekton-chains"})
 	triggersConfigMap := getConfigMapData("triggers-info", "v0.5.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
 	dashboardConfigMap := getConfigMapData("dashboard-info", "v0.7.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
-	operatorConfigMap := getConfigMapData("operators-info", "v0.54.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
+	operatorConfigMap := getConfigMapData("tekton-operator-info", "v0.54.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
 
 	testParams := []struct {
 		name                  string

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -37,7 +37,7 @@ const (
 	pipelinesInfo                  string = "pipelines-info"
 	triggersInfo                   string = "triggers-info"
 	dashboardInfo                  string = "dashboard-info"
-	operatorInfo                   string = "operators-info"
+	operatorInfo                   string = "tekton-operator-info"
 )
 
 var defaultNamespaces = []string{"tekton-pipelines", "openshift-pipelines", "tekton-chains", "tekton-operator", "openshift-operators"}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -430,14 +430,14 @@ func TestGetOperatorVersionViaConfigMap(t *testing.T) {
 		{
 			name:      "get operator version from configmap in tekton-pipelines namespace",
 			namespace: "tekton-pipelines",
-			configMap: getConfigMapData("operators-info", "main", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"}),
+			configMap: getConfigMapData("tekton-operator-info", "main", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"}),
 			want:      "main",
 		},
 		{
 			name:                  "get operator version from configmap present in different namespace other than default namespaces",
 			namespace:             "test",
 			userProvidedNamespace: "test",
-			configMap:             getConfigMapData("operators-info", "test", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"}),
+			configMap:             getConfigMapData("tekton-operator-info", "test", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"}),
 			want:                  "test",
 		},
 	}


### PR DESCRIPTION
Since the configMap name for operator version is changed
from `operators-info` to `tekton-operator-info` in upstream
operator, this patch updates the same in `tkn version` command

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
