### PR TITLE
Fixes pipelinerun and taskrun deletion with keep flag

### DIFF
--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -951,6 +951,15 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			wantError:   false,
 			want:        "No PipelineRuns found\n",
 		},
+		{
+			name:        "Attempt to delete PieplineRun by keeping more than existing PipelineRun for a Pipeline",
+			command:     []string{"delete", "-i", "-f", "--keep", "3", "--pipeline", "pipeline", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "There is/are only 2 PipelineRun(s) associated for Pipeline: pipeline \n",
+		},
 	}
 
 	for _, tp := range testParams {

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -1211,6 +1211,15 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			wantError:   true,
 			want:        "taskruns.tekton.dev \"nonexistent\" not found",
 		},
+		{
+			name:        "Attempt to delete TaskRun by keeping more than existing TaskRun for a Task",
+			command:     []string{"delete", "-i", "-f", "--keep", "2", "--task", "random", "-n", "ns"},
+			dynamic:     seeds[10].dynamicClient,
+			input:       seeds[10].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "There is/are only 1 TaskRun(s) associated for Task: random \n",
+		},
 	}
 
 	for _, tp := range testParams {


### PR DESCRIPTION
This patch fixes pipelinerun and taskrun deletion when keep argument
is not satisfied(to keep more than the existing pipelinerun/taskrun
for a pipeline/task) and returns exit code 0

Closes: #1470 

Sigend-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
