### PR TITLE
Add support to pass CSI workspace

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -39,6 +39,13 @@ For passing the workspaces via flags:
    resources:
      requests:
        storage: 1Gi
+- In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
+  but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+  
+  driver: secrets-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault-database"
 
 
 ### Options

--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -33,6 +33,17 @@ To create a workspace-template.yaml
       			storage: 1Gi
 	EOF
 
+To create a csi-template.yaml
+
+	```sh
+	$ cat <<EOF > csi-template.yaml
+	driver: secrets-store.csi.k8s.io
+	readOnly: true
+	volumeAttributes:
+  		secretProviderClass: "vault-database"
+	EOF
+	```
+
 To run a Pipeline that has one git resource, one image resource,
 two parameters (foo and bar) and four workspaces (my-config, my-pvc,
 my-secret, my-empty-dir and my-volume-claim-template)
@@ -47,6 +58,7 @@ my-secret, my-empty-dir and my-volume-claim-template)
 		--workspace name=my-empty-dir,emptyDir="" \
 		--workspace name=my-pvc,claimName=pvc1,subPath=dir
 		--workspace name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+		--workspace name=my-csi-template,csiFile=csi-template.yaml
 
 ### Options
 

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -38,6 +38,13 @@ For passing the workspaces via flags:
    resources:
      requests:
        storage: 1Gi
+- In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
+  but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+  
+  driver: secrets-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault-database"
 
 
 ### Options

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -157,8 +157,19 @@ requests:
 storage: 1Gi
 
 .RE
