### PR TITLE
Use tkn root comand to get the name of the tkn cli

### DIFF
--- a/pkg/suggestion/suggest.go
+++ b/pkg/suggestion/suggest.go
@@ -77,7 +77,7 @@ func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error
 	if typedName == "" {
 		return cmd.Help()
 	}
-	return fmt.Errorf("command %s %s doesn't exist. Run tkn help for available commands", cmd.Name(), typedName)
+	return fmt.Errorf("command %s %s doesn't exist. Run %s help for available commands", cmd.Name(), typedName, cmd.Root().Name())
 }
 
 // suggestsByPrefixOrLd suggests a command by levenshtein distance or by prefix.


### PR DESCRIPTION
We are hardcoding the `tkn` name. Let's use the cobra GetName for it.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
