### PR TITLE
Fix e2e test broken

### DIFF
--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -93,7 +93,7 @@ func TestClusterTaskInteractiveStartE2E(t *testing.T) {
 	t.Run("Start ClusterTask with flags", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "clustertask", "start", clusterTaskName,
 			"-i=source="+tePipelineGitResourceName,
-			"-p=FILEPATH=docs",
+			"-p=FILEPATH=docs-v2",
 			"-p=FILENAME=README.md",
 			"-w=name=shared-workspace,emptyDir=",
 			"--showlog")
@@ -123,11 +123,11 @@ Waiting for logs to be available...
 				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
 					return err
 				}
-				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs`)"); err != nil {
+				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs-v2`)"); err != nil {
 					return err
 				}
 
-				if _, err := c.ExpectString("(docs)"); err != nil {
+				if _, err := c.ExpectString("(docs-v2)"); err != nil {
 					return err
 				}
 				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
@@ -172,7 +172,7 @@ Waiting for logs to be available...
 			CmdArgs: []string{
 				"clustertask", "start", clusterTaskName,
 				"-i=source=" + tePipelineGitResourceName,
-				"--param=FILEPATH=docs",
+				"--param=FILEPATH=docs-v2",
 				"-w=name=shared-workspace,emptyDir=",
 				"--showlog",
 			},
@@ -246,7 +246,7 @@ Waiting for logs to be available...
 
 		tkn.MustSucceed(t, "clustertask", "start", clusterTaskName,
 			"-i=source="+tePipelineGitResourceName,
-			"-p=FILEPATH=docs",
+			"-p=FILEPATH=docs-v2",
 			"-p=FILENAME=README.md",
 			"-w=name=shared-workspace,emptyDir=",
 			"--showlog",

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -164,7 +164,7 @@ func TestPipelinesE2E(t *testing.T) {
 	t.Run("Start PipelineRun using pipeline start command with SA as 'pipeline' ", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineGitResourceName,
-			"-p=FILEPATH=docs",
+			"-p=FILEPATH=docs-v2",
 			"-p=FILENAME=README.md",
 			"--showlog")
 
@@ -477,7 +477,7 @@ func TestPipelinesNegativeE2E(t *testing.T) {
 	t.Run("Start Pipeline Run using pipeline start command with SA as 'pipelines' ", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "pipeline", "start", tePipelineName,
 			"-r=source-repo="+tePipelineFaultGitResourceName,
-			"-p=FILEPATH=docs",
+			"-p=FILEPATH=docs-v2",
 			"-p=FILENAME=README.md",
 			"--showlog",
 			"true")
@@ -664,7 +664,7 @@ func getCreateFileTask(taskname string, namespace string) *v1beta1.Task {
 					Name:    "read-docs-old",
 					Image:   "ubuntu",
 					Command: []string{"/bin/bash"},
-					Args:    []string{"-c", "ls -la /workspace/damnworkspace/docs/README.md"},
+					Args:    []string{"-c", "ls -la /workspace/damnworkspace/docs-v2/README.md"},
 				},
 				{
 					Name:    "write-new-stuff",

--- a/test/e2e/pipeline/start_test.go
+++ b/test/e2e/pipeline/start_test.go
@@ -61,11 +61,11 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs`)"); err != nil {
+				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs-v2`)"); err != nil {
 					return err
 				}
 
-				if _, err := c.ExpectString("(docs)"); err != nil {
+				if _, err := c.ExpectString("(docs-v2)"); err != nil {
 					return err
 				}
 
@@ -132,7 +132,7 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 		tkn.RunInteractiveTests(t, &cli.Prompt{
 			CmdArgs: []string{
 				"pipeline", "start", "output-pipeline",
-				"-p=FILEPATH=docs", "--use-param-defaults",
+				"-p=FILEPATH=docs-v2", "--use-param-defaults",
 			},
 			Procedure: func(c *expect.Console) error {
 				if _, err := c.ExpectString("Choose the git resource to use for source-repo:"); err != nil {
@@ -266,11 +266,11 @@ func TestPipelineInteractiveStartWithNewResourceE2E(t *testing.T) {
 					return err
 				}
 
-				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs`)"); err != nil {
+				if _, err := c.ExpectString("Value for param `FILEPATH` of type `string`? (Default is `docs-v2`)"); err != nil {
 					return err
 				}
 
-				if _, err := c.ExpectString("(docs)"); err != nil {
+				if _, err := c.ExpectString("(docs-v2)"); err != nil {
 					return err
 				}
 

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -73,7 +73,7 @@ func TestTaskStartE2E(t *testing.T) {
 	t.Run("Start TaskRun using tkn start command with SA as 'pipeline' ", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "task", "start", "read-task",
 			"-i=source="+tePipelineGitResourceName,
-			"-p=FILEPATH=docs",
+			"-p=FILEPATH=docs-v2",
 			"-p=FILENAME=README.md",
 			"--showlog")
 
@@ -175,7 +175,7 @@ Waiting for logs to be available...
 			CmdArgs: []string{
 				"task", "start", "read-task",
 				"-i=source=" + tePipelineGitResourceName,
-				"-p=FILEPATH=docs",
+				"-p=FILEPATH=docs-v2",
 				"--showlog",
 			},
 			Procedure: func(c *expect.Console) error {
@@ -255,7 +255,7 @@ Waiting for logs to be available...
 	t.Run("Start TaskRun with --pod-template", func(t *testing.T) {
 		tkn.MustSucceed(t, "task", "start", "read-task",
 			"-i=source="+tePipelineGitResourceName,
-			"-p=FILEPATH=docs",
+			"-p=FILEPATH=docs-v2",
 			"-p=FILENAME=README.md",
 			"--showlog",
 			"--pod-template="+helper.GetResourcePath("/podtemplate/podtemplate.yaml"))

--- a/test/resources/output-pipelinerun.yaml
+++ b/test/resources/output-pipelinerun.yaml
@@ -44,7 +44,7 @@ spec:
   - name: read-docs-old
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['-c', 'ls -la /workspace/damnworkspace/docs/README.md']  # tests that targetpath works
+    args: ['-c', 'ls -la /workspace/damnworkspace/README.md']  # tests that targetpath works
   - name: write-new-stuff
     image: ubuntu
     command: ['bash']

--- a/test/resources/pipeline.yaml
+++ b/test/resources/pipeline.yaml
@@ -70,7 +70,7 @@ spec:
     type: git
   params:
     - name: FILEPATH
-      default: "docs"
+      default: "docs-v2"
     - name: FILENAME
   tasks:
   - name: first-create-file          # 1. create file

--- a/test/resources/read-file-clustertask.yaml
+++ b/test/resources/read-file-clustertask.yaml
@@ -21,7 +21,7 @@ spec:
     - name: shared-workspace
   params:
     - name: FILEPATH
-      default: "docs"
+      default: "docs-v2"
     - name: FILENAME
   resources:
     inputs:

--- a/test/resources/read-file.yaml
+++ b/test/resources/read-file.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: FILEPATH
-    default: "docs"
+    default: "docs-v2"
   - name: FILENAME
   resources:
     inputs:


### PR DESCRIPTION
This will fix the issue of the e2e test broken
because a pipelinerun test is failing

It is failing because the repository getting
cloned has changed the path of the file accessing.
This will update the path to a different file

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix e2e test broken
```