### PR TITLE
This will fix the version command failing for chain and operator

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -136,6 +136,9 @@ func getConfigMap(c *cli.Clients, name, ns string) (*corev1.ConfigMap, error) {
 			if errors.IsNotFound(err) {
 				continue
 			}
+			if strings.Contains(err.Error(), fmt.Sprintf(`cannot get resource "configmaps" in API group "" in the namespace "%s"`, n)) {
+				continue
+			}
 			return nil, err
 		}
 		if configMap != nil {
@@ -284,20 +287,10 @@ func findDashboardVersion(deployments []v1.Deployment) string {
 
 // GetOperatorVersion Get operator version
 func GetOperatorVersion(c *cli.Clients, ns string) (string, error) {
-
-	var version string
 	configMap, err := getConfigMap(c, operatorInfo, ns)
-	if err == nil {
-		version = configMap.Data["version"]
-	}
-
-	if version != "" {
-		return version, nil
-	}
-
 	if err != nil {
 		return "", err
 	}
-
+	version := configMap.Data["version"]
 	return version, nil
 }


### PR DESCRIPTION
tkn version command is failing for cmponents like chains and operator but
working for pipelines and triggers. The reason is retreiving version from
configmap was failing and pipeline and triggers have backup logic to fetch version
from deployments and hence it was working for them.

For configmap we were checking the not found error but it was returning the
permission error and hence it was not able to iterate through all
namespaces. This will fix the proper error checking

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
This will fix the version command failing for chain and operator
```
