### PR TITLE
Move pipeline describe to v1 CRDs 

### DIFF
--- a/pkg/actions/get.go
+++ b/pkg/actions/get.go
@@ -18,15 +18,18 @@ import (
 	"context"
 	"io"
 
+	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/printer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 )
 
+// TODO: remove as all the function uses are moved to new func
 // PrintObject is used to take a partial resource and the name of an object in the cluster, fetch it using the dynamic client, and print out the object.
 func PrintObject(groupResource schema.GroupVersionResource, obj string, w io.Writer, dynamic dynamic.Interface, discovery discovery.DiscoveryInterface, f *cliopts.PrintFlags, ns string) error {
 	res, err := Get(groupResource, dynamic, discovery, obj, ns, metav1.GetOptions{})
@@ -37,6 +40,44 @@ func PrintObject(groupResource schema.GroupVersionResource, obj string, w io.Wri
 	return printer.PrintObject(w, res, f)
 }
 
+// PrintObject is used to take a partial resource and the name of an object in the cluster, fetch it using the dynamic client, and print out the object.
+func PrintObjectV1(groupResource schema.GroupVersionResource, obj string, w io.Writer, client *cli.Clients, f *cliopts.PrintFlags, ns string) error {
+	res, err := get(groupResource, client, obj, ns, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	return printer.PrintObject(w, res, f)
+}
+
+// GetV1 is used to take a partial resource and the name of an object in the cluster and fetch it from the cluster using the dynamic client.
+func GetV1(gr schema.GroupVersionResource, c *cli.Clients, objname, ns string, op metav1.GetOptions, obj interface{}) error {
+	unstructuredObj, err := get(gr, c, objname, ns, op)
+	if err != nil {
+		return err
+	}
+
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func get(gr schema.GroupVersionResource, c *cli.Clients, objname, ns string, op metav1.GetOptions) (*unstructured.Unstructured, error) {
+	gvr, err := GetGroupVersionResource(gr, c.Tekton.Discovery())
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredObj, err := c.Dynamic.Resource(*gvr).Namespace(ns).Get(context.Background(), objname, op)
+	if err != nil {
+		return nil, err
+	}
+	return unstructuredObj, nil
+}
+
+// TODO: remove as all the function uses are moved to new func
 // Get is used to take a partial resource and the name of an object in the cluster and fetch it from the cluster using the dynamic client.
 func Get(gr schema.GroupVersionResource, dynamic dynamic.Interface, discovery discovery.DiscoveryInterface, objname, ns string, op metav1.GetOptions) (*unstructured.Unstructured, error) {
 	gvr, err := GetGroupVersionResource(gr, discovery)

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tektoncd/cli/pkg/deleter"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/options"
-	"github.com/tektoncd/cli/pkg/pipeline"
+	pipelinepkg "github.com/tektoncd/cli/pkg/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/multierr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +42,8 @@ func pipelineExists(args []string, p cli.Params) ([]string, error) {
 	var errorList error
 	ns := p.Namespace()
 	for _, name := range args {
-		_, err := pipeline.Get(c, name, metav1.GetOptions{}, ns)
+		var pipeline *v1.Pipeline
+		err := actions.GetV1(pipelineGroupResource, c, name, ns, metav1.GetOptions{}, &pipeline)
 		if err != nil {
 			errorList = multierr.Append(errorList, err)
 			continue
@@ -117,7 +118,7 @@ func deletePipelines(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, p
 	})
 	switch {
 	case opts.DeleteAllNs:
-		pNames, err = pipeline.GetAllPipelineNames(pipelineGroupResource, cs, p.Namespace())
+		pNames, err = pipelinepkg.GetAllPipelineNames(pipelineGroupResource, cs, p.Namespace())
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pipeline/describe.go
+++ b/pkg/cmd/pipeline/describe.go
@@ -15,19 +15,20 @@
 package pipeline
 
 import (
+	"context"
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 	"text/tabwriter"
 	"text/template"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	"github.com/tektoncd/cli/pkg/options"
-	"github.com/tektoncd/cli/pkg/pipeline"
+	pipelinepkg "github.com/tektoncd/cli/pkg/pipeline"
 	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -36,7 +37,7 @@ import (
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
+const DescribeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{decorate "bold" "Namespace"}}:	{{ .Pipeline.Namespace }}
 {{- if ne .Pipeline.Spec.Description "" }}
 {{decorate "bold" "Description"}}:	{{ .Pipeline.Spec.Description }}
@@ -46,15 +47,6 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{decorate "bold" "Annotations"}}:
 {{- range $k, $v := $annotations }}
  {{ $k }}={{ $v }}
-{{- end }}
-{{- end }}
-
-{{- if ne (len .Pipeline.Spec.Resources) 0 }}
-
-{{decorate "resources" ""}}{{decorate "underline bold" "Resources\n"}}
- NAME	TYPE
-{{- range $i, $r := .Pipeline.Spec.Resources }}
- {{decorate "bullet" $r.Name }}	{{ $r.Type }}
 {{- end }}
 {{- end }}
 
@@ -68,8 +60,10 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{- else }}
 {{- if eq $p.Type "string" }}
  {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ formatDesc $p.Description }}	{{ $p.Default.StringVal }}
-{{- else }}
+{{- else if eq $p.Type "array" }}
  {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ formatDesc $p.Description }}	{{ $p.Default.ArrayVal }}
+{{- else }}
+ {{decorate "bullet" $p.Name }}	{{ $p.Type }}	{{ formatDesc $p.Description }}	{{ $p.Default.ObjectVal }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -107,7 +101,7 @@ const describeTemplate = `{{decorate "bold" "Name"}}:	{{ .PipelineName }}
 {{decorate "pipelineruns" ""}}{{decorate "underline bold" "PipelineRuns\n"}}
  NAME	STARTED	DURATION	STATUS
 {{- range $i, $pr := .PipelineRuns.Items }}
- {{decorate "bullet" $pr.Name }}	{{ formatAge $pr.Status.StartTime $.Params.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
+ {{decorate "bullet" $pr.Name }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
 {{- end }}
 {{- end }}
 `
@@ -137,7 +131,7 @@ func describeCommand(p cli.Params) *cobra.Command {
 			}
 
 			if len(args) == 0 {
-				pipelineNames, err := pipeline.GetAllPipelineNames(pipelineGroupResource, cs, p.Namespace())
+				pipelineNames, err := pipelinepkg.GetAllPipelineNames(pipelineGroupResource, cs, p.Namespace())
 				if err != nil {
 					return err
 				}
@@ -154,11 +148,10 @@ func describeCommand(p cli.Params) *cobra.Command {
 			}
 
 			if output != "" {
-				pipelineGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "pipelines"}
-				return actions.PrintObject(pipelineGroupResource, opts.PipelineName, cmd.OutOrStdout(), cs.Dynamic, cs.Tekton.Discovery(), f, p.Namespace())
+				return actions.PrintObjectV1(pipelineGroupResource, opts.PipelineName, cmd.OutOrStdout(), cs, f, p.Namespace())
 			}
 
-			return printPipelineDescription(cmd.OutOrStdout(), p, opts.PipelineName)
+			return printPipelineDescription(cmd.OutOrStdout(), cs, p.Namespace(), opts.PipelineName, p.Time())
 		},
 	}
 
@@ -166,42 +159,33 @@ func describeCommand(p cli.Params) *cobra.Command {
 	return c
 }
 
-func printPipelineDescription(out io.Writer, p cli.Params, pname string) error {
-	cs, err := p.Clients()
+func printPipelineDescription(out io.Writer, c *cli.Clients, ns string, pName string, time clockwork.Clock) error {
+	pipeline, err := getPipeline(pipelineGroupResource, c, pName, ns)
 	if err != nil {
 		return err
-	}
-
-	pipeline, err := pipeline.Get(cs, pname, metav1.GetOptions{}, p.Namespace())
-	if err != nil {
-		return err
-	}
-
-	if len(pipeline.Spec.Resources) > 0 {
-		pipeline.Spec.Resources = sortResourcesByTypeAndName(pipeline.Spec.Resources)
 	}
 
 	opts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pname),
+		LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pName),
 	}
 
 	var pipelineRuns *v1.PipelineRunList
-	err = actions.ListV1(pipelineRunGroupResource, cs, opts, p.Namespace(), &pipelineRuns)
+	err = actions.ListV1(pipelineRunGroupResource, c, opts, ns, &pipelineRuns)
 	if err != nil {
 		return err
 	}
 	prsort.SortByStartTime(pipelineRuns.Items)
 
 	var data = struct {
-		Pipeline     *v1beta1.Pipeline
+		Pipeline     *v1.Pipeline
 		PipelineRuns *v1.PipelineRunList
 		PipelineName string
-		Params       cli.Params
+		Time         clockwork.Clock
 	}{
 		Pipeline:     pipeline,
 		PipelineRuns: pipelineRuns,
-		PipelineName: pname,
-		Params:       p,
+		PipelineName: pName,
+		Time:         time,
 	}
 
 	funcMap := template.FuncMap{
@@ -218,7 +202,7 @@ func printPipelineDescription(out io.Writer, p cli.Params, pname string) error {
 	}
 
 	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)
-	t := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(describeTemplate))
+	t := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(DescribeTemplate))
 	err = t.Execute(w, data)
 	if err != nil {
 		return err
@@ -227,25 +211,7 @@ func printPipelineDescription(out io.Writer, p cli.Params, pname string) error {
 	return w.Flush()
 }
 
-// this will sort the Resource by Type and then by Name
-func sortResourcesByTypeAndName(pres []v1beta1.PipelineDeclaredResource) []v1beta1.PipelineDeclaredResource {
-	sort.Slice(pres, func(i, j int) bool {
-		if pres[j].Type < pres[i].Type {
-			return false
-		}
-
-		if pres[j].Type > pres[i].Type {
-			return true
-		}
-
-		return pres[j].Name > pres[i].Name
-	})
-
-	return pres
-}
-
 func askPipelineName(opts *options.DescribeOptions, pipelineNames []string) error {
-
 	if len(pipelineNames) == 0 {
 		return fmt.Errorf("no Pipelines found")
 	}
@@ -256,4 +222,32 @@ func askPipelineName(opts *options.DescribeOptions, pipelineNames []string) erro
 	}
 
 	return nil
+}
+
+func getPipeline(gr schema.GroupVersionResource, c *cli.Clients, pName, ns string) (*v1.Pipeline, error) {
+	var pipeline v1.Pipeline
+	gvr, err := actions.GetGroupVersionResource(gr, c.Tekton.Discovery())
+	if err != nil {
+		return nil, err
+	}
+
+	if gvr.Version == "v1" {
+		err := actions.GetV1(pipelineGroupResource, c, pName, ns, metav1.GetOptions{}, &pipeline)
+		if err != nil {
+			return nil, err
+		}
+		return &pipeline, nil
+
+	}
+
+	var pipelineV1beta1 v1beta1.Pipeline
+	err = actions.GetV1(pipelineGroupResource, c, pName, ns, metav1.GetOptions{}, &pipelineV1beta1)
+	if err != nil {
+		return nil, err
+	}
+	err = pipelineV1beta1.ConvertTo(context.Background(), &pipeline)
+	if err != nil {
+		return nil, err
+	}
+	return &pipeline, nil
 }

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	"gotest.tools/v3/golden"
@@ -33,8 +34,8 @@ import (
 )
 
 func TestPipelineDescribe_invalid_namespace(t *testing.T) {
-	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{})
-	cs.Pipeline.Resources = cb.APIResourceList("v1beta1", []string{"pipeline"})
+	cs, _ := test.SeedTestData(t, test.Data{})
+	cs.Pipeline.Resources = cb.APIResourceList("v1", []string{"pipeline"})
 	tdc := testDynamic.Options{}
 	dc, _ := tdc.Client()
 	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dc}
