### PR TITLE
Fix e2e test by converting to v1beta1 resources

### DIFF
--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -30,11 +30,12 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/test/framework"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetTask(c *framework.Clients, name string) *v1alpha1.Task {
+func GetTask(c *framework.Clients, name string) *v1beta1.Task {
 
 	task, err := c.TaskClient.Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
@@ -44,7 +45,7 @@ func GetTask(c *framework.Clients, name string) *v1alpha1.Task {
 	return task
 }
 
-func GetClusterTask(c *framework.Clients, name string) *v1alpha1.ClusterTask {
+func GetClusterTask(c *framework.Clients, name string) *v1beta1.ClusterTask {
 	clustertask, err := c.ClusterTaskClient.Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		log.Fatalf("Couldn't get expected clustertask  %s", err)
@@ -52,7 +53,7 @@ func GetClusterTask(c *framework.Clients, name string) *v1alpha1.ClusterTask {
 	return clustertask
 }
 
-func GetTaskList(c *framework.Clients) *v1alpha1.TaskList {
+func GetTaskList(c *framework.Clients) *v1beta1.TaskList {
 
 	tasklist, err := c.TaskClient.List(context.Background(), metav1.ListOptions{})
 
@@ -63,7 +64,7 @@ func GetTaskList(c *framework.Clients) *v1alpha1.TaskList {
 	return tasklist
 }
 
-func GetClusterTaskList(c *framework.Clients) *v1alpha1.ClusterTaskList {
+func GetClusterTaskList(c *framework.Clients) *v1beta1.ClusterTaskList {
 	clustertasklist, err := c.ClusterTaskClient.List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		log.Fatalf("Couldn't get expected clustertasklist  %s", err)
@@ -71,7 +72,7 @@ func GetClusterTaskList(c *framework.Clients) *v1alpha1.ClusterTaskList {
 	return clustertasklist
 }
 
-func GetTaskRun(c *framework.Clients, name string) *v1alpha1.TaskRun {
+func GetTaskRun(c *framework.Clients, name string) *v1beta1.TaskRun {
 
 	taskRun, err := c.TaskRunClient.Get(context.Background(), name, metav1.GetOptions{})
 
@@ -82,7 +83,7 @@ func GetTaskRun(c *framework.Clients, name string) *v1alpha1.TaskRun {
 	return taskRun
 }
 
-func GetTaskRunList(c *framework.Clients) *v1alpha1.TaskRunList {
+func GetTaskRunList(c *framework.Clients) *v1beta1.TaskRunList {
 	taskRunlist, err := c.TaskRunClient.List(context.Background(), metav1.ListOptions{})
 
 	if err != nil {
@@ -114,7 +115,7 @@ func GetPipelineResourceList(c *framework.Clients) *v1alpha1.PipelineResourceLis
 	return pipelineResourceList
 }
 
-func GetPipeline(c *framework.Clients, name string) *v1alpha1.Pipeline {
+func GetPipeline(c *framework.Clients, name string) *v1beta1.Pipeline {
 
 	pipeline, err := c.PipelineClient.Get(context.Background(), name, metav1.GetOptions{})
 
@@ -125,7 +126,7 @@ func GetPipeline(c *framework.Clients, name string) *v1alpha1.Pipeline {
 	return pipeline
 }
 
-func GetPipelineList(c *framework.Clients) *v1alpha1.PipelineList {
+func GetPipelineList(c *framework.Clients) *v1beta1.PipelineList {
 
 	pipelineList, err := c.PipelineClient.List(context.Background(), metav1.ListOptions{})
 
@@ -136,7 +137,7 @@ func GetPipelineList(c *framework.Clients) *v1alpha1.PipelineList {
 	return pipelineList
 }
 
-func GetPipelineRun(c *framework.Clients, name string) *v1alpha1.PipelineRun {
+func GetPipelineRun(c *framework.Clients, name string) *v1beta1.PipelineRun {
 
 	pipelineRun, err := c.PipelineRunClient.Get(context.Background(), name, metav1.GetOptions{})
 
@@ -147,7 +148,7 @@ func GetPipelineRun(c *framework.Clients, name string) *v1alpha1.PipelineRun {
 	return pipelineRun
 }
 
-func GetPipelineRunListWithName(c *framework.Clients, pname string, sortByStartTime bool) *v1alpha1.PipelineRunList {
+func GetPipelineRunListWithName(c *framework.Clients, pname string, sortByStartTime bool) *v1beta1.PipelineRunList {
 	opts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pname),
 	}
@@ -164,7 +165,7 @@ func GetPipelineRunListWithName(c *framework.Clients, pname string, sortByStartT
 	return pipelineRunList
 }
 
-func GetTaskRunListByLabel(c *framework.Clients, tname string, sortByStartTime bool, label string) *v1alpha1.TaskRunList {
+func GetTaskRunListByLabel(c *framework.Clients, tname string, sortByStartTime bool, label string) *v1beta1.TaskRunList {
 	opts := metav1.ListOptions{
 		LabelSelector: label,
 	}
@@ -183,17 +184,17 @@ func GetTaskRunListByLabel(c *framework.Clients, tname string, sortByStartTime b
 	return taskRunList
 }
 
-func GetTaskRunListWithTaskName(c *framework.Clients, tname string, sortByStartTime bool) *v1alpha1.TaskRunList {
+func GetTaskRunListWithTaskName(c *framework.Clients, tname string, sortByStartTime bool) *v1beta1.TaskRunList {
 	label := fmt.Sprintf("tekton.dev/task=%s", tname)
 	return GetTaskRunListByLabel(c, tname, sortByStartTime, label)
 }
 
-func GetTaskRunListWithClusterTaskName(c *framework.Clients, ctname string, sortByStartTime bool) *v1alpha1.TaskRunList {
+func GetTaskRunListWithClusterTaskName(c *framework.Clients, ctname string, sortByStartTime bool) *v1beta1.TaskRunList {
 	label := fmt.Sprintf("tekton.dev/clusterTask=%s", ctname)
 	return GetTaskRunListByLabel(c, ctname, sortByStartTime, label)
 }
 
-func GetPipelineRunList(c *framework.Clients) *v1alpha1.PipelineRunList {
+func GetPipelineRunList(c *framework.Clients) *v1beta1.PipelineRunList {
 
 	pipelineRunList, err := c.PipelineRunClient.List(context.Background(), metav1.ListOptions{})
 
@@ -213,7 +214,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 	w := tabwriter.NewWriter(&tmplBytes, 0, 5, 3, ' ', tabwriter.TabIndent)
 
 	switch obj := obj.(type) {
-	case *v1alpha1.TaskList:
+	case *v1beta1.TaskList:
 
 		if len(obj.Items) == 0 {
 
@@ -227,7 +228,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 		}
 		w.Flush()
 		return tmplBytes.String()
-	case *v1alpha1.TaskRunList:
+	case *v1beta1.TaskRunList:
 		if len(obj.Items) == 0 {
 
 			return emptyMsg
@@ -242,7 +243,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 		}
 		w.Flush()
 		return tmplBytes.String()
-	case *v1alpha1.PipelineList:
+	case *v1beta1.PipelineList:
 		if len(obj.Items) == 0 {
 			return emptyMsg
 		}
@@ -255,7 +256,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 		w.Flush()
 		return tmplBytes.String()
 
-	case *v1alpha1.PipelineRunList:
+	case *v1beta1.PipelineRunList:
 		if len(obj.Items) == 0 {
 			return emptyMsg
 		}
@@ -279,7 +280,7 @@ func ListResourceNamesForJSONPath(obj interface{}) string {
 		}
 		w.Flush()
 		return tmplBytes.String()
-	case *v1alpha1.ClusterTaskList:
+	case *v1beta1.ClusterTaskList:
 		if len(obj.Items) == 0 {
 			return emptyMsg
 		}
@@ -367,7 +368,7 @@ func ListAllClusterTasksOutput(t *testing.T, cs *framework.Clients, td map[int]i
 	return tmplBytes.String()
 }
 
-func GetTaskListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1alpha1.TaskList {
+func GetTaskListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1beta1.TaskList {
 	t.Helper()
 
 	tasklist := GetTaskList(c)
@@ -393,7 +394,7 @@ func GetTaskListWithTestData(t *testing.T, c *framework.Clients, td map[int]inte
 	return tasklist
 }
 
-func GetClusterTaskListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1alpha1.ClusterTaskList {
+func GetClusterTaskListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1beta1.ClusterTaskList {
 	t.Helper()
 
 	clustertasklist := GetClusterTaskList(c)
@@ -445,7 +446,7 @@ NAME	STARTED	DURATION	STATUS{{- if $.AllNamespaces }}	NAMESPACE{{- end }}
 		SortByStartTimeTaskRun(taskrun.Items)
 	}
 	var data = struct {
-		TaskRuns      *v1alpha1.TaskRunList
+		TaskRuns      *v1beta1.TaskRunList
 		Time          clockwork.Clock
 		AllNamespaces bool
 	}{
@@ -473,7 +474,7 @@ NAME	STARTED	DURATION	STATUS{{- if $.AllNamespaces }}	NAMESPACE{{- end }}
 	return tmplBytes.String()
 }
 
-func GetTaskRunListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1alpha1.TaskRunList {
+func GetTaskRunListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1beta1.TaskRunList {
 	taskRunlist := GetTaskRunList(c)
 	if len(taskRunlist.Items) != len(td) {
 		t.Errorf("Length of taskrun list and Testdata provided not matching")
@@ -502,7 +503,7 @@ func GetTaskRunListWithTestData(t *testing.T, c *framework.Clients, td map[int]i
 	return taskRunlist
 }
 
-type pipelineruns map[string]v1alpha1.PipelineRun
+type pipelineruns map[string]v1beta1.PipelineRun
 
 type PipelinesListData struct {
 	Name   string
@@ -533,7 +534,7 @@ func ListAllPipelinesOutput(t *testing.T, cs *framework.Clients, td map[int]inte
 		t.Error("Failed to list pipelines")
 	}
 	var data = struct {
-		Pipelines    *v1alpha1.PipelineList
+		Pipelines    *v1beta1.PipelineList
 		PipelineRuns pipelineruns
 		Params       clockwork.Clock
 	}{
@@ -543,7 +544,7 @@ func ListAllPipelinesOutput(t *testing.T, cs *framework.Clients, td map[int]inte
 	}
 
 	funcMap := template.FuncMap{
-		"accessMap": func(prs pipelineruns, name string) *v1alpha1.PipelineRun {
+		"accessMap": func(prs pipelineruns, name string) *v1beta1.PipelineRun {
 			if pr, ok := prs[name]; ok {
 				return &pr
 			}
@@ -570,7 +571,7 @@ func ListAllPipelinesOutput(t *testing.T, cs *framework.Clients, td map[int]inte
 	return tmplBytes.String()
 }
 
-func listPipelineDetailsWithTestData(t *testing.T, cs *framework.Clients, td map[int]interface{}) (*v1alpha1.PipelineList, pipelineruns, error) {
+func listPipelineDetailsWithTestData(t *testing.T, cs *framework.Clients, td map[int]interface{}) (*v1beta1.PipelineList, pipelineruns, error) {
 	t.Helper()
 	ps := GetPipelineListWithTestData(t, cs, td)
 	runs := GetPipelineRunList(cs)
@@ -596,7 +597,7 @@ func listPipelineDetailsWithTestData(t *testing.T, cs *framework.Clients, td map
 	return ps, latestRuns, nil
 }
 
-func GetPipelineListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1alpha1.PipelineList {
+func GetPipelineListWithTestData(t *testing.T, c *framework.Clients, td map[int]interface{}) *v1beta1.PipelineList {
 	t.Helper()
 	ps := GetPipelineList(c)
 
@@ -718,8 +719,8 @@ func GetPipelineDescribeOutput(t *testing.T, cs *framework.Clients, pname string
 	pipelineRuns := GetPipelineRunListWithNameAndTestData(t, cs, pname, td)
 
 	var data = struct {
-		Pipeline     *v1alpha1.Pipeline
-		PipelineRuns *v1alpha1.PipelineRunList
+		Pipeline     *v1beta1.Pipeline
+		PipelineRuns *v1beta1.PipelineRunList
 		PipelineName string
 		Params       clockwork.Clock
 	}{
@@ -756,7 +757,7 @@ func GetPipelineDescribeOutput(t *testing.T, cs *framework.Clients, pname string
 
 }
 
-func GetPipelineWithTestData(t *testing.T, c *framework.Clients, name string, td map[int]interface{}) *v1alpha1.Pipeline {
+func GetPipelineWithTestData(t *testing.T, c *framework.Clients, name string, td map[int]interface{}) *v1beta1.Pipeline {
 	t.Helper()
 	pipeline := GetPipeline(c, name)
 
@@ -770,19 +771,17 @@ func GetPipelineWithTestData(t *testing.T, c *framework.Clients, name string, td
 					pipeline.Spec.Resources[count].Name = k
 					switch v {
 					case "git":
-						pipeline.Spec.Resources[count].Type = v1alpha1.PipelineResourceTypeGit
+						pipeline.Spec.Resources[count].Type = v1beta1.PipelineResourceTypeGit
 					case "storage":
-						pipeline.Spec.Resources[count].Type = v1alpha1.PipelineResourceTypeStorage
+						pipeline.Spec.Resources[count].Type = v1beta1.PipelineResourceTypeStorage
 					case "image":
-						pipeline.Spec.Resources[count].Type = v1alpha1.PipelineResourceTypeImage
+						pipeline.Spec.Resources[count].Type = v1beta1.PipelineResourceTypeImage
 					case "cluster":
-						pipeline.Spec.Resources[count].Type = v1alpha1.PipelineResourceTypeCluster
+						pipeline.Spec.Resources[count].Type = v1beta1.PipelineResourceTypeCluster
 					case "pullRequest":
-						pipeline.Spec.Resources[count].Type = v1alpha1.PipelineResourceTypePullRequest
-					case "gcs":
-						pipeline.Spec.Resources[count].Type = v1alpha1.PipelineResourceTypeGCS
+						pipeline.Spec.Resources[count].Type = v1beta1.PipelineResourceTypePullRequest
 					default:
-						t.Errorf("Provided PipelineResourcesData is not Valid Type : Need to Provide (%s, %s, %s, %s)", v1alpha1.PipelineResourceTypeGit, v1alpha1.PipelineResourceTypeImage, v1alpha1.PipelineResourceTypePullRequest, v1alpha1.PipelineResourceTypeCluster)
+						t.Errorf("Provided PipelineResourcesData is not Valid Type : Need to Provide (%s, %s, %s, %s)", v1beta1.PipelineResourceTypeGit, v1beta1.PipelineResourceTypeImage, v1beta1.PipelineResourceTypePullRequest, v1beta1.PipelineResourceTypeCluster)
 					}
 
 					count++
@@ -818,7 +817,7 @@ func GetPipelineWithTestData(t *testing.T, c *framework.Clients, name string, td
 	return pipeline
 }
 
-func GetPipelineRunListWithNameAndTestData(t *testing.T, c *framework.Clients, pname string, td map[int]interface{}) *v1alpha1.PipelineRunList {
+func GetPipelineRunListWithNameAndTestData(t *testing.T, c *framework.Clients, pname string, td map[int]interface{}) *v1beta1.PipelineRunList {
 	t.Helper()
 	opts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pname),

--- a/test/builder/sort.go
+++ b/test/builder/sort.go
@@ -17,18 +17,18 @@ package builder
 import (
 	"sort"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
-func SortByStartTimeTaskRun(trs []v1alpha1.TaskRun) {
+func SortByStartTimeTaskRun(trs []v1beta1.TaskRun) {
 	sort.Sort(byStartTimeTR(trs))
 }
 
-func SortByStartTimePipelineRun(prs []v1alpha1.PipelineRun) {
+func SortByStartTimePipelineRun(prs []v1beta1.PipelineRun) {
 	sort.Sort(byStartTimePR(prs))
 }
 
-type byStartTimeTR []v1alpha1.TaskRun
+type byStartTimeTR []v1beta1.TaskRun
 
 func (trs byStartTimeTR) Len() int      { return len(trs) }
 func (trs byStartTimeTR) Swap(i, j int) { trs[i], trs[j] = trs[j], trs[i] }
@@ -42,7 +42,7 @@ func (trs byStartTimeTR) Less(i, j int) bool {
 	return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
 }
 
-type byStartTimePR []v1alpha1.PipelineRun
+type byStartTimePR []v1beta1.PipelineRun
 
 func (prs byStartTimePR) Len() int      { return len(prs) }
 func (prs byStartTimePR) Swap(i, j int) { prs[i], prs[j] = prs[j], prs[i] }

--- a/test/builder/validate.go
+++ b/test/builder/validate.go
@@ -19,16 +19,17 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func Details(pre v1alpha1.PipelineResource) string {
 	var key = "url"
-	if pre.Spec.Type == v1alpha1.PipelineResourceTypeStorage {
+	if pre.Spec.Type == v1beta1.PipelineResourceTypeStorage {
 		key = "location"
 	}
-	if pre.Spec.Type == v1alpha1.PipelineResourceTypeCloudEvent {
+	if pre.Spec.Type == v1beta1.PipelineResourceTypeCloudEvent {
 		key = "targeturi"
 	}
 
@@ -41,7 +42,7 @@ func Details(pre v1alpha1.PipelineResource) string {
 	return "---"
 }
 
-func TaskRunHasFailed(tr *v1alpha1.TaskRun) string {
+func TaskRunHasFailed(tr *v1beta1.TaskRun) string {
 	if len(tr.Status.Conditions) == 0 {
 		return ""
 	}
@@ -53,7 +54,7 @@ func TaskRunHasFailed(tr *v1alpha1.TaskRun) string {
 }
 
 // this will sort the Resource by Type and then by Name
-func SortResourcesByTypeAndName(pres []v1alpha1.PipelineDeclaredResource) []v1alpha1.PipelineDeclaredResource {
+func SortResourcesByTypeAndName(pres []v1beta1.PipelineDeclaredResource) []v1beta1.PipelineDeclaredResource {
 	sort.Slice(pres, func(i, j int) bool {
 		if pres[j].Type < pres[i].Type {
 			return false
@@ -71,7 +72,7 @@ func SortResourcesByTypeAndName(pres []v1alpha1.PipelineDeclaredResource) []v1al
 
 // Pipeline Run Describe command
 
-func PipelineRunHasFailed(pr *v1alpha1.PipelineRun) string {
+func PipelineRunHasFailed(pr *v1beta1.PipelineRun) string {
 	if len(pr.Status.Conditions) == 0 {
 		return ""
 	}
@@ -95,7 +96,7 @@ type TaskrunList []tkr
 
 type tkr struct {
 	TaskrunName string
-	*v1alpha1.PipelineRunTaskRunStatus
+	*v1beta1.PipelineRunTaskRunStatus
 }
 
 func (s TaskrunList) Len() int      { return len(s) }

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/tektoncd/cli/test/framework"
 	"github.com/tektoncd/cli/test/helper"
 	"github.com/tektoncd/cli/test/wait"
-
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"

--- a/test/e2e/eventListener/eventListener_test.go
+++ b/test/e2e/eventListener/eventListener_test.go
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pipeline
+package eventListener
 
 import (
 	"context"

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/tektoncd/cli/test/helper"
 	"github.com/tektoncd/cli/test/wait"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"

--- a/test/framework/clients.go
+++ b/test/framework/clients.go
@@ -18,7 +18,7 @@ import (
 	"log"
 
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
 	resourceversioned "github.com/tektoncd/pipeline/pkg/client/resource/clientset/versioned"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/client/resource/clientset/versioned/typed/resource/v1alpha1"
 	"k8s.io/client-go/kubernetes"
@@ -28,11 +28,11 @@ import (
 // clients holds instances of interfaces for making requests to the Pipeline controllers.
 type Clients struct {
 	KubeClient             kubernetes.Interface
-	PipelineClient         v1alpha1.PipelineInterface
-	TaskClient             v1alpha1.TaskInterface
-	ClusterTaskClient      v1alpha1.ClusterTaskInterface
-	TaskRunClient          v1alpha1.TaskRunInterface
-	PipelineRunClient      v1alpha1.PipelineRunInterface
+	PipelineClient         v1beta1.PipelineInterface
+	TaskClient             v1beta1.TaskInterface
+	ClusterTaskClient      v1beta1.ClusterTaskInterface
+	TaskRunClient          v1beta1.TaskRunInterface
+	PipelineRunClient      v1beta1.PipelineRunInterface
 	PipelineResourceClient resourcev1alpha1.PipelineResourceInterface
 }
 
@@ -64,11 +64,11 @@ func NewClients(configPath, clusterName, namespace string) *Clients {
 	if err != nil {
 		log.Fatalf("failed to create pipeline clientset from config file at %s: %s", configPath, err)
 	}
-	c.PipelineClient = cs.TektonV1alpha1().Pipelines(namespace)
-	c.TaskClient = cs.TektonV1alpha1().Tasks(namespace)
-	c.ClusterTaskClient = cs.TektonV1alpha1().ClusterTasks()
-	c.TaskRunClient = cs.TektonV1alpha1().TaskRuns(namespace)
-	c.PipelineRunClient = cs.TektonV1alpha1().PipelineRuns(namespace)
+	c.PipelineClient = cs.TektonV1beta1().Pipelines(namespace)
+	c.TaskClient = cs.TektonV1beta1().Tasks(namespace)
+	c.ClusterTaskClient = cs.TektonV1beta1().ClusterTasks()
+	c.TaskRunClient = cs.TektonV1beta1().TaskRuns(namespace)
+	c.PipelineRunClient = cs.TektonV1beta1().PipelineRuns(namespace)
 	c.PipelineResourceClient = rcs.TektonV1alpha1().PipelineResources(namespace)
 	return c
 }

--- a/test/resources/cancel/pipeline-cancel.yaml
+++ b/test/resources/cancel/pipeline-cancel.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: sleep-pipeline

--- a/test/resources/cancel/task-cancel.yaml
+++ b/test/resources/cancel/task-cancel.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: sleep

--- a/test/resources/clustertask-with-optional-workspace.yaml
+++ b/test/resources/clustertask-with-optional-workspace.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
 metadata:
   generateName: clustertask-optional-ws-

--- a/test/resources/eventlistener/eventlistener.yaml
+++ b/test/resources/eventlistener/eventlistener.yaml
@@ -56,14 +56,14 @@ spec:
     - name: gitrevision
     - name: gitrepositoryurl
   resourcetemplates:
-    - apiVersion: tekton.dev/v1alpha1
+    - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:
         generateName: github-run-
       spec:
         taskSpec:
-          inputs:
-            resources:
+          resources:
+            inputs:
               - name: source
                 type: git
           steps:

--- a/test/resources/output-pipelinerun.yaml
+++ b/test/resources/output-pipelinerun.yaml
@@ -26,19 +26,18 @@ spec:
     value: https://github.com/GoogleContainerTools/skaffold
 ---
 # Task writes "some stuff" to a predefined path in the workspace git PipelineResource
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: create-file
   namespace: tektoncd
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
     - name: workspace
       type: git
       targetPath: damnworkspace
-  outputs:
-    resources:
+    outputs:
     - name: workspace
       type: git
   steps:
@@ -52,14 +51,14 @@ spec:
     args: ['-c', 'ln -s /workspace/damnworkspace /workspace/output/workspace && echo some stuff > /workspace/output/workspace/stuff']
 ---
 # Reads a file from a predefined path in the workspace git PipelineResource
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: check-stuff-file-exists
   namespace: tektoncd
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
     - name: workspace
       type: git
       targetPath: newworkspace
@@ -72,7 +71,7 @@ spec:
 # The Output of the first Task (git resource) create-file is given as an `Input`
 # to the next `Task` check-stuff-file-exists using`from` clause.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: output-pipeline
@@ -101,7 +100,7 @@ spec:
         resource: source-repo
         from: [first-create-file]
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: output-pipeline-run

--- a/test/resources/pipeline-with-workspace.yaml
+++ b/test/resources/pipeline-with-workspace.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: pipeline-with-workspace

--- a/test/resources/pipeline.yaml
+++ b/test/resources/pipeline.yaml
@@ -14,23 +14,22 @@
 
 # Task writes "some stuff" to a predefined path in the workspace git PipelineResource
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: create-file
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
     - name: workspace
       type: git
       targetPath: damnworkspace
-    params:
-      - name: FILEPATH
-      - name: FILENAME
-  outputs:
-    resources:
+    outputs:
     - name: workspace
       type: git
+  params:
+  - name: FILEPATH
+  - name: FILENAME
   steps:
   - name: read-docs-old
     image: ubuntu
@@ -42,13 +41,13 @@ spec:
     args: ['-c', 'ln -s /workspace/damnworkspace /workspace/output/workspace && echo some stuff > /workspace/output/workspace/stuff']
 ---
 # Reads a file from a predefined path in the workspace git PipelineResource
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: check-stuff-file-exists
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
     - name: workspace
       type: git
       targetPath: newworkspace
@@ -61,7 +60,7 @@ spec:
 # The Output of the first Task (git resource) create-file is given as an `Input`
 # to the next `Task` check-stuff-file-exists using`from` clause.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: output-pipeline

--- a/test/resources/read-file-clustertask.yaml
+++ b/test/resources/read-file-clustertask.yaml
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
 metadata:
   generateName: read-clustertask-
 spec:
   workspaces:
     - name: shared-workspace
-  inputs:
-    params:
-      - name: FILEPATH
-        default: "docs"
-      - name: FILENAME
-    resources:
+  params:
+    - name: FILEPATH
+      default: "docs"
+    - name: FILENAME
+  resources:
+    inputs:
       - name: source
         type: git
   steps:

--- a/test/resources/read-file.yaml
+++ b/test/resources/read-file.yaml
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: read-task
 spec:
-  inputs:
-    params:
-    - name: FILEPATH
-      default: "docs"
-    - name: FILENAME
-    resources:
+  params:
+  - name: FILEPATH
+    default: "docs"
+  - name: FILENAME
+  resources:
+    inputs:
     - name: source
       type: git
   steps:

--- a/test/resources/task-volume.yaml
+++ b/test/resources/task-volume.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: task-volume
@@ -39,7 +39,7 @@ spec:
   - name: custom
     emptyDir: {}
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: test-template-volume

--- a/test/resources/task-with-workspace.yaml
+++ b/test/resources/task-with-workspace.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: task-with-workspace

--- a/test/wait/helper-wait.go
+++ b/test/wait/helper-wait.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/cli/test/framework"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.opencensus.io/trace"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,13 +31,13 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-type TaskStateFn func(r *v1alpha1.Task) (bool, error)
+type TaskStateFn func(r *v1beta1.Task) (bool, error)
 
 // TaskRunStateFn is a condition function on TaskRun used polling functions
-type TaskRunStateFn func(r *v1alpha1.TaskRun) (bool, error)
+type TaskRunStateFn func(r *v1beta1.TaskRun) (bool, error)
 
 // PipelineRunStateFn is a condition function on TaskRun used polling functions
-type PipelineRunStateFn func(pr *v1alpha1.PipelineRun) (bool, error)
+type PipelineRunStateFn func(pr *v1beta1.PipelineRun) (bool, error)
 
 type PodRunStateFn func(r *corev1.Pod) (bool, error)
 
@@ -187,7 +187,7 @@ func ForServiceExternalIPState(c *framework.Clients, namespace, name string, inS
 // TaskRunSucceed provides a poll condition function that checks if the TaskRun
 // has successfully completed.
 func TaskRunSucceed(name string) TaskRunStateFn {
-	return func(tr *v1alpha1.TaskRun) (bool, error) {
+	return func(tr *v1beta1.TaskRun) (bool, error) {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
@@ -221,7 +221,7 @@ func PodRunSucceed(name string) PodRunStateFn {
 // TaskRunFailed provides a poll condition function that checks if the TaskRun
 // has failed.
 func TaskRunFailed(name string) TaskRunStateFn {
-	return func(tr *v1alpha1.TaskRun) (bool, error) {
+	return func(tr *v1beta1.TaskRun) (bool, error) {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
@@ -237,7 +237,7 @@ func TaskRunFailed(name string) TaskRunStateFn {
 // PipelineRunSucceed provides a poll condition function that checks if the PipelineRun
 // has successfully completed.
 func PipelineRunSucceed(name string) PipelineRunStateFn {
-	return func(pr *v1alpha1.PipelineRun) (bool, error) {
+	return func(pr *v1beta1.PipelineRun) (bool, error) {
 		c := pr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
@@ -253,7 +253,7 @@ func PipelineRunSucceed(name string) PipelineRunStateFn {
 // PipelineRunFailed provides a poll condition function that checks if the PipelineRun
 // has failed.
 func PipelineRunFailed(name string) PipelineRunStateFn {
-	return func(tr *v1alpha1.PipelineRun) (bool, error) {
+	return func(tr *v1beta1.PipelineRun) (bool, error) {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {

--- a/test/wait/wait.go
+++ b/test/wait/wait.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/tektoncd/cli/test/framework"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -30,7 +30,7 @@ import (
 // ForTaskRunToComplete Wait For Task Run Resource to be completed
 func ForTaskRunToComplete(c *framework.Clients, trname string, namespace string) {
 	log.Printf("Waiting for TaskRun %s in namespace %s to complete", trname, namespace)
-	if err := ForTaskRunState(c, trname, func(tr *v1alpha1.TaskRun) (bool, error) {
+	if err := ForTaskRunState(c, trname, func(tr *v1beta1.TaskRun) (bool, error) {
 		cond := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if cond != nil {
 			if cond.Status == corev1.ConditionTrue || cond.Status == corev1.ConditionFalse {
@@ -48,7 +48,7 @@ func ForTaskRunToComplete(c *framework.Clients, trname string, namespace string)
 // ForTaskRunToBeStarted Wait For Task Run Resource to be completed
 func ForTaskRunToBeStarted(c *framework.Clients, trname string, namespace string) {
 	log.Printf("Waiting for TaskRun %s in namespace %s to be started", trname, namespace)
-	if err := ForTaskRunState(c, trname, func(tr *v1alpha1.TaskRun) (bool, error) {
+	if err := ForTaskRunState(c, trname, func(tr *v1beta1.TaskRun) (bool, error) {
 		cond := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if cond != nil {
 			if cond.Status == corev1.ConditionTrue || cond.Status == corev1.ConditionFalse {
@@ -68,7 +68,7 @@ func ForTaskRunToBeStarted(c *framework.Clients, trname string, namespace string
 func ForPipelineRunToStart(c *framework.Clients, prname string, namespace string) {
 
 	log.Printf("Waiting for Pipelinerun %s in namespace %s to be started", prname, namespace)
-	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1beta1.PipelineRun) (bool, error) {
 		c := pr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
@@ -86,7 +86,7 @@ func ForPipelineRunToStart(c *framework.Clients, prname string, namespace string
 // WaitForPipelineRunToComplete Wait for Pipeline Run to complete
 func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace string) {
 	log.Printf("Waiting for Pipelinerun %s in namespace %s to be started", prname, namespace)
-	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1beta1.PipelineRun) (bool, error) {
 		c := pr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
@@ -112,7 +112,7 @@ func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace str
 
 	for _, taskrunItem := range taskrunList.Items {
 		go func(name string) {
-			err := ForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
+			err := ForTaskRunState(c, name, func(tr *v1beta1.TaskRun) (bool, error) {
 				c := tr.Status.GetCondition(apis.ConditionSucceeded)
 				if c != nil {
 					if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
@@ -138,7 +138,7 @@ func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace str
 	}
 
 	log.Printf("Waiting for PipelineRun %s in namespace %s to be Completed", prname, namespace)
-	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+	if err := ForPipelineRunState(c, prname, framework.Apitimeout, func(pr *v1beta1.PipelineRun) (bool, error) {
 		c := pr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
@@ -158,7 +158,7 @@ func ForPipelineRunToComplete(c *framework.Clients, prname string, namespace str
 		wg.Add(1)
 		go func(name string) {
 			defer wg.Done()
-			err := ForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
+			err := ForTaskRunState(c, name, func(tr *v1beta1.TaskRun) (bool, error) {
 				cond := tr.Status.GetCondition(apis.ConditionSucceeded)
 				if cond != nil {
 					if cond.Status == corev1.ConditionTrue || cond.Status == corev1.ConditionFalse {


### PR DESCRIPTION
This will move all the structs and yaml resources
used in e2e for pipeline, pipelinerun, task, taskrun
and clustertask to v1beta1

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix e2e test by converting to v1beta1 resources
```