### PR TITLE
Remove `v1alpha1` support from PipelineRun.

### DIFF
--- a/pkg/cmd/taskrun/cancel_test.go
+++ b/pkg/cmd/taskrun/cancel_test.go
@@ -34,6 +34,8 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
+const versionA1 = "v1alpha1"
+
 func TestTaskRunCancel(t *testing.T) {
 	trs := []*v1alpha1.TaskRun{
 		{

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -1697,15 +1697,17 @@ func Test_ClusterTask_TaskRuns_Not_Deleted_With_Task_Option(t *testing.T) {
 	}
 
 	// Expect TaskRun from kind ClusterTask random remains after deletion
-	expected := `NAME    STARTED   DURATION   STATUS
-tr0-2   ---       ---        Succeeded
-`
+	expected := []string{`NAME    STARTED   DURATION   STATUS`,
+		`tr0-2   ---       ---        `, "Succeeded"}
+
 	// Run list command to confirm TaskRun still present
 	out, err := test.ExecuteCommand(taskrun, "list", "-n", "ns")
 	if err != nil {
 		t.Errorf("no error expected but received error: %v", err)
 	}
-	test.AssertOutput(t, expected, out)
+	for _, e := range expected {
+		test.AssertOutputContains(t, e, out)
+	}
 }
 
 func Test_Task_TaskRuns_Not_Deleted_With_ClusterTask_Option(t *testing.T) {
@@ -1813,13 +1815,15 @@ func Test_Task_TaskRuns_Not_Deleted_With_ClusterTask_Option(t *testing.T) {
 	}
 
 	// Expect TaskRun from kind ClusterTask random remains after deletion
-	expected := `NAME    STARTED   DURATION   STATUS
-tr0-1   ---       ---        Succeeded
-`
+	expected := []string{`NAME    STARTED   DURATION   STATUS
+tr0-1   ---       ---        `, "Succeeded"}
+	//
 	// Run list command to confirm TaskRun still present
 	out, err := test.ExecuteCommand(taskrun, "list", "-n", "ns")
 	if err != nil {
 		t.Errorf("no error expected but received error: %v", err)
 	}
-	test.AssertOutput(t, expected, out)
+	for _, e := range expected {
+		test.AssertOutputContains(t, e, out)
+	}
 }

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-all_in_namespace.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-all_in_namespace.golden
@@ -1,7 +1,7 @@
 NAME    STARTED          DURATION   STATUS
-tr0-1   ---              ---        Succeeded
-tr3-1   ---              ---        Failed
-tr4-1   ---              ---        Failed
-tr2-2   59 minutes ago   1m0s       Failed
-tr1-1   1 hour ago       1m0s       Succeeded
-tr2-1   1 hour ago       ---        Running
+tr0-1   ---              ---        [92mSucceeded[0m
+tr3-1   ---              ---        [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m
+tr1-1   1 hour ago       1m0s       [92mSucceeded[0m
+tr2-1   1 hour ago       ---        [94mRunning[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-by_Task_name.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-by_Task_name.golden
@@ -1,2 +1,2 @@
 NAME    STARTED      DURATION   STATUS
-tr1-1   1 hour ago   1m0s       Succeeded
+tr1-1   1 hour ago   1m0s       [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label.golden
@@ -1,3 +1,3 @@
 NAME    STARTED   DURATION   STATUS
-tr3-1   ---       ---        Failed
-tr4-1   ---       ---        Failed
+tr3-1   ---       ---        [91mFailed[0m
+tr4-1   ---       ---        [91mFailed[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label_with_in_query.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-filter_taskruns_by_label_with_in_query.golden
@@ -1,4 +1,4 @@
 NAME    STARTED          DURATION   STATUS
-tr3-1   ---              ---        Failed
-tr4-1   ---              ---        Failed
-tr2-2   59 minutes ago   1m0s       Failed
+tr3-1   ---              ---        [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_greater_than_maximum_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_greater_than_maximum_case.golden
@@ -1,7 +1,7 @@
 NAME    STARTED          DURATION   STATUS
-tr0-1   ---              ---        Succeeded
-tr3-1   ---              ---        Failed
-tr4-1   ---              ---        Failed
-tr2-2   59 minutes ago   1m0s       Failed
-tr1-1   1 hour ago       1m0s       Succeeded
-tr2-1   1 hour ago       ---        Running
+tr0-1   ---              ---        [92mSucceeded[0m
+tr3-1   ---              ---        [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m
+tr1-1   1 hour ago       1m0s       [92mSucceeded[0m
+tr2-1   1 hour ago       ---        [94mRunning[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_returned_to_1.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-limit_taskruns_returned_to_1.golden
@@ -1,2 +1,2 @@
 NAME    STARTED   DURATION   STATUS
-tr0-1   ---       ---        Succeeded
+tr0-1   ---       ---        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_in_reverse.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_in_reverse.golden
@@ -1,7 +1,7 @@
 NAME    STARTED          DURATION   STATUS
-tr2-1   1 hour ago       ---        Running
-tr1-1   1 hour ago       1m0s       Succeeded
-tr2-2   59 minutes ago   1m0s       Failed
-tr4-1   ---              ---        Failed
-tr3-1   ---              ---        Failed
-tr0-1   ---              ---        Succeeded
+tr2-1   1 hour ago       ---        [94mRunning[0m
+tr1-1   1 hour ago       1m0s       [92mSucceeded[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr3-1   ---              ---        [91mFailed[0m
+tr0-1   ---              ---        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_taskruns_in_all_namespaces.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_taskruns_in_all_namespaces.golden
@@ -1,4 +1,4 @@
 NAMESPACE   NAME    STARTED   DURATION   STATUS
-lacher      tr4-2   ---       ---        Succeeded
-lacher      tr5-1   ---       ---        Succeeded
-tout        tr4-1   ---       ---        Succeeded
+lacher      tr4-2   ---       ---        [92mSucceeded[0m
+lacher      tr5-1   ---       ---        [92mSucceeded[0m
+tout        tr4-1   ---       ---        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_taskruns_in_all_namespaces_without_headers.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns-print_taskruns_in_all_namespaces_without_headers.golden
@@ -1,3 +1,3 @@
-lacher   tr4-2   ---   ---   Succeeded
-lacher   tr5-1   ---   ---   Succeeded
-tout     tr4-1   ---   ---   Succeeded
+lacher   tr4-2   ---   ---   [92mSucceeded[0m
+lacher   tr5-1   ---   ---   [92mSucceeded[0m
+tout     tr4-1   ---   ---   [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-all_in_namespace.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-all_in_namespace.golden
@@ -1,7 +1,7 @@
 NAME    STARTED          DURATION   STATUS
-tr0-1   ---              ---        Succeeded
-tr3-1   ---              ---        Failed
-tr4-1   ---              ---        Failed
-tr2-2   59 minutes ago   1m0s       Failed
-tr1-1   1 hour ago       1m0s       Succeeded
-tr2-1   1 hour ago       ---        Running
+tr0-1   ---              ---        [92mSucceeded[0m
+tr3-1   ---              ---        [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m
+tr1-1   1 hour ago       1m0s       [92mSucceeded[0m
+tr2-1   1 hour ago       ---        [94mRunning[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-by_Task_name.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-by_Task_name.golden
@@ -1,2 +1,2 @@
 NAME    STARTED      DURATION   STATUS
-tr1-1   1 hour ago   1m0s       Succeeded
+tr1-1   1 hour ago   1m0s       [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-filter_taskruns_by_label.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-filter_taskruns_by_label.golden
@@ -1,3 +1,3 @@
 NAME    STARTED   DURATION   STATUS
-tr3-1   ---       ---        Failed
-tr4-1   ---       ---        Failed
+tr3-1   ---       ---        [91mFailed[0m
+tr4-1   ---       ---        [91mFailed[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-filter_taskruns_by_label_with_in_query.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-filter_taskruns_by_label_with_in_query.golden
@@ -1,4 +1,4 @@
 NAME    STARTED          DURATION   STATUS
-tr3-1   ---              ---        Failed
-tr4-1   ---              ---        Failed
-tr2-2   59 minutes ago   1m0s       Failed
+tr3-1   ---              ---        [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-limit_taskruns_greater_than_maximum_case.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-limit_taskruns_greater_than_maximum_case.golden
@@ -1,7 +1,7 @@
 NAME    STARTED          DURATION   STATUS
-tr0-1   ---              ---        Succeeded
-tr3-1   ---              ---        Failed
-tr4-1   ---              ---        Failed
-tr2-2   59 minutes ago   1m0s       Failed
-tr1-1   1 hour ago       1m0s       Succeeded
-tr2-1   1 hour ago       ---        Running
+tr0-1   ---              ---        [92mSucceeded[0m
+tr3-1   ---              ---        [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m
+tr1-1   1 hour ago       1m0s       [92mSucceeded[0m
+tr2-1   1 hour ago       ---        [94mRunning[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-limit_taskruns_returned_to_1.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-limit_taskruns_returned_to_1.golden
@@ -1,2 +1,2 @@
 NAME    STARTED   DURATION   STATUS
-tr0-1   ---       ---        Succeeded
+tr0-1   ---       ---        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-print_in_reverse.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-print_in_reverse.golden
@@ -1,7 +1,7 @@
 NAME    STARTED          DURATION   STATUS
-tr2-1   1 hour ago       ---        Running
-tr1-1   1 hour ago       1m0s       Succeeded
-tr2-2   59 minutes ago   1m0s       Failed
-tr4-1   ---              ---        Failed
-tr3-1   ---              ---        Failed
-tr0-1   ---              ---        Succeeded
+tr2-1   1 hour ago       ---        [94mRunning[0m
+tr1-1   1 hour ago       1m0s       [92mSucceeded[0m
+tr2-2   59 minutes ago   1m0s       [91mFailed[0m
+tr4-1   ---              ---        [91mFailed[0m
+tr3-1   ---              ---        [91mFailed[0m
+tr0-1   ---              ---        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-print_taskruns_in_all_namespaces.golden
+++ b/pkg/cmd/taskrun/testdata/TestListTaskRuns_v1beta1-print_taskruns_in_all_namespaces.golden
@@ -1,4 +1,4 @@
 NAMESPACE   NAME    STARTED   DURATION   STATUS
-lacher      tr4-2   ---       ---        Succeeded
-lacher      tr5-1   ---       ---        Succeeded
-tout        tr4-1   ---       ---        Succeeded
+lacher      tr4-2   ---       ---        [92mSucceeded[0m
+lacher      tr5-1   ---       ---        [92mSucceeded[0m
+tout        tr4-1   ---       ---        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Results.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Results.golden
@@ -1,16 +1,16 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    task-1
-Labels:
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    task-1
+[1mLabels[0m:
  tekton.dev/task=task-1
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED          DURATION    STATUS
-10 minutes ago   5m0s        Failed
+10 minutes ago   5m0s        [91mFailed[0m
 
-Results
+📝 [4;1mResults[0m
 
- NAME       VALUE
- result-1   value-1
- result-2   value-2
+ NAME         VALUE
+ ∙ result-1   value-1
+ ∙ result-2   value-2

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Workspaces.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_With_Workspaces.golden
@@ -1,23 +1,23 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    task-1
-Labels:
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    task-1
+[1mLabels[0m:
  tekton.dev/task=task-1
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED          DURATION    STATUS
-10 minutes ago   5m0s        Failed
+10 minutes ago   5m0s        [91mFailed[0m
 
-Results
+📝 [4;1mResults[0m
 
- NAME       VALUE
- result-1   value-1
- result-2   value-2
+ NAME         VALUE
+ ∙ result-1   value-1
+ ∙ result-2   value-2
 
-Workspaces
+📂 [4;1mWorkspaces[0m
 
- NAME        SUB PATH   WORKSPACE BINDING
- test        test       EmptyDir (emptyDir=)
- configmap   ---        ConfigMap (config=bar)
- secret      ---        Secret (secret=foobar)
+ NAME          SUB PATH   WORKSPACE BINDING
+ ∙ test        test       EmptyDir (emptyDir=)
+ ∙ configmap   ---        ConfigMap (config=bar)
+ ∙ secret      ---        Secret (secret=foobar)

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneTaskRunPresent.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneTaskRunPresent.golden
@@ -1,10 +1,10 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Labels:
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mLabels[0m:
  tekton.dev/task=t1
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED          DURATION    STATUS
-20 minutes ago   5m0s        Succeeded
+20 minutes ago   5m0s        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneV1beta1TaskRunPresent.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_WithoutNameIfOnlyOneV1beta1TaskRunPresent.golden
@@ -1,10 +1,10 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    task-1
-Labels:
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    task-1
+[1mLabels[0m:
  tekton.dev/task=task-1
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED          DURATION    STATUS
-10 minutes ago   5m0s        Failed
+10 minutes ago   5m0s        [91mFailed[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_cancel_taskrun.golden
@@ -1,11 +1,11 @@
-Name:        tr-1
-Namespace:   ns
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-8 minutes ago   3m0s        Cancelled(TaskRunCancelled)
+8 minutes ago   3m0s        [93mCancelled[0m(TaskRunCancelled)
 
-Message
+[4;1mMessage[0m
 
 TaskRun "tr-1" was cancelled

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_empty_taskrun.golden
@@ -1,11 +1,11 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
-Labels:
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
+[1mLabels[0m:
  tekton.dev/task=t1
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED    DURATION    STATUS
----        ---         Succeeded
+---        ---         [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_failed.golden
@@ -1,13 +1,13 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-8 minutes ago   3m0s        Failed
+8 minutes ago   3m0s        [91mFailed[0m
 
-Message
+[4;1mMessage[0m
 
 Testing tr failed

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_last.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_last.golden
@@ -1,33 +1,33 @@
-Name:        tr-2
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-2
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-8 minutes ago   ---         Succeeded
+8 minutes ago   ---         [92mSucceeded[0m
 
-Input Resources
-
- NAME          RESOURCE REF
- git           git
- image-input   image
-
-Output Resources
+📨 [4;1mInput Resources[0m
 
  NAME            RESOURCE REF
- image-output    image
- image-output2   image
+ ∙ git           git
+ ∙ image-input   image
 
-Params
+📡 [4;1mOutput Resources[0m
 
- NAME     VALUE
- input    param
- input2   param2
+ NAME              RESOURCE REF
+ ∙ image-output    image
+ ∙ image-output2   image
 
-Steps
+⚓ [4;1mParams[0m
 
- NAME    STATUS
- step3   Completed
- step4   Completed
+ NAME       VALUE
+ ∙ input    param
+ ∙ input2   param2
+
+🦶 [4;1mSteps[0m
+
+ NAME      STATUS
+ ∙ step3   [95mCompleted[0m
+ ∙ step4   [95mCompleted[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_lastV1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_lastV1beta1.golden
@@ -1,10 +1,10 @@
-Name:        tr-2
-Namespace:   ns
-Task Ref:    task-1
-Labels:
+[1mName[0m:        tr-2
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    task-1
+[1mLabels[0m:
  tekton.dev/task=task-1
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-0 seconds ago   5m0s        Succeeded
+0 seconds ago   5m0s        [92mSucceeded[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref.golden
@@ -1,33 +1,33 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-9 minutes ago   ---         Succeeded
+9 minutes ago   ---         [92mSucceeded[0m
 
-Input Resources
-
- NAME          RESOURCE REF
- git           
- image-input   image
-
-Output Resources
+📨 [4;1mInput Resources[0m
 
  NAME            RESOURCE REF
- image-output    
- image-output2   
+ ∙ git           git
+ ∙ image-input   image
 
-Params
+📡 [4;1mOutput Resources[0m
 
- NAME     VALUE
- input    param
- input2   param2
+ NAME              RESOURCE REF
+ ∙ image-output    image
+ ∙ image-output2   image
 
-Steps
+⚓ [4;1mParams[0m
 
- NAME    STATUS
- step1   Completed
- step2   Completed
+ NAME       VALUE
+ ∙ input    param
+ ∙ input2   param2
+
+🦶 [4;1mSteps[0m
+
+ NAME      STATUS
+ ∙ step1   [95mCompleted[0m
+ ∙ step2   [95mCompleted[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_taskref.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_taskref.golden
@@ -1,11 +1,11 @@
-Name:        tr-1
-Namespace:   ns
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-8 minutes ago   3m0s        Failed
+8 minutes ago   3m0s        [91mFailed[0m
 
-Message
+[4;1mMessage[0m
 
 Testing tr failed

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun.golden
@@ -1,33 +1,33 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-9 minutes ago   ---         Succeeded
+9 minutes ago   ---         [92mSucceeded[0m
 
-Input Resources
-
- NAME          RESOURCE REF
- git           git
- image-input   image
-
-Output Resources
+📨 [4;1mInput Resources[0m
 
  NAME            RESOURCE REF
- image-output    image
- image-output2   image
+ ∙ git           git
+ ∙ image-input   image
 
-Params
+📡 [4;1mOutput Resources[0m
 
- NAME     VALUE
- input    param
- input2   param2
+ NAME              RESOURCE REF
+ ∙ image-output    image
+ ∙ image-output2   image
 
-Steps
+⚓ [4;1mParams[0m
 
- NAME    STATUS
- step1   Completed
- step2   Completed
+ NAME       VALUE
+ ∙ input    param
+ ∙ input2   param2
+
+🦶 [4;1mSteps[0m
+
+ NAME      STATUS
+ ∙ step1   [95mCompleted[0m
+ ∙ step2   [95mCompleted[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures.golden
@@ -1,39 +1,39 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-9 minutes ago   ---         Failed
+9 minutes ago   ---         [91mFailed[0m
 
-Input Resources
-
- NAME          RESOURCE REF
- git           
- image-input   image
-
-Output Resources
+📨 [4;1mInput Resources[0m
 
  NAME            RESOURCE REF
- image-output    
- image-output2   
+ ∙ git           git
+ ∙ image-input   image
 
-Params
+📡 [4;1mOutput Resources[0m
 
- NAME     VALUE
- input    param
- input2   param2
+ NAME              RESOURCE REF
+ ∙ image-output    image
+ ∙ image-output2   image
 
-Steps
+⚓ [4;1mParams[0m
 
- NAME    STATUS
- step1   Error
- step2   ---
+ NAME       VALUE
+ ∙ input    param
+ ∙ input2   param2
 
-Sidecars
+🦶 [4;1mSteps[0m
 
- NAME       STATUS
- sidecar1   Error
- sidecar2   ---
+ NAME      STATUS
+ ∙ step1   [0mError[0m
+ ∙ step2   [0m---[0m
+
+🚗 [4;1mSidecars[0m
+
+ NAME         STATUS
+ ∙ sidecar1   [0mError[0m
+ ∙ sidecar2   [0m---[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar.golden
@@ -1,38 +1,38 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-9 minutes ago   ---         Running
+9 minutes ago   ---         [94mRunning[0m
 
-Input Resources
-
- NAME          RESOURCE REF
- git           
- image-input   image
-
-Output Resources
+📨 [4;1mInput Resources[0m
 
  NAME            RESOURCE REF
- image-output    
- image-output2   
+ ∙ git           git
+ ∙ image-input   image
 
-Params
+📡 [4;1mOutput Resources[0m
 
- NAME     VALUE
- input    param
- input2   param2
+ NAME              RESOURCE REF
+ ∙ image-output    image
+ ∙ image-output2   image
 
-Steps
+⚓ [4;1mParams[0m
 
- NAME    STATUS
- step1   PodInitializing
- step2   PodInitializing
+ NAME       VALUE
+ ∙ input    param
+ ∙ input2   param2
 
-Sidecars
+🦶 [4;1mSteps[0m
 
- NAME       STATUS
- sidecar1   PodInitializing
+ NAME      STATUS
+ ∙ step1   [0mPodInitializing[0m
+ ∙ step2   [0mPodInitializing[0m
+
+🚗 [4;1mSidecars[0m
+
+ NAME         STATUS
+ ∙ sidecar1   [0mPodInitializing[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars.golden
@@ -1,39 +1,39 @@
-Name:        tr-1
-Namespace:   ns
-Task Ref:    t1
-Timeout:     1h0m0s
+[1mName[0m:        tr-1
+[1mNamespace[0m:   ns
+[1mTask Ref[0m:    t1
+[1mTimeout[0m:     1h0m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED         DURATION    STATUS
-9 minutes ago   ---         Running
+9 minutes ago   ---         [94mRunning[0m
 
-Input Resources
-
- NAME          RESOURCE REF
- git           
- image-input   image
-
-Output Resources
+📨 [4;1mInput Resources[0m
 
  NAME            RESOURCE REF
- image-output    
- image-output2   
+ ∙ git           git
+ ∙ image-input   image
 
-Params
+📡 [4;1mOutput Resources[0m
 
- NAME     VALUE
- input    param
- input2   param2
+ NAME              RESOURCE REF
+ ∙ image-output    image
+ ∙ image-output2   image
 
-Steps
+⚓ [4;1mParams[0m
 
- NAME    STATUS
- step1   Running
- step2   Running
+ NAME       VALUE
+ ∙ input    param
+ ∙ input2   param2
 
-Sidecars
+🦶 [4;1mSteps[0m
 
- NAME       STATUS
- sidecar1   Running
- sidecar2   Running
+ NAME      STATUS
+ ∙ step1   [94mRunning[0m
+ ∙ step2   [94mRunning[0m
+
+🚗 [4;1mSidecars[0m
+
+ NAME         STATUS
+ ∙ sidecar1   [94mRunning[0m
+ ∙ sidecar2   [94mRunning[0m

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_with_annotations.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_with_annotations.golden
@@ -1,9 +1,9 @@
-Name:        tr-with-annotations
-Namespace:   ns
-Annotations:
+[1mName[0m:        tr-with-annotations
+[1mNamespace[0m:   ns
+[1mAnnotations[0m:
  tekton.dev/tags=testing
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED    DURATION    STATUS
 ---        ---         ---

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_zero_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_zero_timeout.golden
@@ -1,7 +1,7 @@
-Name:        tr-zero-timeout
-Namespace:   ns
+[1mName[0m:        tr-zero-timeout
+[1mNamespace[0m:   ns
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED    DURATION    STATUS
 ---        ---         ---

--- a/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunWithSpecDescribe_custom_timeout.golden
@@ -1,8 +1,8 @@
-Name:        tr-custom-timeout
-Namespace:   ns
-Timeout:     1m0s
+[1mName[0m:        tr-custom-timeout
+[1mNamespace[0m:   ns
+[1mTimeout[0m:     1m0s
 
-Status
+🌡️  [4;1mStatus[0m
 
 STARTED    DURATION    STATUS
 ---        ---         ---

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -15,13 +15,11 @@
 package pipeline
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,16 +72,7 @@ func Get(c *cli.Clients, pipelinename string, opts metav1.GetOptions, ns string)
 	}
 
 	if gvr.Version == "v1alpha1" {
-		pipeline, err := getV1alpha1(c, pipelinename, opts, ns)
-		if err != nil {
-			return nil, err
-		}
-		var pipelineConverted v1beta1.Pipeline
-		err = pipeline.ConvertTo(context.Background(), &pipelineConverted)
-		if err != nil {
-			return nil, err
-		}
-		return &pipelineConverted, nil
+		return nil, fmt.Errorf("v1alpha1 is no longer supported")
 	}
 	return GetV1beta1(c, pipelinename, opts, ns)
 }
@@ -96,21 +85,6 @@ func GetV1beta1(c *cli.Clients, pipelinename string, opts metav1.GetOptions, ns 
 	}
 
 	var pipeline *v1beta1.Pipeline
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredP.UnstructuredContent(), &pipeline); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get pipeline from %s namespace \n", ns)
-		return nil, err
-	}
-	return pipeline, nil
-}
-
-// It will fetch the resource in v1alpha1 struct format
-func getV1alpha1(c *cli.Clients, pipelinename string, opts metav1.GetOptions, ns string) (*v1alpha1.Pipeline, error) {
-	unstructuredP, err := actions.Get(pipelineGroupResource, c.Dynamic, c.Tekton.Discovery(), pipelinename, ns, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var pipeline *v1alpha1.Pipeline
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredP.UnstructuredContent(), &pipeline); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get pipeline from %s namespace \n", ns)
 		return nil, err

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -16,119 +16,17 @@ package pipeline
 
 import (
 	"testing"
-	"time"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
-	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	versionA1 = "v1alpha1"
-	versionB1 = "v1beta1"
-)
-
-func TestPipelinesList(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-
-	pdata := []*v1alpha1.Pipeline{
-		{
-
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipeline",
-				Namespace: "ns",
-				// created  5 minutes back
-				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
-			},
-		},
-	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		Pipelines: pdata,
-	})
-	cs.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"pipeline"})
-
-	tdc := testDynamic.Options{}
-	dc, err := tdc.Client(
-		cb.UnstructuredP(pdata[0], versionA1),
-	)
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-
-	pdata2 := []*v1alpha1.Pipeline{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipeline",
-				Namespace: "ns",
-				// created  5 minutes back
-				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipeline2",
-				Namespace: "ns",
-				// created  5 minutes back
-				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
-			},
-		},
-	}
-	cs2, _ := test.SeedTestData(t, pipelinetest.Data{
-		Pipelines: pdata2,
-	})
-	cs2.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"pipeline", "pipelinerun"})
-	tdc2 := testDynamic.Options{}
-	dc2, err := tdc2.Client(
-		cb.UnstructuredP(pdata2[0], versionA1),
-		cb.UnstructuredP(pdata2[1], versionA1),
-	)
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
-	p2 := &test.Params{Tekton: cs2.Pipeline, Clock: clock, Kube: cs2.Kube, Dynamic: dc2}
-	p3 := &test.Params{Tekton: cs2.Pipeline, Clock: clock, Kube: cs2.Kube, Dynamic: dc2}
-	p3.SetNamespace("unknown")
-
-	testParams := []struct {
-		name   string
-		params *test.Params
-		want   []string
-	}{
-		{
-			name:   "Single Pipeline",
-			params: p,
-			want:   []string{"pipeline"},
-		},
-		{
-			name:   "Multi Pipelines",
-			params: p2,
-			want:   []string{"pipeline", "pipeline2"},
-		},
-		{
-			name:   "Unknown namespace",
-			params: p3,
-			want:   []string{},
-		},
-	}
-
-	for _, tp := range testParams {
-		t.Run(tp.name, func(t *testing.T) {
-			got, err := GetAllPipelineNames(tp.params)
-			if err != nil {
-				t.Errorf("unexpected Error")
-			}
-			test.AssertOutput(t, tp.want, got)
-		})
-	}
-}
+const versionB1 = "v1beta1"
 
 func TestPipelinesList_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
@@ -216,53 +114,6 @@ func TestPipelinesList_v1beta1(t *testing.T) {
 			test.AssertOutput(t, tp.want, got)
 		})
 	}
-}
-
-func TestPipelineGet(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-
-	pdata := []*v1alpha1.Pipeline{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipeline",
-				Namespace: "ns",
-				// created  5 minutes back
-				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipeline2",
-				Namespace: "ns",
-				// created  5 minutes back
-				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
-			},
-		},
-	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		Pipelines: pdata,
-	})
-	cs.Pipeline.Resources = cb.APIResourceList(versionA1, []string{"pipeline", "pipelinerun"})
-	tdc := testDynamic.Options{}
-	dc, err := tdc.Client(
-		cb.UnstructuredP(pdata[0], versionA1),
-		cb.UnstructuredP(pdata[1], versionA1),
-	)
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
-	c, err := p.Clients()
-	if err != nil {
-		t.Errorf("unable to create client: %v", err)
-	}
-
-	got, err := Get(c, "pipeline", metav1.GetOptions{}, "ns")
-	if err != nil {
-		t.Errorf("unexpected Error")
-	}
-	test.AssertOutput(t, "pipeline", got.Name)
 }
 
 func TestPipelineGet_v1beta1(t *testing.T) {

--- a/pkg/pipelinerun/pipelinerun.go
+++ b/pkg/pipelinerun/pipelinerun.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -105,16 +104,7 @@ func Get(c *cli.Clients, prname string, opts metav1.GetOptions, ns string) (*v1b
 	}
 
 	if gvr.Version == "v1alpha1" {
-		pipelinerun, err := getV1alpha1(c, prname, opts, ns)
-		if err != nil {
-			return nil, err
-		}
-		var pipelinerunConverted v1beta1.PipelineRun
-		err = pipelinerun.ConvertTo(context.Background(), &pipelinerunConverted)
-		if err != nil {
-			return nil, err
-		}
-		return &pipelinerunConverted, nil
+		return nil, fmt.Errorf("v1alpha1 is no longer supported")
 	}
 	return GetV1beta1(c, prname, opts, ns)
 }
@@ -138,21 +128,6 @@ func GetV1beta1(c *cli.Clients, prname string, opts metav1.GetOptions, ns string
 	}
 
 	return populatedPR, nil
-}
-
-// It will fetch the resource in v1alpha1 struct format
-func getV1alpha1(c *cli.Clients, prname string, opts metav1.GetOptions, ns string) (*v1alpha1.PipelineRun, error) {
-	unstructuredPR, err := actions.Get(prGroupResource, c.Dynamic, c.Tekton.Discovery(), prname, ns, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var pipelinerun *v1alpha1.PipelineRun
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredPR.UnstructuredContent(), &pipelinerun); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get pipelinerun from %s namespace \n", ns)
-		return nil, err
-	}
-	return pipelinerun, nil
 }
 
 func Watch(c *cli.Clients, opts metav1.ListOptions, ns string) (watch.Interface, error) {
@@ -199,14 +174,7 @@ func Create(c *cli.Clients, pr *v1beta1.PipelineRun, opts metav1.CreateOptions, 
 	}
 
 	if gvr.Version == "v1alpha1" {
-		var pipelinerunConverted v1alpha1.PipelineRun
-		err = pipelinerunConverted.ConvertFrom(context.Background(), pr)
-		if err != nil {
-			return nil, err
-		}
-		pipelinerunConverted.Kind = "PipelineRun"
-		pipelinerunConverted.APIVersion = "tekton.dev/v1alpha1"
-		return createUnstructured(&pipelinerunConverted, c, opts, ns, gvr)
+		return nil, fmt.Errorf("v1alpha1 is no longer supported")
 	}
 	return createUnstructured(pr, c, opts, ns, gvr)
 }

--- a/pkg/pipelinerun/pipelinerun_test.go
+++ b/pkg/pipelinerun/pipelinerun_test.go
@@ -24,137 +24,15 @@ import (
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/parse"
-	pipelinetest "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
-
-func TestPipelineRunsList_with_single_run(t *testing.T) {
-	version := "v1alpha1"
-	clock := clockwork.NewFakeClock()
-	pr1Started := clock.Now().Add(10 * time.Second)
-	runDuration := 1 * time.Minute
-
-	prdata := []*v1alpha1.PipelineRun{
-
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipelinerun",
-				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/pipeline": "random"},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipelinerun1",
-				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
-			},
-			Status: v1alpha1.PipelineRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						{
-							Status: corev1.ConditionTrue,
-							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
-						},
-					},
-				},
-				PipelineRunStatusFields: v1alpha1.PipelineRunStatusFields{
-					StartTime:      &metav1.Time{Time: pr1Started},
-					CompletionTime: &metav1.Time{Time: pr1Started.Add(runDuration)},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipelinerun2",
-				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
-			},
-			Status: v1alpha1.PipelineRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						{
-							Status: corev1.ConditionTrue,
-							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
-						},
-					},
-				},
-				PipelineRunStatusFields: v1alpha1.PipelineRunStatusFields{
-					StartTime:      &metav1.Time{Time: pr1Started},
-					CompletionTime: &metav1.Time{Time: pr1Started.Add(runDuration)},
-				},
-			},
-		},
-	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		PipelineRuns: prdata,
-	})
-	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	tdc := testDynamic.Options{}
-	dc, err := tdc.Client(
-		cb.UnstructuredPR(prdata[0], version),
-		cb.UnstructuredPR(prdata[1], version),
-		cb.UnstructuredPR(prdata[2], version),
-	)
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
-	p2 := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
-	p2.SetNamespace("unknown")
-
-	testParams := []struct {
-		name        string
-		params      *test.Params
-		listOptions metav1.ListOptions
-		want        []string
-	}{
-		{
-			name:        "Specify related pipeline",
-			params:      p,
-			listOptions: metav1.ListOptions{LabelSelector: "tekton.dev/pipeline=pipeline"},
-			want: []string{
-				"pipelinerun1 started -10 seconds ago",
-				"pipelinerun2 started -10 seconds ago",
-			},
-		},
-		{
-			name:        "Not specify related pipeline",
-			params:      p,
-			listOptions: metav1.ListOptions{},
-			want: []string{
-				"pipelinerun started ---",
-				"pipelinerun1 started -10 seconds ago",
-				"pipelinerun2 started -10 seconds ago",
-			},
-		},
-		{
-			name:        "Specify unknown namespace",
-			params:      p2,
-			listOptions: metav1.ListOptions{},
-			want:        []string{},
-		},
-	}
-
-	for _, tp := range testParams {
-		t.Run(tp.name, func(t *testing.T) {
-			got, err := GetAllPipelineRuns(tp.params, tp.listOptions, 5)
-			if err != nil {
-				t.Errorf("unexpected Error")
-			}
-			test.AssertOutput(t, tp.want, got)
-		})
-	}
-}
 
 func TestPipelineRunsV1beta1List_with_single_run(t *testing.T) {
 	version := "v1beta1"
@@ -303,82 +181,6 @@ func TestPipelineRunsV1beta1List_with_single_run(t *testing.T) {
 	}
 }
 
-func TestPipelineRunGet(t *testing.T) {
-	version := "v1alpha1"
-	clock := clockwork.NewFakeClock()
-	pr1Started := clock.Now().Add(10 * time.Second)
-	runDuration := 1 * time.Minute
-
-	prdata := []*v1alpha1.PipelineRun{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipelinerun1",
-				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
-			},
-			Status: v1alpha1.PipelineRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						{
-							Status: corev1.ConditionTrue,
-							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
-						},
-					},
-				},
-				PipelineRunStatusFields: v1alpha1.PipelineRunStatusFields{
-					StartTime:      &metav1.Time{Time: pr1Started},
-					CompletionTime: &metav1.Time{Time: pr1Started.Add(runDuration)},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipelinerun2",
-				Namespace: "ns",
-				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
-			},
-			Status: v1alpha1.PipelineRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						{
-							Status: corev1.ConditionTrue,
-							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
-						},
-					},
-				},
-				PipelineRunStatusFields: v1alpha1.PipelineRunStatusFields{
-					StartTime:      &metav1.Time{Time: pr1Started},
-					CompletionTime: &metav1.Time{Time: pr1Started.Add(runDuration)},
-				},
-			},
-		},
-	}
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{
-		PipelineRuns: prdata,
-	})
-	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	tdc := testDynamic.Options{}
-	dc, err := tdc.Client(
-		cb.UnstructuredPR(prdata[0], version),
-		cb.UnstructuredPR(prdata[1], version),
-	)
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
-	c, err := p.Clients()
-	if err != nil {
-		t.Errorf("unable to create client: %v", err)
-	}
-
-	got, err := Get(c, "pipelinerun1", metav1.GetOptions{}, "ns")
-	if err != nil {
-		t.Errorf("unexpected Error")
-	}
-	test.AssertOutput(t, "pipelinerun1", got.Name)
-}
-
 func TestPipelineRunGet_v1beta1(t *testing.T) {
 	version := "v1beta1"
 	clock := clockwork.NewFakeClock()
@@ -499,14 +301,6 @@ status:
     kind: TaskRun
     name: task-run-2
     pipelineTaskName: tr2
-  - apiVersion: tekton.dev/v1alpha1
-    kind: Run
-    name: run-1
-    pipelineTaskName: r1
-  - apiVersion: tekton.dev/v1alpha1
-    kind: Run
-    name: run-2
-    pipelineTaskName: r2
 `, pr1Started.Format(time.RFC3339), pr1Started.Add(runDuration).Format(time.RFC3339))),
 		parse.MustParsePipelineRun(t, fmt.Sprintf(`
 metadata:
@@ -588,39 +382,9 @@ status:
 `),
 	}
 
-	runsData := []*v1alpha1.Run{
-		parse.MustParseRun(t, `
-metadata:
-  name: run-1
-  namespace: ns
-spec:
-  ref:
-    name: someCustomTask
-status:
-  conditions:
-  - reason: Succeeded
-    status: "True"
-    type: Succeeded
-`),
-		parse.MustParseRun(t, `
-metadata:
-  name: run-2
-  namespace: ns
-spec:
-  ref:
-    name: someCustomTask
-status:
-  conditions:
-  - reason: Failed
-    status: "False"
-    type: Succeeded
-`),
-	}
-
 	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		PipelineRuns: prdata,
 		TaskRuns:     trData,
-		Runs:         runsData,
 	})
 
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
@@ -656,17 +420,6 @@ status:
 	}
 	test.AssertOutput(t, string(v1beta1.TaskRunReasonFailed), tr2.Status.GetCondition(apis.ConditionSucceeded).Reason)
 
-	r1 := got.Status.Runs[runsData[0].Name]
-	if r1 == nil {
-		t.Fatalf("Run status map does not contain expected Run %s", runsData[0].Name)
-	}
-	test.AssertOutput(t, "Succeeded", r1.Status.GetCondition(apis.ConditionSucceeded).Reason)
-	r2 := got.Status.Runs[runsData[1].Name]
-	if r2 == nil {
-		t.Fatalf("Run status map does not contain expected Run %s", runsData[1].Name)
-	}
-	test.AssertOutput(t, "Failed", r2.Status.GetCondition(apis.ConditionSucceeded).Reason)
-
 	gotFull, err := Get(c, "pipelinerun2", metav1.GetOptions{}, "ns")
 	if err != nil {
 		t.Errorf("unexpected Error")
@@ -674,9 +427,6 @@ status:
 
 	if d := cmp.Diff(got.Status.TaskRuns, gotFull.Status.TaskRuns); d != "" {
 		t.Errorf("mismatch between minimal and full TaskRun statuses: %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(got.Status.Runs, gotFull.Status.Runs); d != "" {
-		t.Errorf("mismatch between minimal and full Run statuses: %s", diff.PrintWantGot(d))
 	}
 }
 
@@ -713,14 +463,6 @@ status:
     kind: TaskRun
     name: task-run-2
     pipelineTaskName: tr2
-  - apiVersion: tekton.dev/v1alpha1
-    kind: Run
-    name: run-1
-    pipelineTaskName: r1
-  - apiVersion: tekton.dev/v1alpha1
-    kind: Run
-    name: run-2
-    pipelineTaskName: r2
 `, pr1Started.Format(time.RFC3339), pr1Started.Add(runDuration).Format(time.RFC3339))),
 	}
 
@@ -753,39 +495,9 @@ status:
 `),
 	}
 
-	runsData := []*v1alpha1.Run{
-		parse.MustParseRun(t, `
-metadata:
-  name: run-1
-  namespace: ns
-spec:
-  ref:
-    name: someCustomTask
-status:
-  conditions:
-  - reason: Succeeded
-    status: "True"
-    type: Succeeded
-`),
-		parse.MustParseRun(t, `
-metadata:
-  name: run-2
-  namespace: ns
-spec:
-  ref:
-    name: someCustomTask
-status:
-  conditions:
-  - reason: Failed
-    status: "False"
-    type: Succeeded
-`),
-	}
-
 	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{
 		PipelineRuns: prdata,
 		TaskRuns:     trData,
-		Runs:         runsData,
 	})
 
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
@@ -822,53 +534,6 @@ status:
 		t.Fatalf("TaskRun status map does not contain expected TaskRun %s", trData[1].Name)
 	}
 	test.AssertOutput(t, string(v1beta1.TaskRunReasonFailed), tr2.Status.GetCondition(apis.ConditionSucceeded).Reason)
-
-	r1 := got.Status.Runs[runsData[0].Name]
-	if r1 == nil {
-		t.Fatalf("Run status map does not contain expected Run %s", runsData[0].Name)
-	}
-	test.AssertOutput(t, "Succeeded", r1.Status.GetCondition(apis.ConditionSucceeded).Reason)
-	r2 := got.Status.Runs[runsData[1].Name]
-	if r2 == nil {
-		t.Fatalf("Run status map does not contain expected Run %s", runsData[1].Name)
-	}
-	test.AssertOutput(t, "Failed", r2.Status.GetCondition(apis.ConditionSucceeded).Reason)
-}
-
-func TestPipelineRunCreate(t *testing.T) {
-	version := "v1alpha1"
-	prdata := v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pipelinerun1",
-			Namespace: "ns",
-			Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
-		},
-		Spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				Name: "pipeline",
-			},
-		},
-	}
-
-	cs, _ := test.SeedTestData(t, pipelinetest.Data{})
-	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipelinerun"})
-	tdc := testDynamic.Options{}
-	dc, err := tdc.Client()
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-
-	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc}
-	c, err := p.Clients()
-	if err != nil {
-		t.Errorf("unable to create client: %v", err)
-	}
-
-	got, err := Create(c, &prdata, metav1.CreateOptions{}, "ns")
-	if err != nil {
-		t.Errorf("unexpected Error")
-	}
-	test.AssertOutput(t, "pipelinerun1", got.Name)
 }
 
 func TestPipelineRunCreate_v1beta1(t *testing.T) {

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -60,6 +60,21 @@ Actual
 `, diff, expected, actual)
 }
 
+func AssertOutputContains(t *testing.T, expected, actual string) {
+	t.Helper()
+	if !strings.Contains(actual, expected) {
+		t.Errorf(`
+Unexpected output:
+
+Expected to contain
+%s
+
+Actual
+%s
+`, expected, actual)
+	}
+}
+
 func AssertOutputPrefix(t *testing.T, expected, actual string) {
 	t.Helper()
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR removes `v1alpha1` support from `Pipeline` and `PipelineRun`. I believe the non-breaking
sequence here is to follow this with `TaskRun`, then `Task`. (Or do them all at once.)

https://github.com/tektoncd/cli/issues/1335

Note: I separately cleaned up lint issues in https://github.com/tektoncd/cli/pull/1679

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Remove `v1alpha1` support from `Pipeline` and `PipelineRun`.
Users should upgrade outstanding `v1alpha1` pipelines to `v1beta1` or `v1`.
```


