### PR TITLE
Add dependabot to the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This might generate quite some pull-request initially and some of them
will always be red (bumping knative, kubernetes or tekton will
probably require some changes, like re-generate files, …).

But it should help to know when to update *and* will work with the
other type of dependencies.

Doing this based on
https://github.com/tektoncd/pipeline/pull/4915#issuecomment-1142232783

> I think worst case we'll get a few PRs that won't pass unit tests (probably for anything k8s.io related), which will be a signal for additional intervention. Even if we can only use this with 80% of deps, it seems worthwhile to enable it. If this ends up being too noisy we can roll it back.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
