### PR TITLE
fix: set created time for bundle image

### DIFF
--- a/pkg/bundle/builder.go
+++ b/pkg/bundle/builder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -78,6 +79,13 @@ func BuildTektonBundle(contents []string, log io.Writer) (v1.Image, error) {
 			return nil, err
 		}
 	}
+
+	// Set created time for bundle image
+	img, err := mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add created time to image: %w", err)
+	}
+
 	return img, nil
 }
 

--- a/pkg/bundle/builder_test.go
+++ b/pkg/bundle/builder_test.go
@@ -37,6 +37,15 @@ func TestBuildTektonBundle(t *testing.T) {
 		t.Error(err)
 	}
 
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if cfg.Created.IsZero() {
+		t.Error("Created time of image was not set")
+	}
+
 	manifest, err := img.Manifest()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
# Changes

The `Created` field of bundle image config was set as zero time, which
is `0001-01-01T00:00:00Z`. With this commit, it will be set
as the time when the bundle is created.

fixes: #1562

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


# Release Notes

```release-note
set the created time for bundle image correctly.
```