### PR TITLE
Fix pipeline version to v0.42.0 in e2e

### DIFF
--- a/pkg/pipelinerun/tracker.go
+++ b/pkg/pipelinerun/tracker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions"
+	"github.com/tektoncd/pipeline/pkg/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -83,7 +84,7 @@ func (t *Tracker) Monitor(allowed []string) <-chan []trh.Run {
 			return
 		}
 
-		trMap, runMap, err := getFullPipelineTaskStatuses(context.Background(), t.Tekton, t.Ns, pr)
+		trMap, runMap, err := status.GetFullPipelineTaskStatuses(context.Background(), t.Tekton, t.Ns, pr)
 		if err != nil {
 			return
 		}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -143,6 +143,8 @@ function install_pipeline_crd() {
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
     [[ -n ${latestreleaseyaml} ]] || latestreleaseyaml=https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
   fi
+  # TODO: to remove this pinning of pipeline version after v1 support of Pipeline CRDs in cli, as this is done to make CI green till then
+  latestreleaseyaml="https://github.com/tektoncd/pipeline/releases/download/v0.42.0/release.yaml"
   [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
   kubectl apply -f ${latestreleaseyaml} ||
     fail_test "Build pipeline installation failed"

--- a/vendor/github.com/tektoncd/pipeline/pkg/status/status.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/status/status.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetTaskRunStatusForPipelineTask takes a minimal embedded status child reference and returns the actual TaskRunStatus
+// for the PipelineTask. It returns an error if the child reference's kind isn't TaskRun.
+func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Interface, ns string, childRef v1beta1.ChildStatusReference) (*v1beta1.TaskRunStatus, error) {
+	if childRef.Kind != "TaskRun" {
+		return nil, fmt.Errorf("could not fetch status for PipelineTask %s: should have kind TaskRun, but is %s", childRef.PipelineTaskName, childRef.Kind)
+	}
+
+	tr, err := client.TektonV1beta1().TaskRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if tr == nil {
+		return nil, nil
+	}
+
+	return &tr.Status, nil
+}
+
+// GetRunStatusForPipelineTask takes a minimal embedded status child reference and returns the actual RunStatus for the
+// PipelineTask. It returns an error if the child reference's kind isn't Run.
+func GetRunStatusForPipelineTask(ctx context.Context, client versioned.Interface, ns string, childRef v1beta1.ChildStatusReference) (*v1alpha1.RunStatus, error) {
+	if childRef.Kind != "Run" {
+		return nil, fmt.Errorf("could not fetch status for PipelineTask %s: should have kind Run, but is %s", childRef.PipelineTaskName, childRef.Kind)
+	}
+
+	r, err := client.TektonV1alpha1().Runs(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if r == nil {
+		return nil, nil
+	}
+
+	return &r.Status, nil
+}
+
+// GetFullPipelineTaskStatuses returns populated TaskRun and Run status maps for a PipelineRun from its ChildReferences.
+// If the PipelineRun has no ChildReferences, its .Status.TaskRuns and .Status.Runs will be returned instead.
+func GetFullPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns string, pr *v1beta1.PipelineRun) (map[string]*v1beta1.PipelineRunTaskRunStatus,
+	map[string]*v1beta1.PipelineRunRunStatus, error) {
+	// If the PipelineRun is nil, just return
+	if pr == nil {
+		return nil, nil, nil
+	}
+
+	// If there are no child references or either TaskRuns or Runs is non-zero, return the existing TaskRuns and Runs maps
+	if len(pr.Status.ChildReferences) == 0 || len(pr.Status.TaskRuns) > 0 || len(pr.Status.Runs) > 0 {
+		return pr.Status.TaskRuns, pr.Status.Runs, nil
+	}
+
+	trStatuses := make(map[string]*v1beta1.PipelineRunTaskRunStatus)
+	runStatuses := make(map[string]*v1beta1.PipelineRunRunStatus)
+
+	for _, cr := range pr.Status.ChildReferences {
+		switch cr.Kind {
+		case "TaskRun":
+			tr, err := client.TektonV1beta1().TaskRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return nil, nil, err
+			}
+
+			trStatuses[cr.Name] = &v1beta1.PipelineRunTaskRunStatus{
+				PipelineTaskName: cr.PipelineTaskName,
+				WhenExpressions:  cr.WhenExpressions,
+			}
+
+			if tr != nil {
+				trStatuses[cr.Name].Status = &tr.Status
+			}
+		case "Run":
+			r, err := client.TektonV1alpha1().Runs(ns).Get(ctx, cr.Name, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return nil, nil, err
+			}
+
+			runStatuses[cr.Name] = &v1beta1.PipelineRunRunStatus{
+				PipelineTaskName: cr.PipelineTaskName,
+				WhenExpressions:  cr.WhenExpressions,
+			}
+
+			if r != nil {
+				runStatuses[cr.Name].Status = &r.Status
+			}
+		default:
+			// Don't do anything for unknown types.
+		}
+	}
+
+	return trStatuses, runStatuses, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1499,6 +1499,7 @@ github.com/tektoncd/pipeline/pkg/remote
 github.com/tektoncd/pipeline/pkg/remote/oci
 github.com/tektoncd/pipeline/pkg/resolution/common
 github.com/tektoncd/pipeline/pkg/resolution/resource
+github.com/tektoncd/pipeline/pkg/status
 github.com/tektoncd/pipeline/pkg/substitution
 github.com/tektoncd/pipeline/test
 github.com/tektoncd/pipeline/test/diff


### PR DESCRIPTION
This will fix pipeline version to v0.42.0 in e2e
as 0.43.0 version have v1 support and it makes e2e fails

Fixing version in e2e till we add support for pipeline v1 CRDs

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix pipeline version to v0.42.0 in e2e
```
