### PR TITLE
Show Timeouts in PipelineRun describe cmd and deprecate Timeout

### DIFF
--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithTimeouts.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithTimeouts.golden
@@ -1,0 +1,37 @@
+Name:           pipeline-run
+Namespace:      ns
+Pipeline Ref:   pipeline
+
+Status
+
+STARTED         DURATION   STATUS
+0 seconds ago   20m0s      Succeeded
+
+Timeouts
+ Pipeline:   1h0m0s
+ Tasks:      50m0s
+
+Resources
+
+ NAME    RESOURCE REF
+ res-1   test-res
+ res-2   test-res2
+
+Params
+
+ NAME   VALUE
+ p-1    somethingdifferent
+ p-2    [booms booms booms]
+
+Taskruns
+
+ NAME   TASK NAME   STARTED           DURATION   STATUS
+ tr-2   t-2         -10 minutes ago   7m0s       Succeeded
+ tr-1   t-1         0 seconds ago     5m0s       Failed
+
+Skipped Tasks
+
+ NAME
+ task-should-be-skipped-1
+ task-should-be-skipped-2
+ task-should-be-skipped-3

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_custom_timeout.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_custom_timeout.golden
@@ -1,7 +1,7 @@
-Name:           pr-custom-timeout
-Namespace:      ns
-Pipeline Ref:   pr-custom-timeout
-Timeout:        1m0s
+Name:                  pr-custom-timeout
+Namespace:             ns
+Pipeline Ref:          pr-custom-timeout
+Timeout(Deprecated):   1m0s
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed.golden
@@ -1,8 +1,8 @@
-Name:              pipeline-run
-Namespace:         ns
-Pipeline Ref:      pipeline
-Service Account:   test-sa
-Timeout:           1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Service Account:       test-sa
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutPRCondition.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutPRCondition.golden
@@ -1,8 +1,8 @@
-Name:              pipeline-run
-Namespace:         ns
-Pipeline Ref:      pipeline
-Service Account:   test-sa
-Timeout:           1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Service Account:       test-sa
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutTRCondition.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_failed_withoutTRCondition.golden
@@ -1,8 +1,8 @@
-Name:              pipeline-run
-Namespace:         ns
-Pipeline Ref:      pipeline
-Service Account:   test-sa
-Timeout:           1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Service Account:       test-sa
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_ordering.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_ordering.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_without_status.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_multiple_taskrun_without_status.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref.golden
@@ -1,8 +1,8 @@
-Name:              pipeline-run
-Namespace:         ns
-Pipeline Ref:      pipeline
-Service Account:   test-sa
-Timeout:           1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Service Account:       test-sa
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_only_taskrun.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun.golden
@@ -1,8 +1,8 @@
-Name:              pipeline-run
-Namespace:         ns
-Pipeline Ref:      pipeline
-Service Account:   test-sa
-Timeout:           1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Service Account:       test-sa
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_start_time.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_start_time.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_tr_start_time.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_without_tr_start_time.golden
@@ -1,7 +1,7 @@
-Name:           pipeline-run
-Namespace:      ns
-Pipeline Ref:   pipeline
-Timeout:        1h0m0s
+Name:                  pipeline-run
+Namespace:             ns
+Pipeline Ref:          pipeline
+Timeout(Deprecated):   1h0m0s
 Labels:
  tekton.dev/pipeline=pipeline
 

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -74,6 +74,8 @@ func DecorateAttr(attrString, message string) string {
 		return "📂 "
 	case "skippedtasks":
 		return "⏭️  "
+	case "timeouts":
+		return "⏱  "
 	}
 
 	attr := color.Reset

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -82,13 +82,13 @@ func TestDecoration(t *testing.T) {
 	funcMap := template.FuncMap{
 		"decorate": DecorateAttr,
 	}
-	aTemplate := `{{decorate "skippedtasks" ""}}{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "workspaces" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
+	aTemplate := `{{decorate "timeouts" ""}}{{decorate "skippedtasks" ""}}{{decorate "bullet" "Foo"}} {{decorate "check" ""}}{{decorate "resources" ""}}{{decorate "params" ""}}{{decorate "results" ""}}{{decorate "workspaces" ""}}{{decorate "tasks" ""}}{{decorate "pipelineruns" ""}}{{decorate "status" ""}}{{decorate "inputresources" ""}}{{decorate "outputresources" ""}}{{decorate "steps" ""}}{{decorate "message" ""}}{{decorate "taskruns" ""}}{{decorate "sidecars" ""}}{{decorate "red" "Red"}} {{decorate "underline" "Foo"}}`
 	processed := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(aTemplate))
 	buf := new(bytes.Buffer)
 
 	if err := processed.Execute(buf, nil); err != nil {
 		t.Error("Could not process the template.")
 	}
-	test.AssertOutput(t, "⏭️  ∙ Foo ✔ ️📦 ⚓ 📝 📂 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
+	test.AssertOutput(t, "⏱  ⏭️  ∙ Foo ✔ ️📦 ⚓ 📝 📂 🗒  ⛩  🌡️  📨 📡 🦶 💌 🗂  🚗 \x1b[91mRed\x1b[0m \x1b[4mFoo\x1b[0m", buf.String())
 
 }

--- a/pkg/pipelinerun/description/description.go
+++ b/pkg/pipelinerun/description/description.go
@@ -40,8 +40,9 @@ const templ = `{{decorate "bold" "Name"}}:	{{ .PipelineRun.Name }}
 
 {{- $timeout := getTimeout .PipelineRun -}}
 {{- if and (ne $timeout "") (ne $timeout "0s") }}
-{{decorate "bold" "Timeout"}}:	{{ .PipelineRun.Spec.Timeout.Duration.String }}
+{{decorate "bold" "Timeout(Deprecated)"}}:	{{ .PipelineRun.Spec.Timeout.Duration.String }}
 {{- end }}
+
 {{- $l := len .PipelineRun.Labels }}{{ if eq $l 0 }}
 {{- else }}
 {{decorate "bold" "Labels"}}:
@@ -58,6 +59,24 @@ STARTED	DURATION	STATUS
 
 {{decorate "message" ""}}{{decorate "underline bold" "Message\n"}}
 {{ $msg }}
+{{- end }}
+
+
+{{- if .PipelineRun.Spec.Timeouts }}
+
+{{decorate "timeouts" ""}}{{decorate "underline bold" "Timeouts"}}
+{{- $timeout := .PipelineRun.Spec.Timeouts.Pipeline -}}
+{{- if $timeout }}
+ {{decorate "bold" "Pipeline"}}:	{{ $timeout.Duration.String }}
+{{- end }}
+{{- $timeout := .PipelineRun.Spec.Timeouts.Tasks -}}
+{{- if $timeout }}
+ {{decorate "bold" "Tasks"}}:	{{ $timeout.Duration.String }}
+{{- end }}
+{{- $timeout := .PipelineRun.Spec.Timeouts.Finally -}}
+{{- if $timeout }}
+ {{decorate "bold" "Finally"}}:	{{ $timeout.Duration.String }}
+{{- end }}
 {{- end }}
 
 {{- if ne (len .PipelineRun.Spec.Resources) 0 }}


### PR DESCRIPTION
# Changes

With TEP-0046 a new section of timeouts was introduced and existing
timeout field was deprecated. Existing `tkn pr describe` command shows
only the timeout field. This PR adds support to show the timeouts in the
describe command of PipelineRun.

This PR also deprecates the existing Timeout section which gets displayed in case
no timeouts are passed

Sample output
```
Name:              decision-run-2
Namespace:         default
Pipeline Ref:      decision-pipeline
Service Account:   default
Labels:
 tekton.dev/pipeline=decision-pipeline

🌡️  Status

STARTED          DURATION   STATUS
31 seconds ago   22s        Succeeded(Completed)

⏱  Timeouts
 Pipeline:   10m0s
 Tasks:      3m0s
 Finally:    1m0s

⚓ Params

 NAME      VALUE
 ∙ input   taskA

🗂  Taskruns

 NAME                        TASK NAME   STARTED          DURATION   STATUS
 ∙ decision-run-2-task-a     task-a      21 seconds ago   12s        Succeeded
 ∙ decision-run-2-init-tsk   init-tsk    31 seconds ago   10s        Succeeded

⏭️  Skipped Tasks

 NAME
 ∙ task-b
 ∙ status

```

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
show timeouts in the describe command of tkn pipelinerun describe command and deprecate existing timeout section
```