### PR TITLE
reflect state of started pipeline/task when using --showlog

### DIFF
--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -425,7 +425,23 @@ func startTask(opt startOptions, args []string) error {
 		Params:      opt.cliparams,
 		AllSteps:    false,
 	}
-	return taskrun.Run(runLogOpts)
+
+	if err := taskrun.Run(runLogOpts); err != nil {
+		return err
+	}
+
+	// fetch the taskrun again to get the latest status
+	trLatest, err := traction.GetTaskRun(taskrunGroupResource, cs, trCreated.Name, trCreated.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// check if the created taskrun succeed or not
+	if !trLatest.IsSuccessful() {
+		return fmt.Errorf("taskRun %s did not succeed", trCreated.Name)
+	}
+
+	return nil
 }
 
 func printTaskRun(output string, s *cli.Stream, tr interface{}) error {


### PR DESCRIPTION
Signed-off-by: Avinal Kumar <avinal@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- this change fixes an issue where using --showlog with tkn start pipeline/task does not return a non-zero value when  created taskrun/pipelinerun fails.
- fixes #1820

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
using --showlog flag with tkn pipeline/task start now returns correct value based on final state of started pipelinerun/taskrun
``` 
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
