### PR TITLE
Fix creating debian packages with latest debhelpers

### DIFF
--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -11,7 +11,7 @@ endif
 BUILD_DATE := $(BUILD_DATE:+0000=Z)
 
 %:
-	dh $@
+	dh $@ --builddirectory=_build --buildsystem=golang
 
 override_dh_auto_build:
 	@set -x ; export XDG_CACHE_HOME=/tmp/cache ; \


### PR DESCRIPTION
we were getting this error:

```shell
+ go build -mod=vendor -v -o obj-x86_64-linux-gnu/bin/tkn -ldflags -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=0.25.0 ./cmd/tkn
build flag -mod=vendor only valid when using modules
make[1]: *** [debian/rules:17: override_dh_auto_build] Error 1
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:14: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```

tested change building properly: 

![image](https://user-images.githubusercontent.com/98980/180723031-8b209e32-1133-451f-82f1-9fc28c76d470.png)




<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
