### PR TITLE
Add timestamps flags to all pipeline resources that have logs command

### DIFF
--- a/docs/cmd/tkn_clustertask_logs.md
+++ b/docs/cmd/tkn_clustertask_logs.md
@@ -34,11 +34,12 @@ Show logs for given ClusterTask and associated TaskRun:
 ### Options
 
 ```
-  -a, --all         show all logs including init steps injected by tekton
-  -f, --follow      stream live logs
-  -h, --help        help for logs
-  -L, --last        show logs for last TaskRun
-      --limit int   lists number of TaskRuns (default 5)
+  -a, --all          show all logs including init steps injected by tekton
+  -f, --follow       stream live logs
+  -h, --help         help for logs
+  -L, --last         show logs for last TaskRun
+      --limit int    lists number of TaskRuns (default 5)
+  -t, --timestamps   show logs with timestamp
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_pipeline_logs.md
+++ b/docs/cmd/tkn_pipeline_logs.md
@@ -35,11 +35,12 @@ Show logs for given Pipeline and PipelineRun:
 ### Options
 
 ```
-  -a, --all         show all logs including init steps injected by tekton
-  -f, --follow      stream live logs
-  -h, --help        help for logs
-  -L, --last        show logs for last PipelineRun
-      --limit int   lists number of PipelineRuns (default 5)
+  -a, --all          show all logs including init steps injected by tekton
+  -f, --follow       stream live logs
+  -h, --help         help for logs
+  -L, --last         show logs for last PipelineRun
+      --limit int    lists number of PipelineRuns (default 5)
+  -t, --timestamps   show logs with timestamp
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_task_logs.md
+++ b/docs/cmd/tkn_task_logs.md
@@ -34,11 +34,12 @@ Show logs for given Task and associated TaskRun:
 ### Options
 
 ```
-  -a, --all         show all logs including init steps injected by tekton
-  -f, --follow      stream live logs
-  -h, --help        help for logs
-  -L, --last        show logs for last TaskRun
-      --limit int   lists number of TaskRuns (default 5)
+  -a, --all          show all logs including init steps injected by tekton
+  -f, --follow       stream live logs
+  -h, --help         help for logs
+  -L, --last         show logs for last TaskRun
+      --limit int    lists number of TaskRuns (default 5)
+  -t, --timestamps   show logs with timestamp
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tkn_taskrun_logs.md
+++ b/docs/cmd/tkn_taskrun_logs.md
@@ -39,6 +39,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
       --limit int      lists number of TaskRuns (default 5)
       --prefix         prefix each log line with the log source (step name) (default true)
   -s, --step strings   show logs for mentioned steps only
+  -t, --timestamps     show logs with timestamp
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-clustertask-logs.1
+++ b/docs/man/man1/tkn-clustertask-logs.1
@@ -39,6 +39,10 @@ Show ClusterTask logs
 \fB\-\-limit\fP=5
     lists number of TaskRuns
 
+.PP
+\fB\-t\fP, \fB\-\-timestamps\fP[=false]
+    show logs with timestamp
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/tkn-pipeline-logs.1
+++ b/docs/man/man1/tkn-pipeline-logs.1
@@ -39,6 +39,10 @@ Show Pipeline logs
 \fB\-\-limit\fP=5
     lists number of PipelineRuns
 
+.PP
+\fB\-t\fP, \fB\-\-timestamps\fP[=false]
+    show logs with timestamp
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/tkn-task-logs.1
+++ b/docs/man/man1/tkn-task-logs.1
@@ -39,6 +39,10 @@ Show Task logs
 \fB\-\-limit\fP=5
     lists number of TaskRuns
 
+.PP
+\fB\-t\fP, \fB\-\-timestamps\fP[=false]
+    show logs with timestamp
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/tkn-taskrun-logs.1
+++ b/docs/man/man1/tkn-taskrun-logs.1
@@ -51,6 +51,10 @@ Show TaskRuns logs
 \fB\-s\fP, \fB\-\-step\fP=[]
     show logs for mentioned steps only
 
+.PP
+\fB\-t\fP, \fB\-\-timestamps\fP[=false]
+    show logs with timestamp
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/clustertask/logs.go
+++ b/pkg/cmd/clustertask/logs.go
@@ -92,6 +92,7 @@ Show logs for given ClusterTask and associated TaskRun:
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last TaskRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Timestamps, "timestamps", "t", false, "show logs with timestamp")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of TaskRuns")
 
 	return c

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -92,6 +92,7 @@ Show logs for given Pipeline and PipelineRun:
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last PipelineRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Timestamps, "timestamps", "t", false, "show logs with timestamp")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of PipelineRuns")
 
 	return c

--- a/pkg/cmd/task/logs.go
+++ b/pkg/cmd/task/logs.go
@@ -91,6 +91,7 @@ Show logs for given Task and associated TaskRun:
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last TaskRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Timestamps, "timestamps", "t", false, "show logs with timestamp")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", 5, "lists number of TaskRuns")
 
 	return c

--- a/pkg/cmd/taskrun/logs.go
+++ b/pkg/cmd/taskrun/logs.go
@@ -83,6 +83,7 @@ Show the logs of TaskRun named 'microservice-1' for step 'build' only from names
 	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last TaskRun")
 	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
 	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().BoolVarP(&opts.Timestamps, "timestamps", "t", false, "show logs with timestamp")
 	c.Flags().BoolVarP(&opts.Prefixing, "prefix", "", true, "prefix each log line with the log source (step name)")
 	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of TaskRuns")
 	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a TaskRun")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related PR: https://github.com/tektoncd/cli/pull/1751
Add timestamps flags to all pipeline resources(`clusterTask`, `Task`, `Pipeline`, `TaskRun`) that have logs command.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Add timestamps flags to all pipeline resources that have logs command.
```

