### PR TITLE
[Packaging] Force building debian package as gzip

### DIFF
--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -27,3 +27,6 @@ override_dh_auto_install:
 	dh_auto_install -O--buildsystem=golang
 	install -D -m644 debian/tkn.zsh-completion debian/tektoncd-cli/usr/share/zsh/vendor-completions/_tkn
 	install -D -m644 debian/tkn.zsh-completion debian/tektoncd-cli/usr/share/bash-completion/completions/tkn
+
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip

--- a/tekton/debbuild/control/source/options
+++ b/tekton/debbuild/control/source/options
@@ -1,0 +1,3 @@
+# Use bzip2 instead of gzip
+compression = "gzip"
+compression-level = 9


### PR DESCRIPTION
 ubuntu latest dpkg use zstd which is uninstallable on older distros.

```
% file tektoncd-cli_0.24.0-0_amd64.deb
tektoncd-cli_0.24.0-0_amd64.deb: Debian binary package (format 2.0), with control.tar.gz, data compression gz
```

![image](https://user-images.githubusercontent.com/98980/176626497-ffd63b66-6152-40fe-8ff2-c84c4ed94257.png)

Fixes #1630

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
dpkg package should be now be able to install on older debian versions
```