### PR TITLE
Add timestamps flag to show PipelineRun log with timestamps

### DIFF
--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -38,6 +38,7 @@ Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (inc
       --limit int      lists number of PipelineRuns (default 5)
       --prefix         prefix each log line with the log source (task name and step name) (default true)
   -t, --task strings   show logs for mentioned Tasks only
+      --timestamps     show logs with timestamp
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -51,6 +51,10 @@ Show the logs of a PipelineRun
 \fB\-t\fP, \fB\-\-task\fP=[]
     show logs for mentioned Tasks only
 
+.PP
+\fB\-\-timestamps\fP[=false]
+    show logs with timestamp
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/pipelinerun/logs.go
+++ b/pkg/cmd/pipelinerun/logs.go
@@ -80,10 +80,10 @@ Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (inc
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last PipelineRun")
 	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a PipelineRun")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Timestamps, "timestamps", "", false, "show logs with timestamp")
 	c.Flags().BoolVarP(&opts.Prefixing, "prefix", "", true, "prefix each log line with the log source (task name and step name)")
 	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned Tasks only")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of PipelineRuns")
-
 	return c
 }
 

--- a/pkg/log/reader.go
+++ b/pkg/log/reader.go
@@ -32,6 +32,7 @@ type Reader struct {
 	stream          *cli.Stream
 	allSteps        bool
 	follow          bool
+	timestamps      bool
 	tasks           []string
 	steps           []string
 	logType         string
@@ -72,6 +73,7 @@ func NewReader(logType string, opts *options.LogOptions) (*Reader, error) {
 		streamer:        streamer,
 		stream:          opts.Stream,
 		follow:          opts.Follow,
+		timestamps:      opts.Timestamps,
 		allSteps:        opts.AllSteps,
 		tasks:           opts.Tasks,
 		steps:           opts.Steps,

--- a/pkg/options/logs.go
+++ b/pkg/options/logs.go
@@ -49,6 +49,7 @@ type LogOptions struct {
 	AskOpts         survey.AskOpt
 	Fzf             bool
 	Tail            int64
+	Timestamps      bool
 	Prefixing       bool
 	// ActivityTimeout is the amount of time to wait for some activity
 	// (e.g. Pod ready) before giving up.

--- a/pkg/pods/container.go
+++ b/pkg/pods/container.go
@@ -79,17 +79,19 @@ type LogReader struct {
 	containerName string
 	pod           *Pod
 	follow        bool
+	timestamps    bool
 }
 
-func (c *Container) LogReader(follow bool) *LogReader {
-	return &LogReader{c.name, c.pod, follow}
+func (c *Container) LogReader(follow, timestamps bool) *LogReader {
+	return &LogReader{c.name, c.pod, follow, timestamps}
 }
 
 func (lr *LogReader) Read() (<-chan Log, <-chan error, error) {
 	pod := lr.pod
 	opts := &corev1.PodLogOptions{
-		Follow:    lr.follow,
-		Container: lr.containerName,
+		Follow:     lr.follow,
+		Container:  lr.containerName,
+		Timestamps: lr.timestamps,
 	}
 
 	stream, err := pod.Stream(opts)

--- a/pkg/pods/container_test.go
+++ b/pkg/pods/container_test.go
@@ -63,15 +63,16 @@ func TestContainer_fetch_logs(t *testing.T) {
 	pod := New(podName, ns, cs.Kube, fake.Streamer(logs))
 
 	type testdata struct {
-		container string
-		follow    bool
-		expected  []Log
+		container  string
+		follow     bool
+		timestamps bool
+		expected   []Log
 	}
 
 	td := []testdata{
 
 		{
-			container: container1, follow: false,
+			container: container1, follow: false, timestamps: false,
 			expected: []Log{{
 				PodName:       podName,
 				ContainerName: container1,
@@ -80,7 +81,7 @@ func TestContainer_fetch_logs(t *testing.T) {
 		},
 
 		{
-			container: container2, follow: false,
+			container: container2, follow: false, timestamps: false,
 			expected: []Log{{
 				PodName:       podName,
 				ContainerName: container2,
@@ -90,7 +91,7 @@ func TestContainer_fetch_logs(t *testing.T) {
 	}
 
 	for _, d := range td {
-		lr := pod.Container(d.container).LogReader(d.follow)
+		lr := pod.Container(d.container).LogReader(d.follow, d.timestamps)
 		output, err := containerLogs(lr)
 
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Resolves #1749 
Add `timestamps` flag to show PipelineRun log with timestamps.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
  - I don't know how to test this PR in `container_test.go`
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Add timestamps flag to show PipelineRun log with timestamps
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:
-->