+.IP \(bu 2
+In case of binding a CSI workspace, you can pass it like \-w name=my\-csi,csiFile=csi.yaml
+but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+
+.br
 
 .RE
+
+.PP
+driver: secrets\-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault\-database"
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -159,6 +159,25 @@ EOF
 .RE
 
 .PP
+To create a csi\-template.yaml
+
+.PP
+.RS
+
+.nf
+```sh
+$ cat <<EOF > csi\-template.yaml
+driver: secrets\-store.csi.k8s.io
+readOnly: true
+volumeAttributes:
+    secretProviderClass: "vault\-database"
+EOF
+```
+
+.fi
+.RE
+
+.PP
 To run a Pipeline that has one git resource, one image resource,
 two parameters (foo and bar) and four workspaces (my\-config, my\-pvc,
 my\-secret, my\-empty\-dir and my\-volume\-claim\-template)
@@ -176,6 +195,7 @@ $ tkn pipeline start \-\-resource source=samples\-git \\
     \-\-workspace name=my\-empty\-dir,emptyDir="" \\
     \-\-workspace name=my\-pvc,claimName=pvc1,subPath=dir
     \-\-workspace name=my\-volume\-claim\-template,volumeClaimTemplateFile=workspace\-template.yaml
+    \-\-workspace name=my\-csi\-template,csiFile=csi\-template.yaml
 
 .fi
 .RE

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -157,8 +157,19 @@ requests:
 storage: 1Gi
 
 .RE
+.IP \(bu 2
+In case of binding a CSI workspace, you can pass it like \-w name=my\-csi,csiFile=csi.yaml
+but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+
+.br
 
 .RE
+
+.PP
+driver: secrets\-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault\-database"
 
 
 .SH SEE ALSO

--- a/docs/reference/cmd/pipeline_start.md
+++ b/docs/reference/cmd/pipeline_start.md
@@ -25,6 +25,17 @@ To create a workspace-template.yaml
       			storage: 1Gi
 	EOF
 
+To create a csi-template.yaml
+
+	```sh
+	$ cat <<EOF > csi-template.yaml
+	driver: secrets-store.csi.k8s.io
+	readOnly: true
+	volumeAttributes:
+  		secretProviderClass: "vault-database"
+	EOF
+	```
+
 To run a Pipeline that has one git resource, one image resource,
 two parameters (foo and bar) and four workspaces (my-config, my-pvc,
 my-secret, my-empty-dir and my-volume-claim-template)
@@ -39,3 +50,4 @@ my-secret, my-empty-dir and my-volume-claim-template)
 		--workspace name=my-empty-dir,emptyDir="" \
 		--workspace name=my-pvc,claimName=pvc1,subPath=dir
 		--workspace name=my-volume-claim-template,volumeClaimTemplateFile=workspace-template.yaml
+		--workspace name=my-csi-template,csiFile=csi-template.yaml

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -140,6 +140,13 @@ For passing the workspaces via flags:
    resources:
      requests:
        storage: 1Gi
+- In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
+  but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+  
+  driver: secrets-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault-database"
 `
 
 	c := &cobra.Command{

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -135,6 +135,13 @@ For passing the workspaces via flags:
    resources:
      requests:
        storage: 1Gi
+- In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
+  but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+  
+  driver: secrets-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault-database"
 `,
 		SilenceUsage: true,
 

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -148,6 +148,13 @@ For passing the workspaces via flags:
    resources:
      requests:
        storage: 1Gi
+- In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
+  but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
+  
+  driver: secrets-store.csi.k8s.io
+  readOnly: true
+  volumeAttributes:
+    secretProviderClass: "vault-database"
 `,
 		SilenceUsage:      true,
 		ValidArgsFunction: formatted.ParentCompletion,

--- a/pkg/formatted/workspace.go
+++ b/pkg/formatted/workspace.go
@@ -41,6 +41,9 @@ func Workspace(ws v1beta1.WorkspaceBinding) string {
 		secret := getWorkspaceSecret(ws.Secret)
 		return fmt.Sprintf("Secret (%s)", secret)
 	}
+	if ws.CSI != nil {
+		return fmt.Sprintf("CSI (Driver=%s)", ws.CSI.Driver)
+	}
 	return ""
 }
 

--- a/pkg/formatted/workspace_test.go
+++ b/pkg/formatted/workspace_test.go
@@ -47,6 +47,12 @@ func TestWorkspace(t *testing.T) {
 				SecretName: "foobar",
 			},
 		},
+		{
+			Name: "csi",
+			CSI: &corev1.CSIVolumeSource{
+				Driver: "secrets-store.csi.k8s.io",
+			},
+		},
 	}
 	defaultEmptyWorkspaceStr := Workspace(workspaceSpec[0]) // EmptyDir workspace with default storage medium
 	assert.Equal(t, defaultEmptyWorkspaceStr, "EmptyDir (emptyDir=)")
@@ -59,4 +65,7 @@ func TestWorkspace(t *testing.T) {
 
 	secretWorkspaceStr := Workspace(workspaceSpec[3]) // Secret Workspace
 	assert.Equal(t, secretWorkspaceStr, "Secret (secret=foobar)")
+
+	csiWorkspaceStr := Workspace(workspaceSpec[4]) // CSI Workspace
+	assert.Equal(t, csiWorkspaceStr, "CSI (Driver=secrets-store.csi.k8s.io)")
 }

--- a/pkg/workspaces/testdata/csi-typo.yaml
+++ b/pkg/workspaces/testdata/csi-typo.yaml
@@ -1,0 +1,4 @@
+drive: secrets-store.csi.k8s.io
+readOnly: true
+volumeAttributes:
+  secretProviderClass: "vault-database"

--- a/pkg/workspaces/testdata/csi.yaml
+++ b/pkg/workspaces/testdata/csi.yaml
@@ -1,0 +1,4 @@
+driver: secrets-store.csi.k8s.io
+readOnly: true
+volumeAttributes:
+  secretProviderClass: "vault-database"


### PR DESCRIPTION
# Changes

Since Pipelines version v0.38.0, an user can pass CSI Volume
as a workspace. A sample CSI file can look like
```yaml
driver: secrets-store.csi.k8s.io
readOnly: true
volumeAttributes:
  secretProviderClass: "vault-database"
```
This requires feature flag to be alpha. Once feature flag is enabled
user can pass in `tkn` start like

```sh
$ tkn pipeline start foobar -w=csiFile=csi.yaml
```

closes #1668 

Signed-off-by: vinamra28 <jvinamra776@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
Add support to pass CSI as workspace at the time of starting a Task/ClusterTask/Pipeline
```