### PR TITLE
Fixes List command for task and pipeline

### DIFF
--- a/pkg/cmd/pipeline/list.go
+++ b/pkg/cmd/pipeline/list.go
@@ -87,8 +87,13 @@ func listCommand(p cli.Params) *cobra.Command {
 				return fmt.Errorf("output option not set properly: %v", err)
 			}
 
+			ns := p.Namespace()
+			if opts.AllNamespaces {
+				ns = ""
+			}
+
 			if output != "" {
-				return actions.PrintObjects(pipelineGroupResource, cmd.OutOrStdout(), cs.Dynamic, cs.Tekton.Discovery(), f, p.Namespace())
+				return actions.PrintObjects(pipelineGroupResource, cmd.OutOrStdout(), cs.Dynamic, cs.Tekton.Discovery(), f, ns)
 			}
 			stream := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/pipeline/testdata/TestPipelineList_in_all_namespaces_with_output_yaml_flag.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineList_in_all_namespaces_with_output_yaml_flag.golden
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+items:
+- apiVersion: tekton.dev/v1
+  kind: pipeline
+  metadata:
+    creationTimestamp: "1984-03-13T16:00:00Z"
+    name: bananes
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: pipeline
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:40Z"
+    name: mangues
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: pipeline
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:00Z"
+    name: tomates
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: pipeline
+  metadata:
+    creationTimestamp: "1984-03-13T16:00:00Z"
+    name: bananas
+    namespace: namespace
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: pipeline
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:40Z"
+    name: mangoes
+    namespace: namespace
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: pipeline
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:00Z"
+    name: tomatoes
+    namespace: namespace
+  spec: {}
+kind: PipelineList
+metadata:
+  resourceVersion: ""

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -75,8 +75,13 @@ func listCommand(p cli.Params) *cobra.Command {
 				return fmt.Errorf("error: output option not set properly: %v", err)
 			}
 
+			ns := p.Namespace()
+			if opts.AllNamespaces {
+				ns = ""
+			}
+
 			if output != "" {
-				return actions.PrintObjects(taskGroupResource, cmd.OutOrStdout(), cs.Dynamic, cs.Tekton.Discovery(), f, p.Namespace())
+				return actions.PrintObjects(taskGroupResource, cmd.OutOrStdout(), cs.Dynamic, cs.Tekton.Discovery(), f, ns)
 			}
 			stream := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/task/testdata/TestTaskList_in_all_namespaces_with_output_yaml_flag.golden
+++ b/pkg/cmd/task/testdata/TestTaskList_in_all_namespaces_with_output_yaml_flag.golden
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1
+items:
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-03-13T16:00:00Z"
+    name: bananes
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:40Z"
+    name: mangues
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-03-13T13:00:00Z"
+    name: oignons
+    namespace: espace-de-nom
+  spec:
+    description: a test task to test description of task
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-03-13T15:00:00Z"
+    name: pommes
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:00Z"
+    name: tomates
+    namespace: espace-de-nom
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-03-13T16:00:00Z"
+    name: bananas
+    namespace: namespace
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:40Z"
+    name: mangoes
+    namespace: namespace
+  spec: {}
+- apiVersion: tekton.dev/v1
+  kind: task
+  metadata:
+    creationTimestamp: "1984-04-03T23:59:00Z"
+    name: tomatoes
+    namespace: namespace
+  spec: {}
+kind: TaskList
+metadata:
+  resourceVersion: ""


### PR DESCRIPTION
This patch fixes list command with flags --all-namespaces and --output=yaml for task and pipeline

closes: #1888

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
