### PR TITLE
Query PipelineResources only if needed

### DIFF
--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -392,7 +392,7 @@ func (opt *startOptions) getInput(pipeline *v1beta1.Pipeline) error {
 		return err
 	}
 
-	if len(opt.Resources) == 0 && !opt.Last && opt.UsePipelineRun == "" {
+	if len(pipeline.Spec.Resources) > 0 && len(opt.Resources) == 0 && !opt.Last && opt.UsePipelineRun == "" {
 		pres, err := getPipelineResources(cs.Resource, opt.cliparams.Namespace())
 		if err != nil {
 			return fmt.Errorf("failed to list PipelineResources from namespace %s: %v", opt.cliparams.Namespace(), err)


### PR DESCRIPTION
Change the `tkn pipeline start` command to only query for PipelineResources in the cluster if the Pipeline uses Resources. As PipelineResources are marked as deprecated, some cluster maintainers may decide to not install this CRD altogether.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
