### PR TITLE
Use version from object for create

### DIFF
--- a/pkg/actions/create.go
+++ b/pkg/actions/create.go
@@ -25,7 +25,7 @@ import (
 
 // Create is used to take a partial resource and an unstructured object and create it in the cluster using the dynamic client.
 func Create(gr schema.GroupVersionResource, clients *cli.Clients, object *unstructured.Unstructured, ns string, op metav1.CreateOptions) (*unstructured.Unstructured, error) {
-	gvr, err := GetGroupVersionResource(gr, clients.Tekton.Discovery())
+	gvr, err := getGVRWithObject(object, gr)
 	if err != nil {
 		return nil, err
 	}
@@ -34,4 +34,12 @@ func Create(gr schema.GroupVersionResource, clients *cli.Clients, object *unstru
 		return nil, err
 	}
 	return obj, nil
+}
+
+func getGVRWithObject(object *unstructured.Unstructured, gr schema.GroupVersionResource) (*schema.GroupVersionResource, error) {
+	gv, err := schema.ParseGroupVersion(object.GetAPIVersion())
+	if err == nil {
+		gr.Version = gv.Version
+	}
+	return &gr, nil
 }

--- a/pkg/actions/create_test.go
+++ b/pkg/actions/create_test.go
@@ -1,0 +1,89 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/test/diff"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var tektonGroup = "tekton.dev"
+
+func Test_getGVRWithObject(t *testing.T) {
+	type args struct {
+		object *unstructured.Unstructured
+		gvr    schema.GroupVersionResource
+	}
+	tests := []struct {
+		name string
+		args args
+		want *schema.GroupVersionResource
+	}{
+		{
+			name: "v1 task",
+			args: args{
+				object: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "tekton.dev/v1",
+					},
+				},
+				gvr: schema.GroupVersionResource{
+					Group:    tektonGroup,
+					Resource: "tasks",
+				},
+			},
+			want: &schema.GroupVersionResource{
+				Group:    tektonGroup,
+				Resource: "tasks",
+				Version:  "v1",
+			},
+		},
+		{
+			name: "v1beta1 task",
+			args: args{
+				object: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "tekton.dev/v1beta1",
+					},
+				},
+				gvr: schema.GroupVersionResource{
+					Group:    tektonGroup,
+					Resource: "tasks",
+				},
+			},
+			want: &schema.GroupVersionResource{
+				Group:    tektonGroup,
+				Resource: "tasks",
+				Version:  "v1beta1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getGVRWithObject(tt.args.object, tt.args.gvr)
+			if err != nil {
+				t.Errorf("getGVRWithObject() got error: %v", err)
+				return
+			}
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/clustertask/clustertask_test.go
+++ b/pkg/clustertask/clustertask_test.go
@@ -251,6 +251,10 @@ func TestClusterTask_Create(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	ctdata := []*v1beta1.ClusterTask{
 		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "clustertask",
+				APIVersion: version,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "clustertask",
 			},

--- a/pkg/pipelinerun/pipelinerun_test.go
+++ b/pkg/pipelinerun/pipelinerun_test.go
@@ -641,6 +641,10 @@ status:
 func TestPipelineRunCreate(t *testing.T) {
 	version := "v1beta1"
 	prdata := v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PipelineRun",
+			APIVersion: version,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pipelinerun1",
 			Namespace: "ns",

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -266,6 +266,10 @@ func TestTask_Create(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	tdata := []*v1beta1.Task{
 		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Task",
+				APIVersion: version,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "task",
 				Namespace: "ns",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit fixes #1837. After tekton pipeline introduced v1, `clients.Tekton.Discovery()` will return v1 and this is not the same with current cli start command for v1beta1 task and pipeline. Similar like https://github.com/tektoncd/hub/pull/746, we should get the version from the object as the source of truth.

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
