### PR TITLE
Add *experimental* commands support

### DIFF
--- a/docs/cmd/tkn_bundle_list.md
+++ b/docs/cmd/tkn_bundle_list.md
@@ -10,7 +10,7 @@ tkn bundle list
 
 ### Synopsis
 
-List the contents of a Tekton Bundle from a registry. You can further narrow down the results by 
+List the contents of a Tekton Bundle from a registry. You can further narrow down the results by
 optionally specifying the kind, and then the name:
 
 	tkn bundle list docker.io/myorg/mybundle:latest // fetches all objects
@@ -28,7 +28,7 @@ Authentication:
 	3. Additionally, you can use Basic auth via --remote-username and --remote-password
 
 Caching:
-    By default, bundles will be cached in ~/.tekton/bundles. If you would like to use a different location, set 
+    By default, bundles will be cached in ~/.tekton/bundles. If you would like to use a different location, set
 "--cache-dir" and if you would like to skip the cache altogether, set "--no-cache".
 
 

--- a/pkg/cli/prerun/prerun.go
+++ b/pkg/cli/prerun/prerun.go
@@ -1,0 +1,38 @@
+package prerun
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/flags"
+)
+
+func PersistentPreRunE(p cli.Params) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := WarnExperimental(cmd); err != nil {
+			return err
+		}
+		return flags.InitParams(p, cmd)
+	}
+}
+
+func WarnExperimental(cmd *cobra.Command) error {
+	if IsExperimental(cmd) {
+		fmt.Fprintf(cmd.OutOrStderr(), "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\n")
+	}
+	return nil
+}
+
+func IsExperimental(cmd *cobra.Command) bool {
+	if _, ok := cmd.Annotations["experimental"]; ok {
+		return true
+	}
+	var experimental bool
+	cmd.VisitParents(func(cmd *cobra.Command) {
+		if _, ok := cmd.Annotations["experimental"]; ok {
+			experimental = true
+		}
+	})
+	return experimental
+}

