### PR TITLE
Make zsh completion usable without generating file

### DIFF
--- a/docs/cmd/tkn_completion.md
+++ b/docs/cmd/tkn_completion.md
@@ -37,12 +37,13 @@ MacOS:
 
 Zsh:
 
-# If shell completion is not already enabled in your environment you will need
-# to enable it.  You can execute the following once:
+$ source <(tkn completion zsh)
+
+# To load completions for every sessions, you can execute the following once:
 
 $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
-# To load completions for each session, execute once:
+# and add the completion to your fpath (may differ from the first one in the fpath array)
 $ tkn completion zsh > "${fpath[1]}/_tkn"
 
 # You will need to start a new shell for this setup to take effect.

--- a/docs/man/man1/tkn-completion.1
+++ b/docs/man/man1/tkn-completion.1
@@ -55,15 +55,16 @@ MacOS:
 .PP
 Zsh:
 
+.PP
+$ source <(tkn completion zsh)
 
-.SH If shell completion is not already enabled in your environment you will need
 
-.SH to enable it.  You can execute the following once:
+.SH To load completions for every sessions, you can execute the following once:
 .PP
 $ echo "autoload \-U compinit; compinit" >> \~/.zshrc
 
 
-.SH To load completions for each session, execute once:
+.SH and add the completion to your fpath (may differ from the first one in the fpath array)
 .PP
 $ tkn completion zsh > "${fpath[1]}/\_tkn"
 

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -15,9 +15,11 @@
 package completion
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tektoncd/cli/pkg/test"
+	"gotest.tools/v3/assert"
 )
 
 func TestCompletion_Empty(t *testing.T) {
@@ -29,4 +31,10 @@ func TestCompletion_Empty(t *testing.T) {
 	}
 	expected := "accepts 1 arg(s), received 0"
 	test.AssertOutput(t, expected, err.Error())
+}
+
+func TestCompletionZSH(t *testing.T) {
+	cmd := Command()
+	output := genZshCompletion(cmd)
+	assert.Assert(t, strings.HasPrefix(output, "#compdef"))
 }


### PR DESCRIPTION
By default we need to have the completion into the function path to be able to make it works.

Let the user be able to use completion straight away without install if they do a `source <(tkn completion zsh)` like we have on `bash`

Make the commad output  to cobra OutOrStdout instead of os.Stdout directly which helps with unittesting.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```