### PR TITLE
add PersistentPreRunE for sign and verify to avoid calling InitParams

### DIFF
--- a/pkg/cmd/pipeline/sign.go
+++ b/pkg/cmd/pipeline/sign.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -58,6 +59,9 @@ or using kms
 		},
 		Args:    cobra.ExactArgs(1),
 		Example: eg,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return prerun.WarnExperimental(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/pipeline/verify.go
+++ b/pkg/cmd/pipeline/verify.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -57,6 +58,9 @@ or using kms
 		},
 		Args:    cobra.ExactArgs(1),
 		Example: eg,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return prerun.WarnExperimental(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/task/sign.go
+++ b/pkg/cmd/task/sign.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -63,6 +64,9 @@ or using kms
 		},
 		Args:    cobra.ExactArgs(1),
 		Example: eg,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return prerun.WarnExperimental(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
 				Out: cmd.OutOrStdout(),

--- a/pkg/cmd/task/verify.go
+++ b/pkg/cmd/task/verify.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -57,6 +58,9 @@ or using kms
 		},
 		Args:    cobra.ExactArgs(1),
 		Example: eg,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return prerun.WarnExperimental(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &cli.Stream{
 				Out: cmd.OutOrStdout(),


### PR DESCRIPTION
This commits adds PersistentPreRunE for sign and verify to avoid calling InitParams. Because when signing and verifying resources we don't need to check the kubeconfig.

closes #1904  
/kind bug


Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
