### PR TITLE
Fix bundle push authentication error

### DIFF
--- a/pkg/bundle/flags.go
+++ b/pkg/bundle/flags.go
@@ -20,8 +20,7 @@ type RemoteOptions struct {
 // ToOptions outputs a list of `remoteimg.Option`s that can be passed into various fetch/write calls to a remote
 // registry.
 func (r *RemoteOptions) ToOptions() []remoteimg.Option {
-	keychains := authn.NewMultiKeychain(authn.DefaultKeychain, PodmanKeyChain)
-	opts := []remoteimg.Option{remoteimg.WithAuthFromKeychain(keychains)}
+	var opts []remoteimg.Option
 
 	// Set the auth chain based on the flags.
 	if r.bearerToken != "" {
@@ -32,6 +31,12 @@ func (r *RemoteOptions) ToOptions() []remoteimg.Option {
 			Username: r.basicUsername,
 			Password: r.basicPassword,
 		}))
+	}
+
+	// Use local keychain if no auth is provided. It's not allowed to use both.
+	if len(opts) == 0 {
+		keychains := authn.NewMultiKeychain(authn.DefaultKeychain, PodmanKeyChain)
+		opts = []remoteimg.Option{remoteimg.WithAuthFromKeychain(keychains)}
 	}
 
 	transport := http.DefaultTransport.(*http.Transport)


### PR DESCRIPTION
# Changes

go-containerregistry now raises error when both keychain and auth are set(google/go-containerregistry#1334). With this commit, tkn will ignore keychain when auth is provided with flag.

fixes: #1718

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
