### PR TITLE
Removed apt-key for deb-based install instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,8 +78,9 @@ rpm-based distros).
 
     ```bash
     sudo apt update;sudo apt install -y gnupg
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3EFE0E0A2F2F60AA
-    echo "deb http://ppa.launchpad.net/tektoncd/cli/ubuntu eoan main"|sudo tee /etc/apt/sources.list.d/tektoncd-ubuntu-cli.list
+    sudo mkdir -p /etc/apt/keyrings/
+    sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/tektoncd.gpg --keyserver keyserver.ubuntu.com --recv-keys 3EFE0E0A2F2F60AA
+    echo "deb [signed-by=/etc/apt/keyrings/tektoncd.gpg] http://ppa.launchpad.net/tektoncd/cli/ubuntu eoan main"|sudo tee /etc/apt/sources.list.d/tektoncd-ubuntu-cli.list
     sudo apt update && sudo apt install -y tektoncd-cli
     ```
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updated gpg key import for PPA

Users may receive a warning every apt-get update due to apt-key deprecation
W: http://ppa.launchpad.net/tektoncd/cli/ubuntu/dists/eoan/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
Users on older versions of apt may require the bare binary key, instead of the keybox

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] ~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~
- [x] ~Run the code checkers with `make check`~
- [x] ~Regenerate the manpages, docs and go formatting with `make generated`~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
