### PR TITLE
Update .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ archives:
     windows: Windows
     386: i386
     amd64: x86_64
+    arm64: aarch64
   format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
setup replacement for arm64 to aarch64 to be in line with replacements for x86 arch

this fixes https://github.com/tektoncd/plumbing/issues/1222 and https://github.com/tektoncd/cli/issues/1738 and https://github.com/tektoncd/pipeline/issues/5568

this is potentially breaking change as build arm binaries will use different url format

/hold