### PR TITLE
Revert skipping of failed test

### DIFF
--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -476,7 +476,6 @@ func TestPipelinesNegativeE2E(t *testing.T) {
 	var pipelineGeneratedName string
 
 	t.Run("Start Pipeline Run using pipeline start command with SA as 'pipelines' ", func(t *testing.T) {
-		t.Skip("skipping due to problems in TektonPipelines. See https://github.com/tektoncd/pipeline/issues/4747")
 		res := tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineFaultGitResourceName,
 			"-p=FILEPATH=docs",


### PR DESCRIPTION
# Changes

With Pipelines v0.35.1, the test which was failing is now fixed. Earlier
it was skipped in order to unblock the CI but now it seems that we can
revert that.

closes #1565 

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```