### PR TITLE
Mark PipelineResource cmds deprecated

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -29,7 +29,6 @@ CLI for tekton pipelines
 * [tkn hub](tkn_hub.md)	 - Interact with tekton hub
 * [tkn pipeline](tkn_pipeline.md)	 - Manage pipelines
 * [tkn pipelinerun](tkn_pipelinerun.md)	 - Manage PipelineRuns
-* [tkn resource](tkn_resource.md)	 - Manage pipeline resources
 * [tkn task](tkn_task.md)	 - Manage Tasks
 * [tkn taskrun](tkn_taskrun.md)	 - Manage TaskRuns
 * [tkn triggerbinding](tkn_triggerbinding.md)	 - Manage TriggerBindings

--- a/docs/man/man1/tkn.1
+++ b/docs/man/man1/tkn.1
@@ -26,4 +26,4 @@ CLI for tekton pipelines
 
 .SH SEE ALSO
 .PP
-\fBtkn\-bundle(1)\fP, \fBtkn\-chain(1)\fP, \fBtkn\-clustertask(1)\fP, \fBtkn\-clustertriggerbinding(1)\fP, \fBtkn\-completion(1)\fP, \fBtkn\-eventlistener(1)\fP, \fBtkn\-hub(1)\fP, \fBtkn\-pipeline(1)\fP, \fBtkn\-pipelinerun(1)\fP, \fBtkn\-resource(1)\fP, \fBtkn\-task(1)\fP, \fBtkn\-taskrun(1)\fP, \fBtkn\-triggerbinding(1)\fP, \fBtkn\-triggertemplate(1)\fP, \fBtkn\-version(1)\fP
+\fBtkn\-bundle(1)\fP, \fBtkn\-chain(1)\fP, \fBtkn\-clustertask(1)\fP, \fBtkn\-clustertriggerbinding(1)\fP, \fBtkn\-completion(1)\fP, \fBtkn\-eventlistener(1)\fP, \fBtkn\-hub(1)\fP, \fBtkn\-pipeline(1)\fP, \fBtkn\-pipelinerun(1)\fP, \fBtkn\-task(1)\fP, \fBtkn\-taskrun(1)\fP, \fBtkn\-triggerbinding(1)\fP, \fBtkn\-triggertemplate(1)\fP, \fBtkn\-version(1)\fP

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -74,6 +74,7 @@ func createCommand(p cli.Params) *cobra.Command {
 		},
 	}
 	f.AddFlags(c)
+	c.Deprecated = "PipelineResource commands are deprecated, they will be removed soon as it get removed from API."
 	return c
 }
 

--- a/pkg/cmd/pipelineresource/delete.go
+++ b/pkg/cmd/pipelineresource/delete.go
@@ -67,6 +67,7 @@ or
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all PipelineResources in a namespace (default: false)")
+	c.Deprecated = "PipelineResource commands are deprecated, they will be removed soon as it get removed from API."
 
 	return c
 }

--- a/pkg/cmd/pipelineresource/delete_test.go
+++ b/pkg/cmd/pipelineresource/delete_test.go
@@ -80,7 +80,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[0],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineResources deleted: \"pre-1\"\n",
+			want:        "Command \"delete\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\nPipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "With force delete flag",
@@ -88,7 +88,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[1],
 			inputStream: nil,
 			wantError:   false,
-			want:        "PipelineResources deleted: \"pre-1\"\n",
+			want:        "Command \"delete\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\nPipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "Without force delete flag, reply no",
@@ -104,7 +104,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[2],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete pipelineresource(s) \"pre-1\" (y/n): PipelineResources deleted: \"pre-1\"\n",
+			want:        "Command \"delete\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\nAre you sure you want to delete pipelineresource(s) \"pre-1\" (y/n): PipelineResources deleted: \"pre-1\"\n",
 		},
 		{
 			name:        "Remove non existent resource",
@@ -128,7 +128,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[3],
 			inputStream: strings.NewReader("y"),
 			wantError:   false,
-			want:        "Are you sure you want to delete all pipelineresources in namespace \"ns\" (y/n): All PipelineResources deleted in namespace \"ns\"\n",
+			want:        "Command \"delete\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\nAre you sure you want to delete all pipelineresources in namespace \"ns\" (y/n): All PipelineResources deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Delete all with -f",
@@ -136,7 +136,7 @@ func TestPipelineResourceDelete(t *testing.T) {
 			input:       seeds[4],
 			inputStream: nil,
 			wantError:   false,
-			want:        "All PipelineResources deleted in namespace \"ns\"\n",
+			want:        "Command \"delete\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\nAll PipelineResources deleted in namespace \"ns\"\n",
 		},
 		{
 			name:        "Error from using pipelineresource name with --all",

--- a/pkg/cmd/pipelineresource/describe.go
+++ b/pkg/cmd/pipelineresource/describe.go
@@ -111,6 +111,8 @@ or
 	}
 
 	f.AddFlags(c)
+	c.Deprecated = "PipelineResource commands are deprecated, they will be removed soon as it get removed from API."
+
 	return c
 }
 

