### PR TITLE
Allow to use bundle with no kubeconfig

### DIFF
--- a/pkg/cmd/bundle/bundle.go
+++ b/pkg/cmd/bundle/bundle.go
@@ -16,6 +16,7 @@ package bundle
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -35,7 +36,16 @@ func Command(p cli.Params) *cobra.Command {
 			"commandType": "main",
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
+			if err := flags.InitParams(p, cmd); err != nil {
+				// this check allows tkn version to be run without
+				// a kubeconfig so users can list and push bundles
+				noConfigErr := strings.Contains(err.Error(), "no configuration has been provided")
+				if noConfigErr {
+					return nil
+				}
+				return err
+			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
# Changes

It should be possible to list and push bundles without having to have a valid kubeconfig. This change makes sure that no error is thrown if no kubeconfig is found while invoking `tkn bundle`.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
Note: I think tests are not needed for this one. It also follows a [very similar commit](https://github.com/davidmogar/cli/commit/ed9fefc251451bdf84b5bc59476c3f5f9f4b6dcf)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes
```release-note
NONE
```