### PR TITLE
fix taskrun getting deleted of running pipelinerun

### DIFF
--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -34,6 +34,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -i, --ignore-running                ignore running TaskRun (default: true) (default true)
+      --ignore-running-pipelinerun    ignore deleting taskruns of a running PipelineRun (default: true) (default true)
       --keep int                      Keep n most recent number of TaskRuns
       --keep-since int                When deleting all TaskRuns keep the ones that has been completed since n minutes
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -44,6 +44,10 @@ Delete TaskRuns in a namespace
     ignore running TaskRun (default: true)
 
 .PP
+\fB\-\-ignore\-running\-pipelinerun\fP[=true]
+    ignore deleting taskruns of a running PipelineRun (default: true)
+
+.PP
 \fB\-\-keep\fP=0
     Keep n most recent number of TaskRuns
 

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -24,17 +24,18 @@ import (
 )
 
 type DeleteOptions struct {
-	Resource           string
-	ParentResource     string
-	ParentResourceName string
-	ForceDelete        bool
-	DeleteRelated      bool
-	DeleteAllNs        bool
-	DeleteAll          bool
-	Keep               int
-	KeepSince          int
-	IgnoreRunning      bool
-	LabelSelector      string
+	Resource                 string
+	ParentResource           string
+	ParentResourceName       string
+	ForceDelete              bool
+	DeleteRelated            bool
+	DeleteAllNs              bool
+	DeleteAll                bool
+	Keep                     int
+	KeepSince                int
+	IgnoreRunning            bool
+	IgnoreRunningPipelinerun bool
+	LabelSelector            string
 }
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns string) error {
@@ -91,16 +92,19 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 		fmt.Fprintf(s.Out, "Are you sure you want to delete %s(s) %s (y/n): ", o.Resource, formattedNames)
 	}
 
+	return o.TakeInput(s, formattedNames)
+}
+
+func (o *DeleteOptions) TakeInput(s *cli.Stream, formattedNames string) error {
 	scanner := bufio.NewScanner(s.In)
 	for scanner.Scan() {
 		t := strings.TrimSpace(scanner.Text())
 		if t == "y" {
-			break
+			return nil
 		} else if t == "n" {
 			return fmt.Errorf("canceled deleting %s(s) %s", o.Resource, formattedNames)
 		}
 		fmt.Fprint(s.Out, "Please enter (y/n): ")
 	}
-
 	return nil
 }


### PR DESCRIPTION
    This ignores all the taskruns attached to pipelinerun which are
    still running.
    
    Behaviour with keep, keep-since, all by default ignores taskruns
    attached to running pipelinerun.
    Behaviour if user gives taskrun name to delete will reassure before
    deleting , if user also specify -f flag then it deletes with a
    warning msg for each taskrun.
    
    this also adds ignore-running-pipelinerun flag.
    This will help user if they want to delete a taskrun in any case
    
    Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
