### PR TITLE
dependabot: do not update k8s.io/* major/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     - "dependencies"
     - "release-note-none"
     - "kind/misc"
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This makes dependabot ignore major and minor updates to k8s.io/*
modules. It will still update patch release though (0.25.1 to 0.25.2).

The reason to ignore those (major/minor) is because they are usually
tied to `knative/pkg` and this means, we usually only want to update
those *when* `knative/pkg` dependencies are updated as well.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```