--- a/pkg/cmd/pipelineresource/describe_test.go
+++ b/pkg/cmd/pipelineresource/describe_test.go
@@ -46,7 +46,7 @@ func TestPipelineResourceDescribe_Invalid_Namespace(t *testing.T) {
 		t.Errorf("Error expected here")
 	}
 
-	expected := "Error: failed to find pipelineresource \"bar\"\n"
+	expected := "Command \"describe\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\nError: failed to find pipelineresource \"bar\"\n"
 	test.AssertOutput(t, expected, out)
 }
 
@@ -155,7 +155,7 @@ func TestPipelineResourceDescribe_WithSecretParams(t *testing.T) {
 
 func TestPipelineResourcesDescribe_custom_output(t *testing.T) {
 	name := "pipeline-resource"
-	expected := "pipelineresource.tekton.dev/" + name
+	expected := "Command \"describe\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\npipelineresource.tekton.dev/" + name
 
 	clock := clockwork.NewFakeClock()
 

--- a/pkg/cmd/pipelineresource/list.go
+++ b/pkg/cmd/pipelineresource/list.go
@@ -121,6 +121,7 @@ func listCommand(p cli.Params) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Type, "type", "t", "", "Pipeline resource type")
 	cmd.Flags().BoolVarP(&opts.NoHeaders, "no-headers", "", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
 	cmd.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list pipeline resources from all namespaces")
+	cmd.Deprecated = "PipelineResource commands are deprecated, they will be removed soon as it get removed from API."
 
 	return cmd
 }

--- a/pkg/cmd/pipelineresource/list_test.go
+++ b/pkg/cmd/pipelineresource/list_test.go
@@ -219,7 +219,7 @@ func TestPipelineResourceList_empty(t *testing.T) {
 	pipelineresource := Command(p)
 
 	out, _ := test.ExecuteCommand(pipelineresource, "list", "-n", "test-ns-3")
-	test.AssertOutput(t, msgNoPREsFound+"\n", out)
+	test.AssertOutput(t, "Command \"list\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\n"+msgNoPREsFound+"\n", out)
 }
 
 func TestPipelineResourceList_invalidType(t *testing.T) {

--- a/pkg/cmd/pipelineresource/pipelineresource.go
+++ b/pkg/cmd/pipelineresource/pipelineresource.go
@@ -40,6 +40,7 @@ func Command(p cli.Params) *cobra.Command {
 		describeCommand(p),
 		listCommand(p),
 	)
+	cmd.Deprecated = "PipelineResource commands are deprecated, they will be removed soon as it get removed from API."
 
 	return cmd
 }

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceDescribe_WithParams.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceDescribe_WithParams.golden
@@ -1,3 +1,4 @@
+Command "describe" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 Name:                    test-1
 Namespace:               test-ns-1
 PipelineResource Type:   image

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceDescribe_WithSecretParams.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceDescribe_WithSecretParams.golden
@@ -1,3 +1,4 @@
+Command "describe" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 Name:                    test-1
 Namespace:               test-ns-1
 PipelineResource Type:   image

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-All_Namespaces.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-All_Namespaces.golden
@@ -1,3 +1,4 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 NAMESPACE   NAME     TYPE         DETAILS
 test-ns-1   test-5   cloudEvent   targetURI: http://sink
 test-ns-1   test     git          url: git@github.com:tektoncd/cli-new.git

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-By_template.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-By_template.golden
@@ -1,3 +1,4 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 test-5
 test
 test-2

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Empty_Pipeline_Resource_by_type.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Empty_Pipeline_Resource_by_type.golden
@@ -1,1 +1,2 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 No pipelineresources found.

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Invalid_namespace.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Invalid_namespace.golden
@@ -1,1 +1,2 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 No pipelineresources found.

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Multiple_Pipeline_Resource_by_type.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Multiple_Pipeline_Resource_by_type.golden
@@ -1,3 +1,4 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 NAME     TYPE    DETAILS
 test-1   image   URL: quey.io/tekton/controller
 test-3   image   ---

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Multiple_pipeline_resources.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Multiple_pipeline_resources.golden
@@ -1,3 +1,4 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 NAME     TYPE         DETAILS
 test-5   cloudEvent   targetURI: http://sink
 test     git          url: git@github.com:tektoncd/cli-new.git

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-No_Headers.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-No_Headers.golden
@@ -1,3 +1,4 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 test-5   cloudEvent   targetURI: http://sink
 test     git          url: git@github.com:tektoncd/cli-new.git
 test-2   git          url: git@github.com:tektoncd/cli.git

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Single_Pipeline_Resource_by_type.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Single_Pipeline_Resource_by_type.golden
@@ -1,2 +1,3 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 NAME     TYPE    DETAILS
 test-4   image   URL: quey.io/tekton/webhook

--- a/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Single_pipeline_resource.golden
+++ b/pkg/cmd/pipelineresource/testdata/TestPipelineResourceList-Single_pipeline_resource.golden
@@ -1,2 +1,3 @@
+Command "list" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.
 NAME     TYPE    DETAILS
 test-4   image   URL: quey.io/tekton/webhook


### PR DESCRIPTION
This will mark pipelineresources related commands deprecated as it has been deprecated in pipeline long back and can get removed soon. we will also remove as it will get removed there

Part of #1657

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Mark PipelineResource cmds deprecated
```
