### PR TITLE
Clean up all lint issues found by `make check`.

### DIFF
--- a/cmd/docs/generate.go
+++ b/cmd/docs/generate.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -86,7 +85,7 @@ func loadLongDescription(cmd *cobra.Command, path ...string) error {
 			continue
 		}
 
-		content, err := ioutil.ReadFile(fullpath)
+		content, err := os.ReadFile(fullpath)
 		if err != nil {
 			return err
 		}

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/bundle/keychain_test.go
+++ b/pkg/bundle/keychain_test.go
@@ -3,7 +3,6 @@ package bundle
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,7 +17,7 @@ import (
 var testRegistry, _ = name.NewRegistry("test.io", name.WeakValidation)
 
 func setupConfigDir(t *testing.T) string {
-	tmpdir, err := ioutil.TempDir("", "keychain")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "keychain")
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
@@ -40,7 +39,7 @@ func setUpConfigFile(t *testing.T, content string) string {
 		t.Fatalf("unable to mkdir %q: %v", authFileDir, err)
 	}
 
-	if err := ioutil.WriteFile(authFile, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(authFile, []byte(content), 0600); err != nil {
 		t.Fatalf("write %q: %v", authFile, err)
 	}
 	return tmpdir

--- a/pkg/bundle/remote_test.go
+++ b/pkg/bundle/remote_test.go
@@ -3,7 +3,7 @@ package bundle
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -18,7 +18,7 @@ import (
 )
 
 func TestWriteAndRead(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "write-and-read-test")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "write-and-read-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestWriteAndRead(t *testing.T) {
 	}
 
 	reader, _ := layers[0].Uncompressed()
-	remoteContents, err := ioutil.ReadAll(reader)
+	remoteContents, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/bundle/list.go
+++ b/pkg/cmd/bundle/list.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/cmd/bundle/push.go
+++ b/pkg/cmd/bundle/push.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,8 @@ package bundle
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
@@ -92,7 +93,7 @@ func (p *pushOptions) parseArgsAndFlags(args []string) error {
 	for _, path := range p.bundleContentPaths {
 		if path == "-" {
 			// If this flag's value is '-', assume the user has piped input into stdin.
-			stdinContents, err := ioutil.ReadAll(p.stream.In)
+			stdinContents, err := io.ReadAll(p.stream.In)
 			if err != nil || len(stdinContents) == 0 {
 				return fmt.Errorf("failed to read bundle contents from stdin: %w", err)
 			}
@@ -100,7 +101,7 @@ func (p *pushOptions) parseArgsAndFlags(args []string) error {
 			continue
 		}
 
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to find and read file %s: %w", path, err)
 		}

--- a/pkg/cmd/bundle/push_test.go
+++ b/pkg/cmd/bundle/push_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -85,7 +84,7 @@ func TestPushCommand(t *testing.T) {
 
 			ref := fmt.Sprintf("%s/test-img-namespace/%s:1.0", u.Host, tc.name)
 
-			testDir, err := ioutil.TempDir(os.TempDir(), tc.name+"-")
+			testDir, err := os.MkdirTemp(os.TempDir(), tc.name+"-")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -99,7 +98,7 @@ func TestPushCommand(t *testing.T) {
 				}
 
 				filename := path.Join(testDir, name)
-				if err := ioutil.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
+				if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
 					t.Fatalf("failed to write file %s: %s", filename, err)
 				}
 				paths = append(paths, filename)

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -16,7 +16,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -69,9 +69,9 @@ func TestPluginList(t *testing.T) {
 	nd := fs.NewDir(t, "TestPluginList")
 	defer nd.Remove()
 	// nolint: gosec
-	err := ioutil.WriteFile(nd.Join("tkn-exec"), []byte("exec"), 0o700)
+	err := os.WriteFile(nd.Join("tkn-exec"), []byte("exec"), 0o700)
 	assert.NilError(t, err)
-	err = ioutil.WriteFile(nd.Join("tkn-nonexec"), []byte("nonexec"), 0o600)
+	err = os.WriteFile(nd.Join("tkn-nonexec"), []byte("nonexec"), 0o600)
 	assert.NilError(t, err)
 	t.Setenv("PATH", nd.Path()+":/non/existing/path")
 	t.Setenv("TKN_PLUGINS_DIR", "/non/existing/path")

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -17,7 +17,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -221,7 +221,7 @@ func (cli *Client) getRelease(url string) (ghversion GHVersion, err error) {
 		return ghversion, fmt.Errorf("invalid http status %d, error: %s", res.StatusCode, res.Status)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return ghversion, errors.Wrap(err, "failed to read the latest version response body")
 	}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -17,9 +17,9 @@ package file
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -44,7 +44,7 @@ func LoadFileContent(httpClient http.Client, target string, validate TypeValidat
 	if strings.HasPrefix(target, "http") {
 		content, err = getRemoteContent(httpClient, target)
 	} else {
-		content, err = ioutil.ReadFile(target)
+		content, err = os.ReadFile(target)
 	}
 
 	if err != nil {

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -16,8 +16,8 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +29,7 @@ import (
 
 func TestLoadLocalFile(t *testing.T) {
 	localTarget := "./testdata/task.yaml"
-	localContent, err := ioutil.ReadFile(localTarget)
+	localContent, err := os.ReadFile(localTarget)
 	if err != nil {
 		t.Errorf("file path %s does not exist", localTarget)
 	}

--- a/pkg/formatted/color_test.go
+++ b/pkg/formatted/color_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,7 +59,7 @@ func GetAllTknPluginFromPaths() []string {
 	// and add them to the completion command
 	for _, path := range paths {
 		// list all files in path
-		files, err := ioutil.ReadDir(path)
+		files, err := os.ReadDir(path)
 		if err != nil {
 			continue
 		}

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -2,7 +2,7 @@ package plugins
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -13,7 +13,7 @@ func TestFindPlugin(t *testing.T) {
 	nd := fs.NewDir(t, "TestFindPlugins")
 	defer nd.Remove()
 	// nolint: gosec
-	err := ioutil.WriteFile(nd.Join("tkn-test"), []byte("test"), 0o700)
+	err := os.WriteFile(nd.Join("tkn-test"), []byte("test"), 0o700)
 	assert.NilError(t, err)
 	t.Setenv(pluginDirEnv, nd.Path())
 	path, err := FindPlugin("test")
@@ -25,7 +25,7 @@ func TestFindPluginInPath(t *testing.T) {
 	nd := fs.NewDir(t, "TestFindPluginsInPath")
 	defer nd.Remove()
 	// nolint: gosec
-	err := ioutil.WriteFile(nd.Join("tkn-testp"), []byte("testp"), 0o700)
+	err := os.WriteFile(nd.Join("tkn-testp"), []byte("testp"), 0o700)
 	assert.NilError(t, err)
 	t.Setenv("PATH", nd.Path())
 	path, err := FindPlugin("testp")
@@ -37,7 +37,7 @@ func TestGetAllTknPluginFromPathPlugindir(t *testing.T) {
 	nd := fs.NewDir(t, "TestGetAllTknPluginFromPluginPath")
 	defer nd.Remove()
 	// nolint: gosec
-	err := ioutil.WriteFile(nd.Join("tkn-fromplugindir"), []byte("test"), 0o700)
+	err := os.WriteFile(nd.Join("tkn-fromplugindir"), []byte("test"), 0o700)
 	assert.NilError(t, err)
 
 	t.Setenv("PATH", "")
@@ -54,13 +54,13 @@ func TestGetAllTknPluginFromPaths(t *testing.T) {
 	nd := fs.NewDir(t, "TestGetAllTknPluginFromPaths1")
 	defer nd.Remove()
 	// nolint: gosec
-	err := ioutil.WriteFile(nd.Join("tkn-test"), []byte("testp"), 0o700)
+	err := os.WriteFile(nd.Join("tkn-test"), []byte("testp"), 0o700)
 	assert.NilError(t, err)
 
 	nd2 := fs.NewDir(t, "TestGetAllTknPluginFromPaths2")
 	defer nd2.Remove()
 	// nolint: gosec
-	err = ioutil.WriteFile(nd.Join("tkn-test"), []byte("testp"), 0o700)
+	err = os.WriteFile(nd.Join("tkn-test"), []byte("testp"), 0o700)
 	assert.NilError(t, err)
 
 	t.Setenv("PATH", fmt.Sprintf("%s:%s", nd.Path(), nd2.Path()))

--- a/pkg/pods/fake/stream.go
+++ b/pkg/pods/fake/stream.go
@@ -17,7 +17,6 @@ package fake
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/tektoncd/cli/pkg/pods/stream"
@@ -41,7 +40,7 @@ func (ps *PodStream) Stream() (io.ReadCloser, error) {
 		for _, c := range fl.Containers {
 			if c.Name == ps.opts.Container {
 				log := strings.Join(c.Logs, "\n")
-				return ioutil.NopCloser(strings.NewReader(log)), nil
+				return io.NopCloser(strings.NewReader(log)), nil
 			}
 		}
 	}

--- a/test/framework/logs.go
+++ b/test/framework/logs.go
@@ -17,7 +17,7 @@ package framework
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +49,7 @@ func getContainerLogsFromPod(c kubernetes.Interface, pod, namespace string) (str
 		if err != nil {
 			return "", err
 		}
-		bs, err := ioutil.ReadAll(rc)
+		bs, err := io.ReadAll(rc)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR cleans up lint issues found by `make check`; there are no expected functional changes.

Changes are in 2 categories:
- `go fmt` whitespace changes
- `ioutil` --> {`os`, `io`} (depending on the API)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~ **N/A**
- [x] Run the code checkers with `make check`
- [ ] ~Regenerate the manpages, docs and go formatting with `make generated`~ **N/A**
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```