### PR TITLE
Fix `tkn chains signature/payload` by version bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
-	github.com/tektoncd/chains v0.9.0
+	github.com/tektoncd/chains v0.9.1-0.20220520120701-86291376000f
 	github.com/tektoncd/hub v1.7.0
 	github.com/tektoncd/pipeline v0.35.1
 	github.com/tektoncd/plumbing v0.0.0-20220329085922-d765a5cba75f

--- a/go.sum
+++ b/go.sum
@@ -2558,8 +2558,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tdakkota/asciicheck v0.1.1/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
-github.com/tektoncd/chains v0.9.0 h1:S3SfxGNe33koDguaQNrGB9aVBAW3G/z2+dctFH7WMhg=
-github.com/tektoncd/chains v0.9.0/go.mod h1:BKXGxS3r78cieCkiW3cE3WgzeN/inZB0UYDLfGU50As=
+github.com/tektoncd/chains v0.9.1-0.20220520120701-86291376000f h1:DbLGIf0BswsDyVN+rObrWRUS0WSBBfC5Pge/8ampVsU=
+github.com/tektoncd/chains v0.9.1-0.20220520120701-86291376000f/go.mod h1:BKXGxS3r78cieCkiW3cE3WgzeN/inZB0UYDLfGU50As=
 github.com/tektoncd/hub v1.7.0 h1:BU6YrtCeKk4hFf52oDIEIaiWTxmlr1Kh6U3Ts++0MjU=
 github.com/tektoncd/hub v1.7.0/go.mod h1:c3lL6qU1nFD9TCCrFuEnygB3KcfNn5Tbi27nZ3H6nxA=
 github.com/tektoncd/pipeline v0.31.1-0.20220105002759-3e137645be61/go.mod h1:dO84qW4sTq7S7Jv5G0PRmbTjvxnUAuDDxD1NBrsQX9w=

--- a/vendor/github.com/tektoncd/chains/pkg/chains/formats/intotoite6/buildconfig.go
+++ b/vendor/github.com/tektoncd/chains/pkg/chains/formats/intotoite6/buildconfig.go
@@ -17,7 +17,6 @@ limitations under the License.
 package intotoite6
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -40,7 +39,6 @@ type Step struct {
 func buildConfig(tr *v1beta1.TaskRun) BuildConfig {
 	steps := []Step{}
 	for _, step := range tr.Status.Steps {
-		fmt.Println(step)
 		s := Step{}
 		c := container(step, tr)
 		// get the entrypoint

--- a/vendor/github.com/tektoncd/chains/pkg/chains/storage/pubsub/pubsub.go
+++ b/vendor/github.com/tektoncd/chains/pkg/chains/storage/pubsub/pubsub.go
@@ -62,7 +62,7 @@ func (b *Backend) StorePayload(ctx context.Context, tr *v1beta1.TaskRun, rawPayl
 	}
 	defer func() {
 		if err := topic.Shutdown(ctx); err != nil {
-			fmt.Println(err)
+			b.logger.Error(err)
 		}
 	}()
 

--- a/vendor/github.com/tektoncd/chains/pkg/chains/storage/tekton/tekton.go
+++ b/vendor/github.com/tektoncd/chains/pkg/chains/storage/tekton/tekton.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strings"
-
 	"github.com/tektoncd/chains/pkg/config"
 
 	"github.com/tektoncd/chains/pkg/patch"
@@ -118,12 +116,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, tr *v1beta1.TaskRun, o
 	}
 
 	m := make(map[string][]string)
-	for _, res := range tr.Status.TaskRunResults {
-		if strings.HasSuffix(res.Name, "IMAGE_URL") {
-			m[signatureAnnotation] = []string{signature}
-			break
-		}
-	}
+	m[signatureAnnotation] = []string{signature}
 	return m, nil
 }
 
@@ -136,13 +129,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, tr *v1beta1.TaskRun, opt
 		return nil, err
 	}
 	m := make(map[string]string)
-	for _, res := range tr.Status.TaskRunResults {
-		if strings.HasSuffix(res.Name, "IMAGE_URL") {
-			m[payloadAnnotation] = payload
-			break
-		}
-	}
-
+	m[payloadAnnotation] = payload
 	return m, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1263,7 +1263,7 @@ github.com/syndtr/goleveldb/leveldb/opt
 github.com/syndtr/goleveldb/leveldb/storage
 github.com/syndtr/goleveldb/leveldb/table
 github.com/syndtr/goleveldb/leveldb/util
-# github.com/tektoncd/chains v0.9.0
+# github.com/tektoncd/chains v0.9.1-0.20220520120701-86291376000f
 ## explicit; go 1.17
 github.com/tektoncd/chains/pkg/artifacts
 github.com/tektoncd/chains/pkg/chains


### PR DESCRIPTION
# Changes

Tekton Chains looks at PipelineResources AND *IMAGE_URL,
*IMAGE_DIGEST in results to sign and attest relevant outputs.

Prior to this commit, only *IMAGE_URL was considered as a valid output
while looking up TaskRuns, this commit fixes that.

Prior behavior when *IMAGE_URL was not present:

```
$ tkn chain signature build-push-run-output-image-p229w
sync /dev/stderr: invalid argument
{"level":"info","ts":1654512978.599003,"caller":"tekton/tekton.go:115","msg":"Retrieving signature on TaskRun default/build-push-run-output-image-p229w"}
{"level":"info","ts":1654512978.5990307,"caller":"tekton/tekton.go:86","msg":"Retrieving annotation \"chains.tekton.dev/signature-taskrun-6e2f020b-7d50-4022-8064-049680f72d32\" on TaskRun default/build-push-run-output-image-p229w"}
No signatures found for taskrun build-push-run-output-image-p229w
```

New behavior,

```
$ ./tkn chain signature build-push-run-output-image-p229w
Retrieving signature on TaskRun default/build-push-run-output-image-p229w
Retrieving annotation "chains.tekton.dev/signature-taskrun-6e2f020b-7d50-4022-8064-049680f72d32" on TaskRun default/build-push-run-output-image-p229w
[0E _ϹlYP3: 6@V.d@sS!5:shy6CTI#2]
```

This commit bumps the chains dependency version to the commit that contains
this fix upstream.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

```release-note
NONE
```