### PR TITLE
Reset TKN_PLUGINS_DIR env during tests

### DIFF
--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -76,9 +77,17 @@ func TestPluginList(t *testing.T) {
 	err = ioutil.WriteFile(nd.Join("tkn-nonexec"), []byte("nonexec"), 0o600)
 	assert.NilError(t, err)
 	defer env.Patch(t, "PATH", nd.Path()+":/non/existing/path")()
+
+	// Reset the TKN_PLUGINS_DIR so that during local test
+	// existing plugins are not considered using tests
+	pluginHome := os.Getenv("TKN_PLUGINS_DIR")
+	os.Setenv("TKN_PLUGINS_DIR", "/non/existing/path")
+
 	p := &test.Params{}
 	cmd := Root(p)
 	out, err := test.ExecuteCommand(cmd, "help")
 	assert.NilError(t, err)
 	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
+
+	os.Setenv("TKN_PLUGINS_DIR", pluginHome)
 }

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -65,7 +66,15 @@ func TestGetAllTknPluginFromPaths(t *testing.T) {
 	assert.NilError(t, err)
 
 	defer env.Patch(t, "PATH", fmt.Sprintf("%s:%s", nd.Path(), nd2.Path()))()
+
+	// Reset the TKN_PLUGINS_DIR so that during local test
+	// existing plugins are not considered using tests
+	pluginHome := os.Getenv("TKN_PLUGINS_DIR")
+	os.Setenv("TKN_PLUGINS_DIR", "/non/existing/path")
+
 	plugins := GetAllTknPluginFromPaths()
 	assert.NilError(t, err)
 	assert.Equal(t, len(plugins), 1)
+
+	os.Setenv("TKN_PLUGINS_DIR", pluginHome)
 }


### PR DESCRIPTION
# Changes

While running tests on local machine, a few tests related to plugins
were failing as a plugin was already present in the local machine. This
case can arise for other developers as well.

This patch sets the value of TKN_PLUGINS_DIR to a random value before
running the tests and restore the original value once the tests are
done.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```