### PR TITLE
Remove kaniko task from release pipeline & Use workspaces instead of PipelineResources in rpmbuild

### DIFF
--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -88,28 +88,6 @@ spec:
       workspaces:
         - name: source
           workspace: shared-workspace
-    - name: publish
-      runAfter: [build, unit-tests]
-      taskRef:
-        name: kaniko-build-and-push
-      params:
-        - name: DOCKERFILE
-          value: contrib/tkn-image/Dockerfile
-        - name: package
-          value: $(params.package)
-        - name: EXTRA_ARGS
-          value:
-            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:latest
-            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:$(tasks.get-versions.results.version)
-            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:v$(tasks.get-versions.results.major)
-            - --destination=gcr.io/tekton-releases/github.com/tektoncd/cli/cmd/tkn:v$(tasks.get-versions.results.major).$(tasks.get-versions.results.minor)
-            - --destination=gcr.io/tekton-releases/tkn:latest
-            - --destination=gcr.io/tekton-releases/tkn:$(tasks.get-versions.results.version)
-            - --destination=gcr.io/tekton-releases/tkn:v$(tasks.get-versions.results.major)
-            - --destination=gcr.io/tekton-releases/tkn:v$(tasks.get-versions.results.major).$(tasks.get-versions.results.minor)
-      workspaces:
-        - name: source
-          workspace: shared-workspace
     - name: release
       runAfter: [build, unit-tests]
       taskRef:

--- a/tekton/rpmbuild/README.md
+++ b/tekton/rpmbuild/README.md
@@ -36,12 +36,24 @@ need to have a PipelineResource for your git repository. See
 * You need to get your API file from https://copr.fedorainfracloud.org/api/ and have it saved to `~/.config/copr`. You will need to change the 
 `username` field to `chmouel` since the copr repo is currently `/chmouel/tektoncd-cli/`.
 
-* Make sure you have the GitHub token set as documented in [RELEASE_PROCESS.md](../../RELEASE_PROCESS.md). You can also just add the `--namespace` option to all `kubectl` commands below and specify the namespace where you ran the release (by default, the namespace used in `release.sh` is `release`).
+* Make sure you have the GitHub token set as documented in [RELEASE_PROCESS.md](../../RELEASE_PROCESS.md). You can also just add the `--namespace` option to all `kubectl` and `tkn` commands below and specify the namespace where you ran the release (by default, the namespace used in `release.sh` is `release`).
 
 * You create the secret from that copr config file:
 
 ```
 kubectl create secret generic copr-cli-config --from-file=copr=${HOME}/.config/copr
+```
+
+* Make sure you already have git-clone Task installed. To verify, run the command:
+
+```
+tkn task list | grep "git-clone"
+```
+
+If the above command doesn't return anything then you can install using:
+
+```
+tkn hub install task git-clone
 ```
 
 * You should be able create the task with:
@@ -56,10 +68,10 @@ And run it with:
 kubectl create -f rpmbuild-run.yml
 ```
 
-* Use `tkn tr desc rpmbuild-taskrun` to make sure the taskrun didn't fail on validation 
+* Use `tkn pr desc rpmbuild-pipelinerun` to make sure the `PipelineRun` didn't fail on validation 
 
-And use the following command to get the logs of the taskrun: 
+And use the following command to get the logs of the `PipelineRun`: 
 
 ```
-tkn tr logs rpmbuild-taskrun -f
+tkn pr logs rpmbuild-pipelinerun -f
 ```

--- a/tekton/rpmbuild/rpmbuild-run.yml
+++ b/tekton/rpmbuild/rpmbuild-run.yml
@@ -1,19 +1,39 @@
----
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: PipelineRun
 metadata:
-  name: rpmbuild-taskrun
+  name: rpmbuild-pipelinerun
 spec:
-  taskRef:
-    kind: Task
-    name: rpmbuild
-  resources:
-    inputs:
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  pipelineSpec:
+    workspaces:
       - name: source
-        resourceSpec:
-          type: git
-          params:
-            - name: revision
-              value: main
-            - name: url
-              value: https://github.com/tektoncd/cli
+        description: Workspace where source code will be cloned
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: url
+            value: https://github.com/tektoncd/cli
+          - name: revision
+            value: main
+          - name: deleteExisting
+            value: "true"
+      - name: rpmbuild
+        taskRef:
+          name: rpmbuild
+        workspaces:
+          - name: source
+            workspace: source
+        runAfter: ["fetch-repository"]

--- a/tekton/rpmbuild/rpmbuild.yml
+++ b/tekton/rpmbuild/rpmbuild.yml
@@ -4,11 +4,9 @@ kind: Task
 metadata:
   name: rpmbuild
 spec:
-  resources:
-    inputs:
-      - name: source
-        type: git
-        targetPath: src
+  workspaces:
+    - name: source
+      description: Volume containing the source code
   steps:
   - name: build-rpm
     env:
@@ -23,5 +21,5 @@ spec:
           name: copr-cli-config
           key: copr
     image: quay.io/chmouel/rpmbuild
-    workingdir: /workspace/src
+    workingDir: $(workspaces.source.path)
     command: ["tekton/rpmbuild/build.sh"]


### PR DESCRIPTION
# Changes

- Since we are not pushing the image of tkn to gcr registry, hence
removing the usage of kaniko task from the pipeline.
- rpmbuild Task & TaskRun were still using PipelineResources which are
    deprecated. Updating both to use workspaces instead.
    
Signed-off-by: vinamra28 <jvinamra776@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```