### PR TITLE
[cherry-pick] Cp/fix/tr delete with running pr

### DIFF
--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -34,6 +34,7 @@ or
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
   -i, --ignore-running                ignore running TaskRun (default: true) (default true)
+      --ignore-running-pipelinerun    ignore deleting taskruns of a running PipelineRun (default: true) (default true)
       --keep int                      Keep n most recent number of TaskRuns
       --keep-since int                When deleting all TaskRuns keep the ones that has been completed since n minutes
   -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -44,6 +44,10 @@ Delete TaskRuns in a namespace
     ignore running TaskRun (default: true)
 
 .PP
+\fB\-\-ignore\-running\-pipelinerun\fP[=true]
+    ignore deleting taskruns of a running PipelineRun (default: true)
+
+.PP
 \fB\-\-keep\fP=0
     Keep n most recent number of TaskRuns
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/tektoncd/chains v0.12.1-0.20220901150427-1bf8faaf4475
 	github.com/tektoncd/hub v1.9.0
 	github.com/tektoncd/pipeline v0.38.3
-	github.com/tektoncd/plumbing v0.0.0-20220329085922-d765a5cba75f
+	github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7
 	github.com/tektoncd/triggers v0.20.2
 	go.opencensus.io v0.23.0
 	go.uber.org/atomic v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -2643,8 +2643,9 @@ github.com/tektoncd/pipeline v0.38.2/go.mod h1:9uQZ6PdOZXPtoceupLMyChXUR6elsTuHp
 github.com/tektoncd/pipeline v0.38.3 h1:yMmEW5HRlCDJhepfPzaKhjbhZfAEf9GR34bJMZE5wQY=
 github.com/tektoncd/pipeline v0.38.3/go.mod h1:9uQZ6PdOZXPtoceupLMyChXUR6elsTuHpVNlEGAIJXU=
 github.com/tektoncd/plumbing v0.0.0-20220304154415-13228ac1f4a4/go.mod h1:b9esRuV1absBvaPzKkjYdKXjC5Tgs8/vh1sz++RiTdc=
-github.com/tektoncd/plumbing v0.0.0-20220329085922-d765a5cba75f h1:74OqGOB+R3aobu2j9fxKnsgupS9c7KH1bZaR5LSXICw=
 github.com/tektoncd/plumbing v0.0.0-20220329085922-d765a5cba75f/go.mod h1:b9esRuV1absBvaPzKkjYdKXjC5Tgs8/vh1sz++RiTdc=
+github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7 h1:YsjQ83UBIIq4k/s2PzQ6pqe4tpPtm1hia3oyNBDDrDU=
+github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
 github.com/tektoncd/resolution v0.0.0-20220331203013-e4203c70c5eb h1:bSrsnmoOJJh1JorlaTDSusq/eIBnk5zRKAVXOhnJyD8=
 github.com/tektoncd/resolution v0.0.0-20220331203013-e4203c70c5eb/go.mod h1:u7+LospaKMTW8f1mKHpul2XmGXYSG86kMrbJqUr2w0Q=
 github.com/tektoncd/triggers v0.20.2 h1:ORX3zy/2kKRa3Y7F1FHh5rXe41BAG4QPV2QbJQu2lys=

