### PR TITLE
Try plugins from where tkn binary is

### DIFF
--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -21,6 +21,17 @@ func TestFindPlugin(t *testing.T) {
 	assert.Equal(t, path, nd.Join("tkn-test"))
 }
 
+func TestFindPluginNoExec(t *testing.T) {
+	nd := fs.NewDir(t, "TestFindPlugins")
+	defer nd.Remove()
+	// nolint: gosec
+	err := ioutil.WriteFile(nd.Join("tkn-test"), []byte("test"), 0o600)
+	assert.NilError(t, err)
+	t.Setenv(pluginDirEnv, nd.Path())
+	_, err = FindPlugin("test")
+	assert.ErrorContains(t, err, "cannot find plugin")
+}
+
 func TestFindPluginInPath(t *testing.T) {
 	nd := fs.NewDir(t, "TestFindPluginsInPath")
 	defer nd.Remove()


### PR DESCRIPTION
Try the plugin where tkn binary is :

i.e: you uncompress a tarball or install tkn-foo and tkn in ~/Downloads/ and run

`~/Downloads/tkn foo`

it would work even if ~/Downloads is not in path.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
