### PR TITLE
Adding a check for the set bundle max used in the pipeline controller.

### DIFF
--- a/pkg/bundle/builder.go
+++ b/pkg/bundle/builder.go
@@ -24,6 +24,10 @@ import (
 func BuildTektonBundle(contents []string, log io.Writer) (v1.Image, error) {
 	img := empty.Image
 
+	if len(contents) > tkremote.MaximumBundleObjects {
+		return nil, fmt.Errorf("bundle contains more than the maximum %d allow objects", tkremote.MaximumBundleObjects)
+	}
+
 	fmt.Fprint(log, "Creating Tekton Bundle:\n")
 
 	// For each block of input, attempt to parse all of the YAML/JSON objects as Tekton objects and compress them into
@@ -95,5 +99,9 @@ func getObjectName(obj runtime.Object) (string, error) {
 	if !ok {
 		return "", errors.New("object is not a registered kubernetes resource")
 	}
-	return metaObj.GetName(), nil
+	name := metaObj.GetName()
+	if name == "" {
+		return "", errors.New("kubernetes resources should have a name")
+	}
+	return name, nil
 }


### PR DESCRIPTION
Currently a user does not know when they might have added too many objects until they attempt to run an image. Adding to the bundle cmd will at least give them feedback before attempting to use the bundle.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Adding a quick check to the bundle to make sure its layers don't go over the max allowed in the pipeline controller. This is really more for devs using the cli, as it can be a poor ux to create a bundle and not know its unusable till attempting to 😅 .
There is a pr to double the current allowed about [here](https://github.com/tektoncd/pipeline/pull/4899) so there is a potential for these to be out of sync and not sure if that should be addressed considering bundles are still in alpha. 

Also added some tests 😸 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
The cli will error if attempting to create a bundle with more objects than allowed by the pipeline controller.
```
