### PR TITLE
fix "send on closed channel"

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -69,18 +69,14 @@ func NewWithDefaults(name, ns string, client k8s.Interface) *Pod {
 	}
 }
 
-// Wait wait for the pod to get up and running
+// Wait waits for the pod to get up and running
 func (p *Pod) Wait() (*corev1.Pod, error) {
-	// ensure pod exists before we actually check for it
 	if _, err := p.Get(); err != nil {
 		return nil, err
 	}
 
 	stopC := make(chan struct{})
 	eventC := make(chan interface{})
-	defer close(eventC)
-	defer close(stopC)
-
 	p.watcher(stopC, eventC)
 
 	var pod *corev1.Pod
@@ -88,10 +84,10 @@ func (p *Pod) Wait() (*corev1.Pod, error) {
 	for e := range eventC {
 		pod, err = checkPodStatus(e)
 		if pod != nil || err != nil {
-			break
+			close(stopC)
+			return pod, err
 		}
 	}
-
 	return pod, err
 }
 
@@ -103,9 +99,32 @@ func (p *Pod) watcher(stopC <-chan struct{}, eventC chan<- interface{}) {
 
 	factory.Core().V1().Pods().Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { eventC <- obj },
-			UpdateFunc: func(oldObj, newObj interface{}) { eventC <- newObj },
-			DeleteFunc: func(obj interface{}) { eventC <- obj },
+			// first check if update still needed.
+			AddFunc: func(obj interface{}) {
+
+				stopCh := stopC
+				select {
+				case <-stopCh:
+					return
+				case eventC <- obj:
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				stopCh := stopC
+				select {
+				case <-stopCh:
+					return
+				case eventC <- newObj:
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				stopCh := stopC
+				select {
+				case <-stopCh:
+					return
+				case eventC <- obj:
+				}
+			},
 		})
 
 	factory.Start(stopC)


### PR DESCRIPTION
fix: https://github.com/tektoncd/cli/issues/1650
this fixes panic on send on closed channel with logs commands in follow mode.
before writing to the event channel we check if we still need to update.
Ones we get some update on the pod we ask the SharedInformer to stop by sending signal to stopC

Only concern is not able to test it with actual panic scenario.

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
