### PR TITLE
Add different timeout flags for Pipeline start cmd

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -53,11 +53,13 @@ my-secret, my-empty-dir and my-volume-claim-template)
 ```
       --dry-run                       preview PipelineRun without running it
   -f, --filename string               local or remote file name containing a Pipeline definition to start a PipelineRun
+      --finally-timeout string        timeout for Finally TaskRuns
   -h, --help                          help for start
   -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the Pipeline using last PipelineRun values
   -o, --output string                 format of PipelineRun (yaml, json or name)
   -p, --param stringArray             pass the param as key=value for string type, or key=value1,value2,... for array type
+      --pipeline-timeout string       timeout for PipelineRun
       --pod-template string           local or remote file containing a PodTemplate definition
       --prefix-name string            specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)
   -r, --resource strings              pass the resource name and ref as name=ref
@@ -65,7 +67,7 @@ my-secret, my-empty-dir and my-volume-claim-template)
       --showlog                       show logs right after starting the Pipeline
       --skip-optional-workspace       skips the prompt for optional workspaces
       --task-serviceaccount strings   pass the service account corresponding to the task
-      --timeout string                timeout for PipelineRun
+      --tasks-timeout string          timeout for Pipeline TaskRuns
       --use-param-defaults            use default parameter values without prompting for input
       --use-pipelinerun string        use this pipelinerun values to re-run the pipeline. 
   -w, --workspace stringArray         pass one or more workspaces to map to the corresponding physical volumes

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -36,6 +36,10 @@ Parameters, at least those that have no default value
     local or remote file name containing a Pipeline definition to start a PipelineRun
 
 .PP
+\fB\-\-finally\-timeout\fP=""
+    timeout for Finally TaskRuns
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for start
 
@@ -54,6 +58,10 @@ Parameters, at least those that have no default value
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
     pass the param as key=value for string type, or key=value1,value2,... for array type
+
+.PP
+\fB\-\-pipeline\-timeout\fP=""
+    timeout for PipelineRun
 
 .PP
 \fB\-\-pod\-template\fP=""
@@ -84,8 +92,8 @@ Parameters, at least those that have no default value
     pass the service account corresponding to the task
 
 .PP
-\fB\-\-timeout\fP=""
-    timeout for PipelineRun
+\fB\-\-tasks\-timeout\fP=""
+    timeout for Pipeline TaskRuns
 
 .PP
 \fB\-\-use\-param\-defaults\fP[=false]

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -834,7 +834,7 @@ func TestPipelineStart_ExecuteCommand(t *testing.T) {
 			want:      "cannot use --last option with --filename option",
 		},
 		{
-			name: "Dry Run with --timeout specified",
+			name: "Dry Run with --timeout specified (deprecated)",
 			command: []string{
 				"start", "test-pipeline",
 				"-s=svc1",
@@ -1533,7 +1533,7 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			want:      "cannot use --last option with --filename option",
 		},
 		{
-			name: "Dry Run with --timeout specified",
+			name: "Dry Run with --timeout specified (deprecated)",
 			command: []string{
 				"start", "test-pipeline",
 				"-s=svc1",
@@ -1551,7 +1551,64 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			goldenFile: true,
 		},
 		{
-			name: "Dry Run with invalid --timeout specified",
+			name: "Dry Run with --pipeline-timeout specified",
+			command: []string{
+				"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-p=rev-param=value2",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"--pipeline-timeout", "1s",
+			},
+			namespace:  "",
+			input:      c2,
+			wantError:  false,
+			goldenFile: true,
+		},
+		{
+			name: "Dry Run with --pipeline-timeout, --tasks-timeout specified",
+			command: []string{
+				"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-p=rev-param=value2",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"--pipeline-timeout", "2s",
+				"--tasks-timeout", "1s",
+			},
+			namespace:  "",
+			input:      c2,
+			wantError:  false,
+			goldenFile: true,
+		},
+		{
+			name: "Dry Run with --pipeline-timeout, --tasks-timeout, --finally-timeout specified",
+			command: []string{
+				"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-p=rev-param=value2",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"--pipeline-timeout", "3s",
+				"--tasks-timeout", "1s",
+				"--finally-timeout", "1s",
+			},
+			namespace:  "",
+			input:      c2,
+			wantError:  false,
+			goldenFile: true,
+		},
+		{
+			name: "Dry Run with invalid --timeout specified (deprecated)",
 			command: []string{
 				"start", "test-pipeline",
 				"-s=svc1",
@@ -1569,6 +1626,64 @@ func TestPipelineV1beta1Start_ExecuteCommand(t *testing.T) {
 			hasPrefix: true,
 			want:      `time: unknown unit`,
 		},
+		{
+			name: "Dry Run with invalid --pipeline-timeout specified",
+			command: []string{
+				"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-p=rev-param=value2",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"--pipeline-timeout", "5d",
+			},
+			namespace: "",
+			input:     c2,
+			wantError: true,
+			hasPrefix: true,
+			want:      `time: unknown unit`,
+		},
+		{
+			name: "Dry Run with invalid --tasks-timeout specified",
+			command: []string{
+				"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-p=rev-param=value2",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"--tasks-timeout", "5d",
+			},
+			namespace: "",
+			input:     c2,
+			wantError: true,
+			hasPrefix: true,
+			want:      `time: unknown unit`,
+		},
+		{
+			name: "Dry Run with --finally-timeout specified",
+			command: []string{
+				"start", "test-pipeline",
+				"-s=svc1",
+				"-r=source=scaffold-git",
+				"-p=pipeline-param=value1",
+				"-p=rev-param=value2",
+				"-l=jemange=desfrites",
+				"-n", "ns",
+				"--dry-run",
+				"--finally-timeout", "5d",
+			},
+			namespace: "",
+			input:     c2,
+			wantError: true,
+			hasPrefix: true,
+			want:      `time: unknown unit`,
+		},
+
 		{
 			name: "Dry Run with PodTemplate",
 			command: []string{
@@ -4248,7 +4363,7 @@ func Test_start_pipeline_last_v1beta1(t *testing.T) {
 	test.AssertOutput(t, timeoutDuration, pr.Spec.Timeout.Duration)
 }
 
-func Test_start_pipeline_last_override_timeout_v1beta1(t *testing.T) {
+func Test_start_pipeline_last_override_timeout_deprecated_v1beta1(t *testing.T) {
 	pipelineName := "test-pipeline"
 	ps := []*v1beta1.Pipeline{
 		{
@@ -4426,7 +4541,7 @@ func Test_start_pipeline_last_override_timeout_v1beta1(t *testing.T) {
 		"-n", "ns",
 	)
 
-	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
+	expected := "Flag --timeout has been deprecated, please use --pipeline-timeout flag instead\nPipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
 
 	cl, _ := p.Clients()
@@ -7681,4 +7796,29 @@ func Test_start_pipeline_with_skip_optional_workspace_flag(t *testing.T) {
 
 	expected := "PipelineRun started: random\n\nIn order to track the PipelineRun progress run:\ntkn pipelinerun logs random -f -n ns\n"
 	test.AssertOutput(t, expected, got)
+}
+
+func Test_GetTimeouts(t *testing.T) {
+	opts := startOptions{
+		PipelineTimeOut: "1m",
+		TasksTimeOut:    "2m",
+	}
+
+	prs := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pr-1",
+				Namespace: "namespace",
+				Labels:    map[string]string{"tekton.dev/pipeline": "test"},
+			},
+		},
+	}
+
+	err := opts.getTimeouts(prs[0])
+	if err != nil {
+		t.Errorf("Expected nil, Got err: %v", err)
+	}
+
+	test.AssertOutput(t, "2m0s", prs[0].Spec.Timeouts.Tasks.Duration.String())
+	test.AssertOutput(t, "1m0s", prs[0].Spec.Timeouts.Pipeline.Duration.String())
 }

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--timeout_specified_(deprecated).golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand-Dry_Run_with_--timeout_specified_(deprecated).golden
@@ -1,0 +1,24 @@
+Flag --timeout has been deprecated, please use --pipeline-timeout flag instead
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  labels:
+    jemange: desfrites
+  namespace: ns
+spec:
+  params:
+  - name: pipeline-param
+    value: value1
+  - name: rev-param
+    value: revision
+  pipelineRef:
+    name: test-pipeline
+  resources:
+  - name: source
+    resourceRef:
+      name: scaffold-git
+  serviceAccountName: svc1
+  timeout: 1s
+status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--pipeline-timeout,_--tasks-timeout,_--finally-timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--pipeline-timeout,_--tasks-timeout,_--finally-timeout_specified.golden
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  labels:
+    jemange: desfrites
+  namespace: ns
+spec:
+  params:
+  - name: pipeline-param
+    value: value1
+  - name: rev-param
+    value: value2
+  pipelineRef:
+    name: test-pipeline
+  resources:
+  - name: source
+    resourceRef:
+      name: scaffold-git
+  serviceAccountName: svc1
+  timeouts:
+    finally: 1s
+    pipeline: 3s
+    tasks: 1s
+status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--pipeline-timeout,_--tasks-timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--pipeline-timeout,_--tasks-timeout_specified.golden
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   creationTimestamp: null
@@ -11,7 +11,7 @@ spec:
   - name: pipeline-param
     value: value1
   - name: rev-param
-    value: revision
+    value: value2
   pipelineRef:
     name: test-pipeline
   resources:
@@ -19,5 +19,7 @@ spec:
     resourceRef:
       name: scaffold-git
   serviceAccountName: svc1
-  timeout: 1s
+  timeouts:
+    pipeline: 2s
+    tasks: 1s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--pipeline-timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--pipeline-timeout_specified.golden
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: test-pipeline-run-
+  labels:
+    jemange: desfrites
+  namespace: ns
+spec:
+  params:
+  - name: pipeline-param
+    value: value1
+  - name: rev-param
+    value: value2
+  pipelineRef:
+    name: test-pipeline
+  resources:
+  - name: source
+    resourceRef:
+      name: scaffold-git
+  serviceAccountName: svc1
+  timeouts:
+    pipeline: 1s
+status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--timeout_specified_(deprecated).golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineV1beta1Start_ExecuteCommand-Dry_Run_with_--timeout_specified_(deprecated).golden
@@ -1,3 +1,4 @@
+Flag --timeout has been deprecated, please use --pipeline-timeout flag instead
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:


### PR DESCRIPTION
# Changes

With Pipelines release v0.36.0, Timeouts was moved out of feature flags
and existing Timeout was deprecated.

This PR updates the timeouts flags of `tkn pipeline start` to allow user
to pass the different timeouts for `Pipeline`, `PipelineTask` and
`FinallyTask` before starting a `Pipeline` using CLI.

closes #1561 

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Add flags `--pipeline-timeout`, `--tasks-timeout` and `--finally-timeout` before starting the Pipeline using tkn CLI. Also deprecating the existing `--timeout` flag
```