--- a/pkg/options/delete.go
+++ b/pkg/options/delete.go
@@ -24,17 +24,18 @@ import (
 )
 
 type DeleteOptions struct {
-	Resource           string
-	ParentResource     string
-	ParentResourceName string
-	ForceDelete        bool
-	DeleteRelated      bool
-	DeleteAllNs        bool
-	DeleteAll          bool
-	Keep               int
-	KeepSince          int
-	IgnoreRunning      bool
-	LabelSelector      string
+	Resource                 string
+	ParentResource           string
+	ParentResourceName       string
+	ForceDelete              bool
+	DeleteRelated            bool
+	DeleteAllNs              bool
+	DeleteAll                bool
+	Keep                     int
+	KeepSince                int
+	IgnoreRunning            bool
+	IgnoreRunningPipelinerun bool
+	LabelSelector            string
 }
 
 func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns string) error {
@@ -91,16 +92,19 @@ func (o *DeleteOptions) CheckOptions(s *cli.Stream, resourceNames []string, ns s
 		fmt.Fprintf(s.Out, "Are you sure you want to delete %s(s) %s (y/n): ", o.Resource, formattedNames)
 	}
 
+	return o.TakeInput(s, formattedNames)
+}
+
+func (o *DeleteOptions) TakeInput(s *cli.Stream, formattedNames string) error {
 	scanner := bufio.NewScanner(s.In)
 	for scanner.Scan() {
 		t := strings.TrimSpace(scanner.Text())
 		if t == "y" {
-			break
+			return nil
 		} else if t == "n" {
 			return fmt.Errorf("canceled deleting %s(s) %s", o.Resource, formattedNames)
 		}
 		fmt.Fprint(s.Out, "Please enter (y/n): ")
 	}
-
 	return nil
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -143,6 +143,7 @@ function install_pipeline_crd() {
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
     [[ -n ${latestreleaseyaml} ]] || latestreleaseyaml=https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
   fi
+  latestreleaseyaml="https://github.com/tektoncd/pipeline/releases/download/v0.38.3/release.yaml"
   [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
   kubectl apply -f ${latestreleaseyaml} ||
     fail_test "Build pipeline installation failed"
@@ -170,6 +171,7 @@ function install_triggers_crd() {
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
     [[ -z ${latestreleaseyaml} ]] && latestreleaseyaml="https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml"
   fi
+  latestreleaseyaml="https://github.com/tektoncd/triggers/releases/download/v0.20.2/release.yaml"
   if [[ -n ${RELEASE_YAML_TRIGGERS_INTERCEPTORS} ]];then
 	latestinterceptorsyaml=${RELEASE_YAML_TRIGGERS_INTERCEPTORS}
   else
@@ -180,6 +182,7 @@ function install_triggers_crd() {
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
     [[ -z ${latestinterceptorsyaml} ]] && latestinterceptorsyaml="https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml"
   fi
+  latestinterceptorsyaml="https://github.com/tektoncd/triggers/releases/download/v0.20.2/interceptors.yaml"
   [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
   [[ -z ${latestinterceptorsyaml} ]] && fail_test "Could not get latest released interceptors.yaml"
   kubectl apply -f ${latestreleaseyaml} ||

--- a/vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
@@ -258,7 +258,7 @@ function create_test_cluster_with_retries() {
       # Exit if test succeeded
       [[ "$(get_test_return_code)" == "0" ]] && return
       # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources to fulfill the request' ${cluster_creation_log})" ]] && return
+      [[ -z "$(grep -Eio 'does not have enough resources available' ${cluster_creation_log})" ]] && return
     done
   done
 }

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -20,7 +20,7 @@
 
 # Default GKE version to be used with Tekton Serving
 readonly SERVING_GKE_VERSION=gke-channel-regular
-readonly SERVING_GKE_IMAGE=cos
+readonly SERVING_GKE_IMAGE=cos_containerd
 
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1401,7 +1401,7 @@ github.com/tektoncd/pipeline/pkg/substitution
 github.com/tektoncd/pipeline/test
 github.com/tektoncd/pipeline/test/diff
 github.com/tektoncd/pipeline/test/parse
-# github.com/tektoncd/plumbing v0.0.0-20220329085922-d765a5cba75f
+# github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7
 ## explicit; go 1.13
 github.com/tektoncd/plumbing/scripts
 # github.com/tektoncd/resolution v0.0.0-20220331203013-e4203c70c5eb


### PR DESCRIPTION
With this fix tkn ignores to delete all the taskrun(s) attached to pipelinerun which are
still running(without a completion time).

Behaviour with keep, keep-since, all by default ignores taskruns attached to running
pipelinerun.
Behaviour if user gives taskrun name to delete will reassure before deleting, if user
also specify -f flag then it deletes with a warning message for each taskrun.

This also adds ignore-running-pipelinerun flag will helps user to delete a taskrun
attached to a running pipelienrun.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
