### PR TITLE
Fix for taskrun list command not working

### DIFF
--- a/pkg/cmd/bundle/bundle.go
+++ b/pkg/cmd/bundle/bundle.go
@@ -35,6 +35,7 @@ func Command(p cli.Params) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType":  "main",
 			"experimental": "",
+			"kubernetes":   "false",
 		},
 		PersistentPreRunE: prerun.PersistentPreRunE(p),
 	}

--- a/pkg/cmd/bundle/list.go
+++ b/pkg/cmd/bundle/list.go
@@ -77,6 +77,7 @@ Caching:
 		Long:  longHelp,
 		Annotations: map[string]string{
 			"commandType": "main",
+			"kubernetes":  "false",
 		},
 		Args: cobra.RangeArgs(1, 3),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/bundle/push.go
+++ b/pkg/cmd/bundle/push.go
@@ -58,6 +58,7 @@ Input:
 		Long:  longHelp,
 		Annotations: map[string]string{
 			"commandType": "main",
+			"kubernetes":  "false",
 		},
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -175,14 +175,14 @@ func list(p cli.Params, task string, limit int, labelselector string, allnamespa
 		}
 	}
 
-	ns := p.Namespace()
-	if allnamespaces {
-		ns = ""
-	}
-
 	cs, err := p.Clients()
 	if err != nil {
 		return nil, err
+	}
+
+	ns := p.Namespace()
+	if allnamespaces {
+		ns = ""
 	}
 
 	trs, err := trlist.TaskRuns(cs, options, ns)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -103,6 +103,16 @@ func InitParams(p cli.Params, cmd *cobra.Command) error {
 	}
 	p.SetKubeContext(kubeContext)
 
+	// ensure that the config is valid by creating a client but skip for bundle cmd
+	// as bundle cmd does not need k8s client and config
+	// if this annotation is available on cmd and value is false then client
+	// will not be initialized
+	if cmd.Annotations["kubernetes"] != "false" {
+		if _, err := p.Clients(); err != nil {
+			return err
+		}
+	}
+
 	ns, err := cmd.Flags().GetString(namespace)
 	if err != nil {
 		return err


### PR DESCRIPTION
This will fix the issue for taskrun list command
not working and throwing error regarding cluster-scope
as the client is not getting initialized before and namespace
is empty if not passed specifically.

The client initialization happening in every cmd init was removed
because it was getting initialized in all cmds but not required in
cmd like bundle and hence bundle cmd failing with kube config error
which was not required.

This reverts that and add exception for bundle cmds based on
annotation available on cmd. Now all cmd will have client initialization
and cmd with annotation kubernetes=false will be exempted.

Fix https://github.com/tektoncd/cli/issues/1874

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix for taskrun list command not working
```