### PR TITLE
Switch to prefered quilt packaging format.

### DIFF
--- a/tekton/debbuild/control/source/format
+++ b/tekton/debbuild/control/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Switch to prefered quilt packaging.

From the [docs](https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#native):

    The non-native Debian package in the “3.0 (quilt)” format is the most normal Debian source
    package format. The debian/source/format file should have “3.0 (quilt)” in it as described in
    dpkg-source(1)....

    A native Debian package is the rare Debian binary package format. It may be used only when
    the package is useful and valuable only for Debian. Thus, its use is generally discouraged.

Some additional details can be found [here](https://wiki.debian.org/DebianMentorsFaq#What_is_the_difference_between_a_native_Debian_package_and_a_non-native_package.3F).


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] ~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~ -- no functional changes
- [x] Run the code checkers with `make check`
- [x] ~Regenerate the manpages, docs and go formatting with `make generated`~ -- no diffs to manpages
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Switch packaging format to prefered `quilt`.
```
