### PR TITLE
Remove k8s client validity check from pkg/flags

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -103,11 +103,6 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 	}
 	p.SetKubeContext(kubeContext)
 
-	// ensure that the config is valid by creating a client
-	if _, err := p.Clients(); err != nil {
-		return err
-	}
-
 	ns, err := cmd.Flags().GetString(namespace)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Changes

With the addition of `cli/pkg/cli/prerun` to `pkg/cmd/bundle` in #1575 the validity of the Kubernetes REST client is checked via invocation of `pkg/flags.InitParams` where it fails with:

```
Error: Couldn't get kubeConfiguration namespace: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

A valid Kuberenets configuration should not be supplied for `tkn bundle` commands, so this removes verifying that the Kuberenets configuration is valid from `pkg/flags.InitParams`. Seems that the same check for validity is preformed whenever invocation of `pkg/cli.Params.Clients` is used regardless, so having a check in the `InitParams` needlessly enforces the requirement of valid Kubernetes configuration.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
tkn bundle commands no longer require valid Kubernetes client parameters
```