@@ -56,8 +57,8 @@ func TestPipelineDescribe_invalid_pipeline(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{Namespaces: ns})
-	cs.Pipeline.Resources = cb.APIResourceList("v1beta1", []string{"pipeline"})
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: ns})
+	cs.Pipeline.Resources = cb.APIResourceList("v1", []string{"pipeline"})
 	tdc := testDynamic.Options{}
 	dynamic, err := tdc.Client()
 	if err != nil {
@@ -77,7 +78,7 @@ func TestPipelineDescribe_invalid_pipeline(t *testing.T) {
 func TestPipelineDescribe_empty(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	pipelines := []*v1beta1.Pipeline{
+	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipeline",
@@ -87,7 +88,7 @@ func TestPipelineDescribe_empty(t *testing.T) {
 			},
 		},
 	}
-	pipelineRuns := []*v1beta1.PipelineRun{}
+	pipelineRuns := []*v1.PipelineRun{}
 	namespaces := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -96,15 +97,15 @@ func TestPipelineDescribe_empty(t *testing.T) {
 		},
 	}
 
-	version := "v1beta1"
+	version := "v1"
 	tdc := testDynamic.Options{}
 	dynamic, err := tdc.Client(
-		cb.UnstructuredV1beta1P(pipelines[0], version),
+		cb.UnstructuredP(pipelines[0], version),
 	)
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
-	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
 	pipeline := Command(p)
@@ -116,7 +117,7 @@ func TestPipelineDescribe_empty(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_run(t *testing.T) {
+func TestPipelineDescribe_with_run_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	pipelines := []*v1beta1.Pipeline{
@@ -195,7 +196,7 @@ func TestPipelineDescribe_with_run(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_spec_run(t *testing.T) {
+func TestPipelineDescribe_with_spec_run_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	pipelines := []*v1beta1.Pipeline{
@@ -292,7 +293,7 @@ func TestPipelineDescribe_with_spec_run(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_spec_resource_param_run(t *testing.T) {
+func TestPipelineDescribe_with_spec_resource_param_run_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -405,7 +406,7 @@ func TestPipelineDescribe_with_spec_resource_param_run(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_multiple_pipelineruns(t *testing.T) {
+func TestPipelineDescribe_with_multiple_pipelineruns_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 
@@ -574,7 +575,7 @@ func TestPipelineDescribe_with_multiple_pipelineruns(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_taskSpec(t *testing.T) {
+func TestPipelineDescribe_with_taskSpec_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -625,7 +626,7 @@ func TestPipelineDescribe_with_taskSpec(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_spec_multiple_resource_param_run(t *testing.T) {
+func TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -768,7 +769,150 @@ func TestPipelineDescribe_with_spec_multiple_resource_param_run(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_custom_output(t *testing.T) {
+func TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1beta1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1beta1.PipelineSpec{
+				Description: "",
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "task",
+						TaskRef: &v1beta1.TaskRef{
+							Name: "taskref",
+						},
+						RunAfter: []string{
+							"one",
+							"two",
+						},
+						Params: []v1beta1.Param{{
+							Name: "param", Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "value"},
+						}},
+						Timeout: &metav1.Duration{
+							Duration: 5 * time.Minute,
+						},
+					},
+				},
+				Resources: []v1beta1.PipelineDeclaredResource{
+					{
+						Name: "name",
+						Type: v1beta1.PipelineResourceTypeGit,
+					},
+					{
+						Name: "code",
+						Type: v1beta1.PipelineResourceTypeGit,
+					},
+					{
+						Name: "code-image",
+						Type: v1beta1.PipelineResourceTypeImage,
+					},
+					{
+						Name: "artifact-image",
+						Type: v1beta1.PipelineResourceTypeImage,
+					},
+					{
+						Name: "repo",
+						Type: v1beta1.PipelineResourceTypeGit,
+					},
+				},
+				Params: []v1beta1.ParamSpec{
+					{
+						Name: "pipeline-param",
+						Type: v1beta1.ParamTypeString,
+						Default: &v1beta1.ArrayOrString{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+					{
+						Name: "rev-param",
+						Type: v1beta1.ParamTypeArray,
+						Default: &v1beta1.ArrayOrString{
+							Type:     v1beta1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+					{
+						Name: "pipeline-param",
+						Type: v1beta1.ParamTypeString,
+					},
+					{
+						Name: "rev-param2",
+						Type: v1beta1.ParamTypeArray,
+					},
+				},
+			},
+		},
+	}
+
+	pipelineRuns := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "pipeline-run-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now()},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(5 * time.Minute)},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredV1beta1P(pipelines[0], version),
+		cb.UnstructuredV1beta1PR(pipelineRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	// -5 : pipeline created
+	//  0 : pipeline run - 1 started
+	// 10 : pipeline run - 1 finished
+	// 15 : <<< now run pipeline ls << - advance clock to this point
+
+	clock.Advance(15 * time.Minute)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline", "-o", "yaml")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_custom_output_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -818,7 +962,7 @@ func TestPipelineDescribe_custom_output(t *testing.T) {
 	}
 }
 
-func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent(t *testing.T) {
+func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -879,67 +1023,7 @@ func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_task_conditions(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	pipelines := []*v1beta1.Pipeline{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipeline",
-				Namespace: "ns",
-			},
-			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
-				Tasks: []v1beta1.PipelineTask{
-					{
-						Name: "task-1",
-						TaskRef: &v1beta1.TaskRef{
-							Name: "task-1",
-						},
-					},
-					{
-						Name: "task-2",
-						TaskRef: &v1beta1.TaskRef{
-							Name: "task-2",
-						},
-					},
-				},
-			},
-		},
-	}
-	namespaces := []*corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns",
-			},
-		},
-	}
-
-	version := "v1beta1"
-	tdc := testDynamic.Options{}
-	dynamic, err := tdc.Client(
-		cb.UnstructuredV1beta1P(pipelines[0], version),
-	)
-	if err != nil {
-		t.Errorf("unable to create dynamic client: %v", err)
-	}
-	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{Namespaces: namespaces, Pipelines: pipelines})
-	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
-	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
-	pipeline := Command(p)
-
-	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
-}
-
-func TestPipelineDescribe_with_results(t *testing.T) {
+func TestPipelineDescribe_with_results_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -1024,7 +1108,7 @@ func TestPipelineDescribe_with_results(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_workspaces(t *testing.T) {
+func TestPipelineDescribe_with_workspaces_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -1115,7 +1199,7 @@ func TestPipelineDescribe_with_workspaces(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_annotations(t *testing.T) {
+func TestPipelineDescribe_with_annotations_v1beta1(t *testing.T) {
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1157,7 +1241,7 @@ func TestPipelineDescribe_with_annotations(t *testing.T) {
 	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
 }
 
-func TestPipelineDescribe_with_OptionalWorkspaces(t *testing.T) {
+func TestPipelineDescribe_with_OptionalWorkspaces_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -1242,6 +1326,1078 @@ func TestPipelineDescribe_with_OptionalWorkspaces(t *testing.T) {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
 	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_run(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+				// created  5 minutes back
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+		},
+	}
+	pipelineRuns := []*v1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-1",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+		cb.UnstructuredPR(pipelineRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	// -5 : pipeline created
+	//  0 : pipeline run - 1 started
+	// 10 : pipeline run - 1 finished
+	// 15 : <<< now run pipeline ls << - advance clock to this point
+
+	clock.Advance(15 * time.Minute)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_spec_run(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+				// created  5 minutes back
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+			Spec: v1.PipelineSpec{
+				Description: "a test description",
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task",
+						TaskRef: &v1.TaskRef{
+							Name: "taskref",
+						},
+						RunAfter: []string{"one", "two"},
+						Params: []v1.Param{{
+							Name: "task-param", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "value"},
+						}},
+						Timeout: &metav1.Duration{
+							Duration: 5 * time.Minute,
+						},
+					},
+				},
+			},
+		},
+	}
+	pipelineRuns := []*v1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-1",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+		cb.UnstructuredPR(pipelineRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	// -5 : pipeline created
+	//  0 : pipeline run - 1 started
+	// 10 : pipeline run - 1 finished
+	// 15 : <<< now run pipeline ls << - advance clock to this point
+
+	clock.Advance(15 * time.Minute)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_multiple_pipelineruns(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+				// created  5 minutes back
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-5 * time.Minute)},
+			},
+			Spec: v1.PipelineSpec{
+				Description: "a test description",
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task",
+						TaskRef: &v1.TaskRef{
+							Name: "taskref",
+						},
+						RunAfter: []string{"one", "two"},
+						Params: []v1.Param{{
+							Name: "task-param", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "value"},
+						}},
+						Timeout: &metav1.Duration{
+							Duration: 5 * time.Minute,
+						},
+					},
+				},
+				Params: []v1.ParamSpec{
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+						Default: &v1.ParamValue{
+							Type:      v1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+				},
+			},
+		},
+	}
+	pipelineRuns := []*v1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-1",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now()},
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					// pipeline run starts now
+					StartTime: &metav1.Time{Time: clock.Now()},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-2",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-15 * time.Minute)},
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					// pipeline run started 15 minutes ago
+					StartTime: &metav1.Time{Time: clock.Now().Add(-15 * time.Minute)},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-3",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-10 * time.Minute)},
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					// pipeline run started 10 minutes ago
+					StartTime: &metav1.Time{Time: clock.Now().Add(-10 * time.Minute)},
+					// takes 10 minutes to complete
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(10 * time.Minute)},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+		cb.UnstructuredPR(pipelineRuns[0], version),
+		cb.UnstructuredPR(pipelineRuns[1], version),
+		cb.UnstructuredPR(pipelineRuns[2], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	clock.Advance(15 * time.Minute)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_taskSpec(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Description: "",
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task",
+						TaskSpec: &v1.EmbeddedTask{TaskSpec: v1.TaskSpec{
+							Steps: []v1.Step{{
+								Name:  "step",
+								Image: "myimage",
+							}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_spec_multiple_param_run(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Description: "",
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task",
+						TaskRef: &v1.TaskRef{
+							Name: "taskref",
+						},
+						RunAfter: []string{
+							"one",
+							"two",
+						},
+						Params: []v1.Param{{
+							Name: "param", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "value"},
+						}},
+						Timeout: &metav1.Duration{
+							Duration: 5 * time.Minute,
+						},
+					},
+				},
+				Params: []v1.ParamSpec{
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+						Default: &v1.ParamValue{
+							Type:      v1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+					{
+						Name: "rev-param",
+						Type: v1.ParamTypeArray,
+						Default: &v1.ParamValue{
+							Type:     v1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+					},
+					{
+						Name: "rev-param2",
+						Type: v1.ParamTypeArray,
+					},
+				},
+			},
+		},
+	}
+
+	pipelineRuns := []*v1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "pipeline-run-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now()},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(5 * time.Minute)},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+		cb.UnstructuredPR(pipelineRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	// -5 : pipeline created
+	//  0 : pipeline run - 1 started
+	// 10 : pipeline run - 1 finished
+	// 15 : <<< now run pipeline ls << - advance clock to this point
+
+	clock.Advance(15 * time.Minute)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_spec_multiple_param_run_output(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Description: "",
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task",
+						TaskRef: &v1.TaskRef{
+							Name: "taskref",
+						},
+						RunAfter: []string{
+							"one",
+							"two",
+						},
+						Params: []v1.Param{{
+							Name: "param", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "value"},
+						}},
+						Timeout: &metav1.Duration{
+							Duration: 5 * time.Minute,
+						},
+					},
+				},
+				Params: []v1.ParamSpec{
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+						Default: &v1.ParamValue{
+							Type:      v1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+					{
+						Name: "rev-param",
+						Type: v1.ParamTypeArray,
+						Default: &v1.ParamValue{
+							Type:     v1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+					},
+					{
+						Name: "rev-param2",
+						Type: v1.ParamTypeArray,
+					},
+				},
+			},
+		},
+	}
+
+	pipelineRuns := []*v1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "pipeline-run-1",
+				Labels:    map[string]string{"tekton.dev/pipeline": "pipeline"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: clock.Now()},
+					CompletionTime: &metav1.Time{Time: clock.Now().Add(5 * time.Minute)},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+		cb.UnstructuredPR(pipelineRuns[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines, PipelineRuns: pipelineRuns})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	// -5 : pipeline created
+	//  0 : pipeline run - 1 started
+	// 10 : pipeline run - 1 finished
+	// 15 : <<< now run pipeline ls << - advance clock to this point
+
+	clock.Advance(15 * time.Minute)
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline", "-o", "yaml")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_custom_output(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Description: "",
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task",
+						TaskRef: &v1.TaskRef{
+							Name: "taskref",
+						},
+						RunAfter: []string{
+							"one",
+							"two",
+						},
+						Params: []v1.Param{{
+							Name: "param", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "value"},
+						}},
+						Timeout: &metav1.Duration{
+							Duration: 5 * time.Minute,
+						},
+					},
+				},
+				Params: []v1.ParamSpec{
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+						Default: &v1.ParamValue{
+							Type:      v1.ParamTypeString,
+							StringVal: "somethingdifferent",
+						},
+					},
+					{
+						Name: "rev-param",
+						Type: v1.ParamTypeArray,
+						Default: &v1.ParamValue{
+							Type:     v1.ParamTypeArray,
+							ArrayVal: []string{"booms", "booms", "booms"},
+						},
+					},
+					{
+						Name: "pipeline-param",
+						Type: v1.ParamTypeString,
+					},
+					{
+						Name: "rev-param2",
+						Type: v1.ParamTypeArray,
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-o", "name", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	got = strings.TrimSpace(got)
+	if got != "pipeline.tekton.dev/pipeline" {
+		t.Errorf("Result should be 'pipeline.tekton.dev/pipeline' != '%s'", got)
+	}
+}
+
+func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	p.SetNamespace("ns")
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_results(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+				Results: []v1.PipelineResult{
+					{
+						Name:        "result-1",
+						Description: "This is a description for result 1",
+						Type:        v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+					{
+						Name:        "result-2",
+						Description: "This is a description for result 2",
+						Type:        v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+					{
+						Name: "result-3",
+						Type: v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_workspaces(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+				Results: []v1.PipelineResult{
+					{
+						Name:        "result-1",
+						Description: "This is a description for result 1",
+						Type:        v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+					{
+						Name:        "result-2",
+						Description: "This is a description for result 2",
+						Type:        v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+					{
+						Name: "result-3",
+						Type: v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+				},
+				Workspaces: []v1.PipelineWorkspaceDeclaration{
+					{
+						Name:        "test",
+						Description: "test workspace",
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "pipeline")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_annotations(t *testing.T) {
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p1",
+				Namespace: "ns",
+				Annotations: map[string]string{
+					corev1.LastAppliedConfigAnnotation: "LastAppliedConfig",
+					"tekton.dev/tags":                  "testing",
+				},
+			},
+		},
+	}
+
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	p := &test.Params{Tekton: cs.Pipeline, Kube: cs.Kube, Dynamic: dynamic}
+	pipeline := Command(p)
+
+	got, err := test.ExecuteCommand(pipeline, "desc", "-n", "ns", "p1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	golden.Assert(t, got, fmt.Sprintf("%s.golden", t.Name()))
+}
+
+func TestPipelineDescribe_with_OptionalWorkspaces(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	pipelines := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipeline",
+				Namespace: "ns",
+			},
+			Spec: v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{
+					{
+						Name: "task-1",
+						TaskRef: &v1.TaskRef{
+							Name: "task-1",
+						},
+					},
+					{
+						Name: "task-2",
+						TaskRef: &v1.TaskRef{
+							Name: "task-2",
+						},
+					},
+				},
+				Results: []v1.PipelineResult{
+					{
+						Name:        "result-1",
+						Description: "This is a description for result 1",
+						Type:        v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+					{
+						Name:        "result-2",
+						Description: "This is a description for result 2",
+						Type:        v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+					{
+						Name: "result-3",
+						Type: v1.ResultsTypeString,
+						Value: v1.ParamValue{
+							Type: v1.ParamTypeString,
+						},
+					},
+				},
+				Workspaces: []v1.PipelineWorkspaceDeclaration{
+					{
+						Name:        "test",
+						Description: "test workspace",
+					},
+					{
+						Name:        "test-optional",
+						Description: "test optional workspace",
+						Optional:    true,
+					},
+				},
+			},
+		},
+	}
+	namespaces := []*corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns",
+			},
+		},
+	}
+
+	version := "v1"
+	tdc := testDynamic.Options{}
+	dynamic, err := tdc.Client(
+		cb.UnstructuredP(pipelines[0], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+	cs, _ := test.SeedTestData(t, test.Data{Namespaces: namespaces, Pipelines: pipelines})
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
 	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dynamic}
 	pipeline := Command(p)

--- a/pkg/cmd/pipeline/logs.go
+++ b/pkg/cmd/pipeline/logs.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cmd/pipelinerun"
 	"github.com/tektoncd/cli/pkg/flags"
@@ -26,6 +27,7 @@ import (
 	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/pipeline"
 	pipelinerunpkg "github.com/tektoncd/cli/pkg/pipelinerun"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,7 +38,8 @@ func nameArg(args []string, p cli.Params) error {
 			return err
 		}
 		name, ns := args[0], p.Namespace()
-		if _, err = pipeline.Get(c, name, metav1.GetOptions{}, ns); err != nil {
+		var pipeline *v1.Pipeline
+		if err = actions.GetV1(pipelineGroupResource, c, name, ns, metav1.GetOptions{}, &pipeline); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent.golden
@@ -1,11 +1,6 @@
 Name:        pipeline
 Namespace:   ns
 
-Resources
-
- NAME   TYPE
- name   git
-
 Tasks
 
  NAME     TASKREF   RUNAFTER   TIMEOUT   PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1.golden
@@ -1,10 +1,7 @@
 Name:        pipeline
 Namespace:   ns
-
-Resources
-
- NAME   TYPE
- name   git
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Tasks
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_OptionalWorkspaces_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_OptionalWorkspaces_v1beta1.golden
@@ -1,5 +1,7 @@
 Name:        pipeline
 Namespace:   ns
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Results
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_annotations_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_annotations_v1beta1.golden
@@ -1,0 +1,4 @@
+Name:        p1
+Namespace:   ns
+Annotations:
+ tekton.dev/tags=testing

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_pipelineruns_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_pipelineruns_v1beta1.golden
@@ -1,6 +1,8 @@
 Name:          pipeline
 Namespace:     ns
 Description:   a test description
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Params
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_results.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_results.golden
@@ -1,11 +1,6 @@
 Name:        pipeline
 Namespace:   ns
 
-Resources
-
- NAME   TYPE
- name   git
-
 Results
 
  NAME       DESCRIPTION

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_results_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_results_v1beta1.golden
@@ -1,5 +1,7 @@
 Name:        pipeline
 Namespace:   ns
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Results
 
@@ -7,12 +9,6 @@ Results
  result-1   This is a descripti...
  result-2   This is a descripti...
  result-3   
-
-Workspaces
-
- NAME            DESCRIPTION              OPTIONAL
- test            test workspace           false
- test-optional   test optional works...   true
 
 Tasks
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_run_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_run_v1beta1.golden
@@ -1,0 +1,7 @@
+Name:        pipeline
+Namespace:   ns
+
+PipelineRuns
+
+ NAME             STARTED          DURATION   STATUS
+ pipeline-run-1   15 minutes ago   10m0s      Succeeded

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_param_run.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_param_run.golden
@@ -1,15 +1,6 @@
 Name:        pipeline
 Namespace:   ns
 
-Resources
-
- NAME             TYPE
- code             git
- name             git
- repo             git
- artifact-image   image
- code-image       image
-
 Params
 
  NAME             TYPE     DESCRIPTION   DEFAULT VALUE

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_param_run_output.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_param_run_output.golden
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1
+kind: pipeline
+metadata:
+  creationTimestamp: null
+  name: pipeline
+  namespace: ns
+spec:
+  params:
+  - default: somethingdifferent
+    name: pipeline-param
+    type: string
+  - default:
+    - booms
+    - booms
+    - booms
+    name: rev-param
+    type: array
+  - name: pipeline-param
+    type: string
+  - name: rev-param2
+    type: array
+  tasks:
+  - name: task
+    params:
+    - name: param
+      value: value
+    runAfter:
+    - one
+    - two
+    taskRef:
+      name: taskref
+    timeout: 5m0s

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1.golden
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: pipeline
+metadata:
+  creationTimestamp: null
+  name: pipeline
+  namespace: ns
+spec:
+  params:
+  - default: somethingdifferent
+    name: pipeline-param
+    type: string
+  - default:
+    - booms
+    - booms
+    - booms
+    name: rev-param
+    type: array
+  - name: pipeline-param
+    type: string
+  - name: rev-param2
+    type: array
+  resources:
+  - name: name
+    type: git
+  - name: code
+    type: git
+  - name: code-image
+    type: image
+  - name: artifact-image
+    type: image
+  - name: repo
+    type: git
+  tasks:
+  - name: task
+    params:
+    - name: param
+      value: value
+    runAfter:
+    - one
+    - two
+    taskRef:
+      name: taskref
+    timeout: 5m0s

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1.golden
@@ -1,0 +1,22 @@
+Name:        pipeline
+Namespace:   ns
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"},{"name":"code","type":"git"},{"name":"code-image","type":"image"},{"name":"artifact-image","type":"image"},{"name":"repo","type":"git"}]
+
+Params
+
+ NAME             TYPE     DESCRIPTION   DEFAULT VALUE
+ pipeline-param   string                 somethingdifferent
+ rev-param        array                  [booms booms booms]
+ pipeline-param   string                 ---
+ rev-param2       array                  ---
+
+Tasks
+
+ NAME   TASKREF   RUNAFTER   TIMEOUT     PARAMS
+ task   taskref   one, two   5 minutes   param: value
+
+PipelineRuns
+
+ NAME             STARTED          DURATION   STATUS
+ pipeline-run-1   15 minutes ago   5m0s       Succeeded

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_resource_param_run_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_resource_param_run_v1beta1.golden
@@ -1,11 +1,13 @@
 Name:          pipeline
 Namespace:     ns
 Description:   a test description
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Params
 
- NAME             TYPE     DESCRIPTION   DEFAULT VALUE
- pipeline-param   string                 somethingdifferent
+ NAME             TYPE     DESCRIPTION            DEFAULT VALUE
+ pipeline-param   string   param of type string   somethingdifferent
 
 Tasks
 
@@ -16,5 +18,3 @@ PipelineRuns
 
  NAME             STARTED          DURATION   STATUS
  pipeline-run-1   15 minutes ago   10m0s      Succeeded
- pipeline-run-3   25 minutes ago   20m0s      Succeeded
- pipeline-run-2   30 minutes ago   25m0s      Succeeded

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_run_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_run_v1beta1.golden
@@ -2,16 +2,6 @@ Name:          pipeline
 Namespace:     ns
 Description:   a test description
 
-Resources
-
- NAME   TYPE
- name   git
-
-Params
-
- NAME             TYPE     DESCRIPTION            DEFAULT VALUE
- pipeline-param   string   param of type string   somethingdifferent
-
 Tasks
 
  NAME   TASKREF   RUNAFTER   TIMEOUT     PARAMS

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_taskSpec_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_taskSpec_v1beta1.golden
@@ -1,0 +1,7 @@
+Name:        pipeline
+Namespace:   ns
+
+Tasks
+
+ NAME   TASKREF    RUNAFTER   TIMEOUT   PARAMS
+ task   EMBEDDED              ---       ---

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_workspaces.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_workspaces.golden
@@ -1,11 +1,6 @@
 Name:        pipeline
 Namespace:   ns
 
-Resources
-
- NAME   TYPE
- name   git
-
 Results
 
  NAME       DESCRIPTION

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_workspaces_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_workspaces_v1beta1.golden
@@ -1,5 +1,7 @@
 Name:        pipeline
 Namespace:   ns
+Annotations:
+ tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Results
 
@@ -10,9 +12,8 @@ Results
 
 Workspaces
 
- NAME            DESCRIPTION              OPTIONAL
- test            test workspace           false
- test-optional   test optional works...   true
+ NAME   DESCRIPTION      OPTIONAL
+ test   test workspace   false
 
 Tasks
 

--- a/pkg/formatted/param_test.go
+++ b/pkg/formatted/param_test.go
@@ -17,102 +17,124 @@ package formatted
 import (
 	"testing"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
 )
 
 func TestParam(t *testing.T) {
-	paramSpec := []v1beta1.ParamSpec{
+	paramSpec := []v1.ParamSpec{
 		{
 			Name:    "foo",
-			Type:    v1beta1.ParamTypeString,
-			Default: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "astring"},
+			Type:    v1.ParamTypeString,
+			Default: &v1.ParamValue{Type: v1.ParamTypeString, StringVal: "astring"},
 		},
 		{
 			Name:    "bar",
-			Type:    v1beta1.ParamTypeString,
-			Default: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "bstring"},
+			Type:    v1.ParamTypeString,
+			Default: &v1.ParamValue{Type: v1.ParamTypeString, StringVal: "bstring"},
 		},
 		{
 			Name:    "foo-array-1",
-			Type:    v1beta1.ParamTypeArray,
-			Default: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"a1", "a2"}},
+			Type:    v1.ParamTypeArray,
+			Default: &v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"a1", "a2"}},
 		},
 		{
 			Name:    "foo-array-2",
-			Type:    v1beta1.ParamTypeArray,
-			Default: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"b1", "b2"}},
+			Type:    v1.ParamTypeArray,
+			Default: &v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"b1", "b2"}},
 		},
 		{
 			Name: "no-def-val",
-			Type: v1beta1.ParamTypeString,
+			Type: v1.ParamTypeString,
 		},
 		{
 			Name: "no-def-val-1",
-			Type: v1beta1.ParamTypeArray,
+			Type: v1.ParamTypeArray,
+		},
+		{
+			Name: "no-def-val-2",
+			Type: v1.ParamTypeObject,
 		},
 	}
