### PR TITLE
fix trusted resources docs error

### DIFF
--- a/docs/cmd/tkn_pipeline_sign.md
+++ b/docs/cmd/tkn_pipeline_sign.md
@@ -23,7 +23,7 @@ tkn pipeline sign
 Sign a Pipeline pipeline.yaml:
 	tkn pipeline sign pipeline.yaml -K=cosign.key -f=signed.yaml
 or using kms
-	tkn pipeline sign pipeline.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml
+	tkn pipeline sign pipeline.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml
 
 ### Options
 

--- a/docs/cmd/tkn_pipeline_verify.md
+++ b/docs/cmd/tkn_pipeline_verify.md
@@ -23,7 +23,7 @@ tkn pipeline verify
 Verify a Pipeline signed.yaml:
 	tkn pipeline verify signed.yaml -K=cosign.pub
 or using kms
-	tkn pipeline verify signed.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
+	tkn pipeline verify signed.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
 
 ### Options
 

--- a/docs/cmd/tkn_task_sign.md
+++ b/docs/cmd/tkn_task_sign.md
@@ -23,7 +23,7 @@ tkn task sign
 Sign a Task task.yaml:
 	tkn task sign task.yaml -K=cosign.key -f=signed.yaml
 or using kms
-	tkn task sign task.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml
+	tkn task sign task.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml
 
 ### Options
 

--- a/docs/cmd/tkn_task_verify.md
+++ b/docs/cmd/tkn_task_verify.md
@@ -23,7 +23,7 @@ tkn task verify
 Verify a Task signed.yaml:
 	tkn Task verify signed.yaml -K=cosign.pub
 or using kms
-	tkn Task verify signed.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
+	tkn Task verify signed.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
 
 ### Options
 

--- a/docs/man/man1/tkn-pipeline-sign.1
+++ b/docs/man/man1/tkn-pipeline-sign.1
@@ -87,7 +87,7 @@ For KMS:
 Sign a Pipeline pipeline.yaml:
     tkn pipeline sign pipeline.yaml \-K=cosign.key \-f=signed.yaml
 or using kms
-    tkn pipeline sign pipeline.yaml \-K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION \-f=signed.yaml
+    tkn pipeline sign pipeline.yaml \-m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION \-f=signed.yaml
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-pipeline-verify.1
+++ b/docs/man/man1/tkn-pipeline-verify.1
@@ -83,7 +83,7 @@ For KMS:
 Verify a Pipeline signed.yaml:
     tkn pipeline verify signed.yaml \-K=cosign.pub
 or using kms
-    tkn pipeline verify signed.yaml \-K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
+    tkn pipeline verify signed.yaml \-m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-sign.1
+++ b/docs/man/man1/tkn-task-sign.1
@@ -87,7 +87,7 @@ For KMS:
 Sign a Task task.yaml:
     tkn task sign task.yaml \-K=cosign.key \-f=signed.yaml
 or using kms
-    tkn task sign task.yaml \-K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION \-f=signed.yaml
+    tkn task sign task.yaml \-m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION \-f=signed.yaml
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-task-verify.1
+++ b/docs/man/man1/tkn-task-verify.1
@@ -83,7 +83,7 @@ For KMS:
 Verify a Task signed.yaml:
     tkn Task verify signed.yaml \-K=cosign.pub
 or using kms
-    tkn Task verify signed.yaml \-K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
+    tkn Task verify signed.yaml \-m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION
 
 
 .SH SEE ALSO

--- a/pkg/cmd/pipeline/sign.go
+++ b/pkg/cmd/pipeline/sign.go
@@ -39,7 +39,7 @@ func signCommand(p cli.Params) *cobra.Command {
 	eg := `Sign a Pipeline pipeline.yaml:
 	tkn pipeline sign pipeline.yaml -K=cosign.key -f=signed.yaml
 or using kms
-	tkn pipeline sign pipeline.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml`
+	tkn pipeline sign pipeline.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml`
 	long := `
 	Sign the Tekton Pipeline with user provided private key file or KMS reference. Key files support ecdsa, ed25519, rsa.
 	For KMS:

--- a/pkg/cmd/pipeline/verify.go
+++ b/pkg/cmd/pipeline/verify.go
@@ -38,7 +38,7 @@ func verifyCommand(p cli.Params) *cobra.Command {
 	eg := `Verify a Pipeline signed.yaml:
 	tkn pipeline verify signed.yaml -K=cosign.pub
 or using kms
-	tkn pipeline verify signed.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION`
+	tkn pipeline verify signed.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION`
 	long := `
 	Verify the Tekton Pipeline with user provided private key file or KMS reference. Key files support ecdsa, ed25519, rsa.
 	For KMS:

--- a/pkg/cmd/task/sign.go
+++ b/pkg/cmd/task/sign.go
@@ -44,7 +44,7 @@ func signCommand(p cli.Params) *cobra.Command {
 	eg := `Sign a Task task.yaml:
 	tkn task sign task.yaml -K=cosign.key -f=signed.yaml
 or using kms
-	tkn task sign task.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml`
+	tkn task sign task.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION -f=signed.yaml`
 	long := `
 	Sign the Tekton Task with user provided private key file or KMS reference. Key files support ecdsa, ed25519, rsa.
 	For KMS:

--- a/pkg/cmd/task/verify.go
+++ b/pkg/cmd/task/verify.go
@@ -38,7 +38,7 @@ func verifyCommand(p cli.Params) *cobra.Command {
 	eg := `Verify a Task signed.yaml:
 	tkn Task verify signed.yaml -K=cosign.pub
 or using kms
-	tkn Task verify signed.yaml -K=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION`
+	tkn Task verify signed.yaml -m=gcpkms://projects/PROJECTID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY/cryptoKeyVersions/VERSION`
 	long := `
 	Verify the Tekton Task with user provided private key file or KMS reference. Key files support ecdsa, ed25519, rsa.
 	For KMS:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the error in trusted resources docs. The example of using kms key uses wrong flag and should be corrected.

/kind docs

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