--- a/pkg/cmd/bundle/bundle.go
+++ b/pkg/cmd/bundle/bundle.go
@@ -16,10 +16,10 @@ package bundle
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -33,20 +33,10 @@ func Command(p cli.Params) *cobra.Command {
 		Aliases: []string{"tkb", "bundles"},
 		Short:   "Manage Tekton Bundles",
 		Annotations: map[string]string{
-			"commandType": "main",
+			"commandType":  "main",
+			"experimental": "",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := flags.InitParams(p, cmd); err != nil {
-				// this check allows tkn version to be run without
-				// a kubeconfig so users can list and push bundles
-				noConfigErr := strings.Contains(err.Error(), "no configuration has been provided")
-				if noConfigErr {
-					return nil
-				}
-				return err
-			}
-			return nil
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/bundle/list.go
+++ b/pkg/cmd/bundle/list.go
@@ -49,7 +49,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	}
 	f := cliopts.NewPrintFlags("")
 
-	longHelp := `List the contents of a Tekton Bundle from a registry. You can further narrow down the results by 
+	longHelp := `List the contents of a Tekton Bundle from a registry. You can further narrow down the results by
 optionally specifying the kind, and then the name:
 
 	tkn bundle list docker.io/myorg/mybundle:latest // fetches all objects
@@ -67,7 +67,7 @@ Authentication:
 	3. Additionally, you can use Basic auth via --remote-username and --remote-password
 
 Caching:
-    By default, bundles will be cached in ~/.tekton/bundles. If you would like to use a different location, set 
+    By default, bundles will be cached in ~/.tekton/bundles. If you would like to use a different location, set
 "--cache-dir" and if you would like to skip the cache altogether, set "--no-cache".
 `
 

--- a/pkg/cmd/bundle/list_test.go
+++ b/pkg/cmd/bundle/list_test.go
@@ -48,34 +48,34 @@ func TestListCommand(t *testing.T) {
 		{
 			name:           "no-format",
 			format:         "",
-			expectedStdout: "task.tekton.dev/foobar\npipeline.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\npipeline.tekton.dev/foobar\n",
 		}, {
 			name:           "name-format",
 			format:         "name",
-			expectedStdout: "task.tekton.dev/foobar\npipeline.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\npipeline.tekton.dev/foobar\n",
 		}, {
 			name:           "yaml-format",
 			format:         "yaml",
-			expectedStdout: examplePullTask + examplePullPipeline,
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\n" + examplePullTask + examplePullPipeline,
 		}, {
 			name:           "specify-kind-task",
 			format:         "name",
-			expectedStdout: "task.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\n",
 			additionalArgs: []string{"Task"},
 		}, {
 			name:           "specify-kind-task-lowercase-plural",
 			format:         "name",
-			expectedStdout: "task.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\n",
 			additionalArgs: []string{"tasks"},
 		}, {
 			name:           "specify-kind-task-lowercase-singular",
 			format:         "name",
-			expectedStdout: "task.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\n",
 			additionalArgs: []string{"task"},
 		}, {
 			name:           "specify-kind-pipeline",
 			format:         "name",
-			expectedStdout: "pipeline.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\npipeline.tekton.dev/foobar\n",
 			additionalArgs: []string{"Pipeline"},
 		}, {
 			name:           "specify-kind-name-dne",
@@ -85,7 +85,7 @@ func TestListCommand(t *testing.T) {
 		}, {
 			name:           "specify-kind-name",
 			format:         "name",
-			expectedStdout: "pipeline.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\npipeline.tekton.dev/foobar\n",
 			additionalArgs: []string{"Pipeline", "foobar"},
 		},
 	}

--- a/pkg/cmd/chain/chain.go
+++ b/pkg/cmd/chain/chain.go
@@ -17,6 +17,7 @@ package chain
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -32,9 +33,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/clustertask/clustertask.go
+++ b/pkg/cmd/clustertask/clustertask.go
@@ -17,6 +17,7 @@ package clustertask
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -28,9 +29,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
+++ b/pkg/cmd/clustertriggerbinding/clustertriggerbinding.go
@@ -17,6 +17,7 @@ package clustertriggerbinding
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -31,9 +32,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/eventlistener/eventlistener.go
+++ b/pkg/cmd/eventlistener/eventlistener.go
@@ -17,6 +17,7 @@ package eventlistener
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -31,9 +32,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -17,6 +17,7 @@ package pipeline
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -28,9 +29,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/pipelineresource/pipelineresource.go
+++ b/pkg/cmd/pipelineresource/pipelineresource.go
@@ -17,6 +17,7 @@ package pipelineresource
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -28,9 +29,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cmd/pipelinerun/pipelinerun.go
@@ -17,6 +17,7 @@ package pipelinerun
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -29,9 +30,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(c)

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -17,6 +17,7 @@ package task
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -28,9 +29,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)
@@ -44,3 +43,19 @@ func Command(p cli.Params) *cobra.Command {
 	)
 	return cmd
 }
+
+// Example of an "marked experimental" sub command
+// func fooCommand(p cli.Params) *cobra.Command {
+// 	return &cobra.Command{
+// 		Use:   "foo",
+// 		Short: "Foo is bar and baz",
+// 		Annotations: map[string]string{
+// 			"experimental": "",
+// 			"commandType":  "main",
+// 		},
+// 		RunE: func(cmd *cobra.Command, args []string) error {
+// 			fmt.Fprintf(cmd.OutOrStdout(), "Foo is bar\n")
+// 			return nil
+// 		},
+// 	}
+// }

--- a/pkg/cmd/taskrun/taskrun.go
+++ b/pkg/cmd/taskrun/taskrun.go
@@ -17,6 +17,7 @@ package taskrun
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -28,9 +29,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/testdata/TestPluginList.golden
+++ b/pkg/cmd/testdata/TestPluginList.golden
@@ -4,8 +4,9 @@ Usage:
 tkn [flags]
 tkn [command]
 
+
 Available Commands:
-  bundle                Manage Tekton Bundles
+  bundle*               Manage Tekton Bundles (experimental)
   chain                 Manage Chains
   clustertask           Manage ClusterTasks
   clustertriggerbinding Manage ClusterTriggerBindings

--- a/pkg/cmd/triggerbinding/triggerbinding.go
+++ b/pkg/cmd/triggerbinding/triggerbinding.go
@@ -17,6 +17,7 @@ package triggerbinding
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -31,9 +32,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)

--- a/pkg/cmd/triggertemplate/triggertemplate.go
+++ b/pkg/cmd/triggertemplate/triggertemplate.go
@@ -17,6 +17,7 @@ package triggertemplate
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
 )
 
@@ -28,9 +29,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.InitParams(p, cmd)
-		},
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}
 
 	flags.AddTektonOptions(cmd)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Commands can be annotated with `experimental` to be treated as such.
This will show up in usage/help as well as will output a warning
message in stderr on execution.

Examples:

```bash
$ tkn task
Available Commands:
  create      Create a Task from ClusterTask
  delete      Delete Tasks in a namespace
  describe    Describe a Task in a namespace
  foo*        Foo is bar and baz (experimental)
  list        Lists Tasks in a namespace
  logs        Show Task logs
  start       Start Tasks
$ tkn task foo --help
Foo is bar and baz

Usage:
tkn task foo [flags]

EXPERIMENTAL:
  tkn task foo is an experimental feature.
  Experimental features provide early access to the project functionality. These
  features may change between releases without warning, or can be removed from a
  future release.
$ tkn task foo
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Foo is bar
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature

Closes #1568

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Add a way to mark commands as `experimental` and warn user of their usage
```
