### PR TITLE
Add qps and bursts same like kubectl

### DIFF
--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -93,14 +93,12 @@ func (p *TektonParams) dynamicClient(config *rest.Config) (dynamic.Interface, er
 
 // Only returns kube client, not tekton client
 func (p *TektonParams) KubeClient() (k8s.Interface, error) {
-
 	config, err := p.config()
 	if err != nil {
 		return nil, err
 	}
 
 	kube, err := p.kubeClient(config)
-
 	if err != nil {
 		return nil, err
 	}
@@ -181,6 +179,11 @@ func (p *TektonParams) config() (*rest.Config, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Parsing kubeconfig failed")
 	}
+
+	// set values as done in kubectl
+	config.QPS = 50.0
+	config.Burst = 300
+
 	return config, nil
 }
 


### PR DESCRIPTION
This will add the values of qps and burst the same like kubectl
to have the same response time on commands

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Add qps and bursts same like kubectl
```