### PR TITLE
remove kubernetes requirements for sign and verify

### DIFF
--- a/pkg/cmd/pipeline/sign.go
+++ b/pkg/cmd/pipeline/sign.go
@@ -53,6 +53,7 @@ or using kms
 		Long:  long,
 		Annotations: map[string]string{
 			"commandType":  "main",
+			"kubernetes":   "false",
 			"experimental": "",
 		},
 		Args:    cobra.ExactArgs(1),

--- a/pkg/cmd/pipeline/verify.go
+++ b/pkg/cmd/pipeline/verify.go
@@ -52,6 +52,7 @@ or using kms
 		Long:  long,
 		Annotations: map[string]string{
 			"commandType":  "main",
+			"kubernetes":   "false",
 			"experimental": "",
 		},
 		Args:    cobra.ExactArgs(1),

--- a/pkg/cmd/task/sign.go
+++ b/pkg/cmd/task/sign.go
@@ -58,6 +58,7 @@ or using kms
 		Long:  long,
 		Annotations: map[string]string{
 			"commandType":  "main",
+			"kubernetes":   "false",
 			"experimental": "",
 		},
 		Args:    cobra.ExactArgs(1),

--- a/pkg/cmd/task/verify.go
+++ b/pkg/cmd/task/verify.go
@@ -52,6 +52,7 @@ or using kms
 		Long:  long,
 		Annotations: map[string]string{
 			"commandType":  "main",
+			"kubernetes":   "false",
 			"experimental": "",
 		},
 		Args:    cobra.ExactArgs(1),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commits fixes https://github.com/tektoncd/cli/issues/1904. This commits adds kubernetes annotation and
set it to false for  sign and verify commands to avoid the requirements of a
kubernetes.  Previously the PersistentPreRunE in
task and pipeline commands will check the kube config.

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
sign and verify don't require the kube config file
```
-->

```release-note
sign and verify don't require the kube config file
```
