### PR TITLE
Add few reference notes in debbuild readme

### DIFF
--- a/tekton/debbuild/README.md
+++ b/tekton/debbuild/README.md
@@ -4,14 +4,13 @@
 
 * First you need to join the launchpad team here :
 
-    https://launchpad.net/~tektoncd/+join
+  https://launchpad.net/~tektoncd/+join
 
 * You need to make sure you upload your GPG key to your launchpad profile, ie:
 
-    https://launchpad.net/~chmouel/+editpgpkeys
+  https://launchpad.net/~chmouel/+editpgpkeys
 
-
-    (replace chmouel by your user)
+  (replace chmouel by your user)
 
 * add an environment variable called GPG_KEY with your GPG key user ID
 
@@ -20,3 +19,20 @@
 * It should upload to
   https://launchpad.net/~tektoncd/+archive/ubuntu/cli/+packages you can inspect
   the build logs in there in case of failure.
+
+- **Note**: There can be a case when the uploaded build fails on launchpad with the below error:
+
+  ```
+  + go build -mod=vendor -v -o obj-x86_64-linux-gnu/bin/tkn -ldflags -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=0.25.1 ./cmd/tkn
+  build flag -mod=vendor only valid when using modules
+  make[1]: *** [debian/rules:17: override_dh_auto_build] Error 1
+  make[1]: Leaving directory '/<<PKGBUILDDIR>>'
+  make: *** [debian/rules:14: build] Error 2
+  dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
+  --------------------------------------------------------------------------------
+  ```
+
+  In this case, edit the [rules](./control//rules) file. Try appending `GO111MODULE=on` at Line #20.
+
+- **Note**: If the first build fails, then in order to repush the new build, increment the release
+  version in [buildpackage.sh](./container/buildpackage.sh) at Line #6


### PR DESCRIPTION
# Changes

At the time of doing patch release v0.25.1, the build at launchpad failed with the error

```
+ cat debian/VERSION
+ VERSION=0.25.1
+ go build -mod=vendor -v -o obj-x86_64-linux-gnu/bin/tkn -ldflags -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=0.25.1 ./cmd/tkn
build flag -mod=vendor only valid when using modules
make[1]: *** [debian/rules:17: override_dh_auto_build] Error 1
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:14: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
--------------------------------------------------------------------------------
```

So adding the notes in Readme for future reference.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```