### PR TITLE
Refactoring : move chain cmd to new func

### DIFF
--- a/pkg/cmd/chain/chain.go
+++ b/pkg/cmd/chain/chain.go
@@ -19,11 +19,14 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/cli/prerun"
 	"github.com/tektoncd/cli/pkg/flags"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
 	x509Keypair string = "k8s://%s/signing-secrets"
 )
+
+var taskrunGroupResource = schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
 
 func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/cmd/chain/payload.go
+++ b/pkg/cmd/chain/payload.go
@@ -21,9 +21,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/chains/pkg/chains"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/chain"
 	"github.com/tektoncd/cli/pkg/cli"
-	"github.com/tektoncd/cli/pkg/taskrun"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -62,12 +62,12 @@ func payloadCommand(p cli.Params) *cobra.Command {
 			}
 
 			// Retrieve the taskrun.
-			tr, err := taskrun.Get(cs, taskName, metav1.GetOptions{}, p.Namespace())
-			if err != nil {
+			var taskrun *v1beta1.TaskRun
+			if err = actions.GetV1(taskrunGroupResource, cs, taskName, p.Namespace(), metav1.GetOptions{}, &taskrun); err != nil {
 				return fmt.Errorf("failed to get TaskRun %s: %v", taskName, err)
 			}
 
-			return printPayloads(cs, chainsNamespace, tr, skipVerify)
+			return printPayloads(cs, chainsNamespace, taskrun, skipVerify)
 		},
 	}
 	f.AddFlags(c)

--- a/pkg/cmd/chain/signature.go
+++ b/pkg/cmd/chain/signature.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/chain"
 	"github.com/tektoncd/cli/pkg/cli"
-	"github.com/tektoncd/cli/pkg/taskrun"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,13 +50,12 @@ func signatureCommand(p cli.Params) *cobra.Command {
 				return fmt.Errorf("failed to create tekton client")
 			}
 
-			// Retrieve the taskrun.
-			tr, err := taskrun.Get(cs, taskName, metav1.GetOptions{}, p.Namespace())
-			if err != nil {
+			var taskrun *v1beta1.TaskRun
+			if err = actions.GetV1(taskrunGroupResource, cs, taskName, p.Namespace(), metav1.GetOptions{}, &taskrun); err != nil {
 				return fmt.Errorf("failed to get TaskRun %s: %v", taskName, err)
 			}
 
-			return printSignatures(cs, chainsNamespace, tr)
+			return printSignatures(cs, chainsNamespace, taskrun)
 		},
 	}
 


### PR DESCRIPTION
This is refactoring to move the chains cmds to new get func so that we can remove the old func

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Refactoring : move chain cmd to new func
```