### PR TITLE
Fix debbuilds by pointing to build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Expand-Archive $HOME/tektoncd/cli/*.zip -DestinationPath C:\Users\Developer\tekt
   ```shell
   sudo apt update;sudo apt install -y gnupg
   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3EFE0E0A2F2F60AA
-  echo "deb http://ppa.launchpad.net/tektoncd/cli/ubuntu impish main"|sudo tee /etc/apt/sources.list.d/tektoncd-ubuntu-cli.list
+  echo "deb http://ppa.launchpad.net/tektoncd/cli/ubuntu jammy main"|sudo tee /etc/apt/sources.list.d/tektoncd-ubuntu-cli.list
   sudo apt update && sudo apt install -y tektoncd-cli
   ```
 

--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-TKN := obj-$(DEB_HOST_GNU_TYPE)/bin/tkn
+TKN := _build/bin/tkn
 
 DATE_FMT = %Y-%m-%dT%H:%M:%S%z
 ifdef SOURCE_DATE_EPOCH


### PR DESCRIPTION
# Changes

With latest changes in https://github.com/tektoncd/cli/pull/1654, the packaging was working but when installing the latest CLI `tektoncd-cli_0.25.0-2_amd64.deb` from PPA, there was no binary present but source code.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```