### PR TITLE
Ignore zap logger sync error

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -43,9 +43,8 @@ func GetTaskRunBackends(cs *cli.Clients, namespace string, tr *v1beta1.TaskRun) 
 	}
 	// flushes buffer, if any
 	defer func() {
-		if err := logger.Sync(); err != nil {
-			fmt.Println(err)
-		}
+		// intentionally ignoring error here, see https://github.com/uber-go/zap/issues/328
+		_ = logger.Sync()
 	}()
 	sugaredLogger := logger.Sugar()
 


### PR DESCRIPTION
Prior to this commit, this is how all `tkn chains` output starts like:

```
$ tkn chain payload build-push-run-output-image-p229w
sync /dev/stderr: invalid argument
...
...
```

This commit gets rid of the `sync /dev/stderr: invalid argument` error
by ignoring it, which is safe: see
https://github.com/uber-go/zap/issues/328

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._