### PR TITLE
Add Optional status of Workspaces in describe cmd of Task/Pipeline

### DIFF
--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -87,9 +87,9 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{- if ne (len .Pipeline.Spec.Workspaces) 0 }}
 
 {{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
- NAME	DESCRIPTION
+ NAME	DESCRIPTION	OPTIONAL
 {{- range $workspace := .Pipeline.Spec.Workspaces }}
- {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}
+ {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}	{{ $workspace.Optional }}
 {{- end }}
 {{- end }}
 

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -1377,3 +1377,87 @@ func TestPipelineDescribe_with_annotations(t *testing.T) {
 	}
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestPipelineDescribe_OptionalWorkspaces(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1beta1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1beta1.PipelineSpec{
+				Resources: []v1beta1.PipelineDeclaredResource{
+					{
+						Name: "name",
+						Type: v1alpha1.PipelineResourceTypeGit,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+				Results: []v1beta1.PipelineResult{
+					{
+						Name:        "result-1",
+						Description: "This is a description for result 1",
+					},
+					{
+						Name:        "result-2",
+						Description: "This is a description for result 2",
+					},
+					{
+						Name: "result-3",
+					},
+				},
+				Workspaces: []v1beta1.PipelineWorkspaceDeclaration{
+					{
+						Name:        "test",
+						Description: "test workspace",
+					},
+					{
+						Name:        "test-optional",
+						Description: "test optional workspace",
+						Optional:    true,
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1P(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_OptionalWorkspaces.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_OptionalWorkspaces.golden
@@ -15,8 +15,9 @@ Results
 
 Workspaces
 
- NAME   DESCRIPTION      OPTIONAL
- test   test workspace   false
+ NAME            DESCRIPTION              OPTIONAL
+ test            test workspace           false
+ test-optional   test optional works...   true
 
 Tasks
 

--- a/pkg/cmd/task/describe.go
+++ b/pkg/cmd/task/describe.go
@@ -101,9 +101,9 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .Task.Name }}
 {{- if ne (len .Task.Spec.Workspaces) 0 }}
 
 {{decorate "workspaces" ""}}{{decorate "underline bold" "Workspaces\n"}}
- NAME	DESCRIPTION
+ NAME	DESCRIPTION	OPTIONAL
 {{- range $workspace := .Task.Spec.Workspaces }}
- {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}
+ {{ decorate "bullet" $workspace.Name }}	{{ formatDesc $workspace.Description }}	{{ $workspace.Optional }}
 {{- end }}
 {{- end }}
 

--- a/pkg/cmd/task/describe_test.go
+++ b/pkg/cmd/task/describe_test.go
@@ -1103,3 +1103,66 @@ func TestTaskDescribe_with_annotations(t *testing.T) {
 	}
 	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
 }
+
+func TestTaskDescribe_With_OptionalWorkspaces(t *testing.T) {
+	tasks := []*v1beta1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "task-1",
+			},
+			Spec: v1beta1.TaskSpec{
+				Description: "a test description",
+				Steps: []v1beta1.Step{
+					{
+						Name:  "hello",
+						Image: "busybox",
+					},
+				},
+				Workspaces: []v1beta1.WorkspaceDeclaration{
+					{
+						Name:        "test",
+						Description: "test workspace",
+						MountPath:   "/workspace/test/file",
+						ReadOnly:    true,
+					},
+					{
+						Name:        "test-optional",
+						Description: "test optional workspace",
+						MountPath:   "/workspace/test-optional/file",
+						ReadOnly:    true,
+						Optional:    true,
+					},
+				},
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1T(tasks[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: tasks, Namespaces: namespaces})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task", "taskrun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	task := Command(p)
+	out, err := test.ExecuteCommand(task, "desc", "task-1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, out, fmt.Sprintf("%s.golden", t.Name()))
+}

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_OptionalWorkspaces.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_OptionalWorkspaces.golden
@@ -1,0 +1,13 @@
+Name:          task-1
+Namespace:     ns
+Description:   a test description
+
+Workspaces
+
+ NAME            DESCRIPTION              OPTIONAL
+ test            test workspace           false
+ test-optional   test optional works...   true
+
+Steps
+
+ hello

--- a/pkg/cmd/task/testdata/TestTaskDescribe_With_Workspaces.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_With_Workspaces.golden
@@ -4,8 +4,8 @@ Description:   a test description
 
 Workspaces
 
- NAME   DESCRIPTION
- test   test workspace
+ NAME   DESCRIPTION      OPTIONAL
+ test   test workspace   false
 
 Steps
 


### PR DESCRIPTION
# Changes

Until now there was no way user could get to know whether the defined
workspace in the Task/Pipeline are optional or not until and unless they
start the Task/Pipeline interactively.

This patch adds the `Optional` column in the describe command of
Task/Pipeline which will print true/false based on what is defined in
the definition of Task/Pipeline.

closes #1670 

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
show optional status of workspace in the describe command of Task and Pipeline
```