-	p := []v1beta1.Param{
+	p := []v1.Param{
 		{
 			Name: "foo",
-			Value: v1beta1.ArrayOrString{
-				Type:      v1beta1.ParamTypeString,
+			Value: v1.ParamValue{
+				Type:      v1.ParamTypeString,
 				StringVal: "bar",
 			},
 		},
 		{
 			Name: "foo-1",
-			Value: v1beta1.ArrayOrString{
-				Type:      v1beta1.ParamTypeString,
+			Value: v1.ParamValue{
+				Type:      v1.ParamTypeString,
 				StringVal: "bar-1",
 			},
 		},
 	}
-	p1 := []v1beta1.Param{
+	p1 := []v1.Param{
 		{
 			Name: "foo",
-			Value: v1beta1.ArrayOrString{
-				Type:     v1beta1.ParamTypeArray,
+			Value: v1.ParamValue{
+				Type:     v1.ParamTypeArray,
 				ArrayVal: []string{"v1", "v2"},
 			},
 		},
 		{
 			Name: "foo-bar",
-			Value: v1beta1.ArrayOrString{
-				Type:     v1beta1.ParamTypeArray,
+			Value: v1.ParamValue{
+				Type:     v1.ParamTypeArray,
 				ArrayVal: []string{"v3", "v4", "v5"},
 			},
 		},
 	}
-	p2 := []v1beta1.Param{
+	p2 := []v1.Param{
 		{
 			Name: "foo",
-			Value: v1beta1.ArrayOrString{
-				Type:      v1beta1.ParamTypeString,
+			Value: v1.ParamValue{
+				Type:      v1.ParamTypeString,
 				StringVal: "$(params.foo)",
 			},
 		},
 		{
 			Name: "foo-array",
-			Value: v1beta1.ArrayOrString{
-				Type:     v1beta1.ParamTypeArray,
+			Value: v1.ParamValue{
+				Type:     v1.ParamTypeArray,
 				ArrayVal: []string{"$(params.foo-array-1)", "$(params.foo-array-2)", "last"},
 			},
 		},
 	}
-	p3 := []v1beta1.Param{
+	p3 := []v1.Param{
 		{
 			Name: "foo",
-			Value: v1beta1.ArrayOrString{
-				Type:      v1beta1.ParamTypeString,
+			Value: v1.ParamValue{
+				Type:      v1.ParamTypeString,
 				StringVal: "$(no-def-val)",
 			},
 		},
 		{
 			Name: "foo-array",
-			Value: v1beta1.ArrayOrString{
-				Type:     v1beta1.ParamTypeArray,
+			Value: v1.ParamValue{
+				Type:     v1.ParamTypeArray,
 				ArrayVal: []string{"$(no-def-val)", "$(no-def-val-1)", "last"},
+			},
+		},
+	}
+	p4 := []v1.Param{
+		{
+			Name: "foo",
+			Value: v1.ParamValue{
+				Type:      v1.ParamTypeObject,
+				ObjectVal: map[string]string{"key1": "$(no-def-val-2)"},
+			},
+		},
+	}
+	p5 := []v1.Param{
+		{
+			Name: "foo",
+			Value: v1.ParamValue{
+				Type:      v1.ParamTypeObject,
+				ObjectVal: map[string]string{"key1": "$(params.foo)"},
 			},
 		},
 	}
@@ -131,4 +153,10 @@ func TestParam(t *testing.T) {
 
 	str = Param(p3, paramSpec)                                              // Param value and default is not defined
 	assert.Equal(t, str, "foo: string, foo-array: [ string, array, last ]") // show param type
+
+	str = Param(p4, paramSpec) // Param has object type
+	assert.Equal(t, str, "foo: { key1: object }")
+
+	str = Param(p5, paramSpec) // Param has object type
+	assert.Equal(t, str, "foo: { key1: astring }")
 }

--- a/pkg/formatted/task.go
+++ b/pkg/formatted/task.go
@@ -15,10 +15,10 @@
 package formatted
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-func GetTaskRefName(task *v1beta1.PipelineTask) string {
+func GetTaskRefName(task *v1.PipelineTask) string {
 	if task.TaskRef != nil {
 		return task.TaskRef.Name
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -43,6 +43,7 @@ func GetAllPipelineNames(gr schema.GroupVersionResource, c *cli.Clients, ns stri
 	return ret, nil
 }
 
+// TODO: remove as all the function uses are moved to new func
 // Get will fetch the pipeline resource based on pipeline name
 func Get(c *cli.Clients, pipelinename string, opts metav1.GetOptions, ns string) (*v1beta1.Pipeline, error) {
 	unstructuredP, err := actions.Get(pipelineGroupResource, c.Dynamic, c.Tekton.Discovery(), pipelinename, ns, opts)


### PR DESCRIPTION
# Changes

This will move pipeline describe command to v1 CRDs and
pipelineresources will not be displayed anymore

For -o yaml/json, it will still show resources, as we show the
exact yaml

Part of #1804 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Move pipeline describe to v1 CRDs
```