### PR TITLE
Make task and clustertask start commands to work with v1 apis

### DIFF
--- a/docs/cmd/tkn_clustertask_start.md
+++ b/docs/cmd/tkn_clustertask_start.md
@@ -58,7 +58,7 @@ For passing the workspaces via flags:
   -L, --last                      re-run the ClusterTask using last TaskRun values
       --output string             format of TaskRun (yaml or json)
   -o, --outputresource strings    pass the output resource name and ref as name=ref
-  -p, --param stringArray         pass the param as key=value for string type, or key=value1,value2,... for array type
+  -p, --param stringArray         pass the param as key=value for string type, or key=value1,value2,... for array type, or key="key1:value1, key2:value2" for object type
       --pod-template string       local or remote file containing a PodTemplate definition
       --prefix-name string        specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string     pass the serviceaccount name

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -58,7 +58,7 @@ For passing the workspaces via flags:
   -L, --last                      re-run the Task using last TaskRun values
       --output string             format of TaskRun (yaml or json)
   -o, --outputresource strings    pass the output resource name and ref as name=ref
-  -p, --param stringArray         pass the param as key=value for string type, or key=value1,value2,... for array type
+  -p, --param stringArray         pass the param as key=value for string type, or key=value1,value2,... for array type, or key="key1:value1, key2:value2" for object type
       --pod-template string       local or remote file containing a PodTemplate definition
       --prefix-name string        specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
   -s, --serviceaccount string     pass the serviceaccount name

--- a/docs/man/man1/tkn-clustertask-start.1
+++ b/docs/man/man1/tkn-clustertask-start.1
@@ -49,7 +49,7 @@ Start ClusterTasks
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param as key=value for string type, or key=value1,value2,... for array type
+    pass the param as key=value for string type, or key=value1,value2,... for array type, or key="key1:value1, key2:value2" for object type
 
 .PP
 \fB\-\-pod\-template\fP=""

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -53,7 +53,7 @@ Start Tasks
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param as key=value for string type, or key=value1,value2,... for array type
+    pass the param as key=value for string type, or key=value1,value2,... for array type, or key="key1:value1, key2:value2" for object type
 
 .PP
 \fB\-\-pod\-template\fP=""

--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -189,7 +189,7 @@ For passing the workspaces via flags:
 
 	c.Flags().StringSliceVarP(&opt.InputResources, "inputresource", "i", []string{}, "pass the input resource name and ref as name=ref")
 	c.Flags().StringSliceVarP(&opt.OutputResources, "outputresource", "o", []string{}, "pass the output resource name and ref as name=ref")
-	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type")
+	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type, or key=\"key1:value1, key2:value2\" for object type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the ClusterTask using last TaskRun values")
 	c.Flags().StringVarP(&opt.UseTaskRun, "use-taskrun", "", "", "specify a TaskRun name to use its values to re-run the TaskRun")

--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -535,7 +535,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 			wantError:   false,
 			want:        "TaskRun started: taskrun-1\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-1 -f -n ns\n",
 		},
-		/*TODO: this should be fixed with start command
 		{
 			name:        "Start with --last option",
 			command:     []string{"start", "clustertask-1", "--last"},
@@ -544,7 +543,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "TaskRun started: taskrun-2\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-2 -f -n ns\n",
-		},*/
+		},
 		{
 			name:        "Start with --use-taskrun option",
 			command:     []string{"start", "clustertask-1", "--use-taskrun", "taskrun-123"},
@@ -673,7 +672,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 			wantError:   false,
 			goldenFile:  true,
 		},
-		/*TODO: this should be fixed with start command
 		{
 			name: "Dry run with --last",
 			command: []string{"start", "clustertask-1",
@@ -689,7 +687,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			goldenFile:  true,
-		},*/
+		},
 		{
 			name: "Dry run with --timeout v1beta1",
 			command: []string{"start", "clustertask-2",
@@ -835,7 +833,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 			wantError:   false,
 			goldenFile:  true,
 		},
-		/*TODO: this should be fixed with start command
 		{
 			name: "Dry Run with --prefix-name and --last v1beta1",
 			command: []string{"start", "clustertask-1",
@@ -851,7 +848,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			goldenFile:  true,
-		},*/
+		},
 		{
 			name: "Start clustertask with skip-optional-workspaces flag",
 			command: []string{"start", "clustertask-4",

--- a/pkg/cmd/task/start_test.go
+++ b/pkg/cmd/task/start_test.go
@@ -515,8 +515,6 @@ func Test_start_task(t *testing.T) {
 }
 
 func Test_start_task_last(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -703,8 +701,6 @@ func Test_start_task_last(t *testing.T) {
 }
 
 func Test_start_task_last_with_override_timeout(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1045,8 +1041,6 @@ func Test_start_use_taskrun_cancelled_status(t *testing.T) {
 }
 
 func Test_start_task_last_generate_name(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1211,8 +1205,6 @@ func Test_start_task_last_generate_name(t *testing.T) {
 }
 
 func Test_start_task_last_with_prefix_name(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1376,8 +1368,6 @@ func Test_start_task_last_with_prefix_name(t *testing.T) {
 }
 
 func Test_start_task_with_prefix_name(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1541,8 +1531,6 @@ func Test_start_task_with_prefix_name(t *testing.T) {
 }
 
 func Test_start_task_last_with_inputs(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1732,8 +1720,6 @@ func Test_start_task_last_with_inputs(t *testing.T) {
 }
 
 func Test_start_task_last_without_taskrun(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2383,6 +2369,10 @@ func Test_start_task_allkindparam(t *testing.T) {
 						Name: "printafter",
 						Type: v1beta1.ParamTypeArray,
 					},
+					{
+						Name: "printlast",
+						Type: v1beta1.ParamTypeObject,
+					},
 				},
 				Steps: []v1beta1.Step{
 					{
@@ -2421,6 +2411,7 @@ func Test_start_task_allkindparam(t *testing.T) {
 		"-p=myarg=value1",
 		"-p=print=boom,boom",
 		"-p=printafter=booms",
+		"-p=printlast=a:b, c:d",
 		"-l=key=value",
 		"-o=code-image=output-image",
 		"-s=svc1",
@@ -2439,7 +2430,7 @@ func Test_start_task_allkindparam(t *testing.T) {
 		t.Errorf("Error taskrun generated is different %+v", tr)
 	}
 
-	test.AssertOutput(t, 3, len(tr.Items[0].Spec.Params))
+	test.AssertOutput(t, 4, len(tr.Items[0].Spec.Params))
 
 	for _, v := range tr.Items[0].Spec.Params {
 		if v.Name == "my-arg" {
@@ -2452,6 +2443,10 @@ func Test_start_task_allkindparam(t *testing.T) {
 
 		if v.Name == "printafter" {
 			test.AssertOutput(t, v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"booms"}}, v.Value)
+		}
+
+		if v.Name == "printlast" {
+			test.AssertOutput(t, v1.ParamValue{Type: v1.ParamTypeObject, ObjectVal: map[string]string{"a": "b", "c": "d"}}, v.Value)
 		}
 	}
 

--- a/pkg/options/start.go
+++ b/pkg/options/start.go
@@ -6,14 +6,18 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/task"
-	tractions "github.com/tektoncd/cli/pkg/taskrun"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	versionedResource "github.com/tektoncd/pipeline/pkg/client/resource/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+var taskrunGroupResource = schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
 
 type InteractiveOpts struct {
 	Stream                *cli.Stream
@@ -63,19 +67,18 @@ func (taskRunOpts *TaskRunOpts) UseTaskRunFrom(tr *v1beta1.TaskRun, cs *cli.Clie
 		err    error
 	)
 	if taskRunOpts.Last {
-		trtemp, err := task.LastRun(cs, tname, taskRunOpts.CliParams.Namespace(), taskKind)
+		name, err := task.LastRunName(cs, tname, taskRunOpts.CliParams.Namespace(), taskKind)
 		if err != nil {
 			return err
 		}
 
-		// TODO: remove as we move the start command to v1
-		err = trUsed.ConvertFrom(context.TODO(), trtemp)
+		trUsed, err = getTaskRunV1beta1(taskrunGroupResource, cs, name, taskRunOpts.CliParams.Namespace())
 		if err != nil {
 			return err
 		}
 
 	} else if taskRunOpts.UseTaskRun != "" {
-		trUsed, err = tractions.Get(cs, taskRunOpts.UseTaskRun, metav1.GetOptions{}, taskRunOpts.CliParams.Namespace())
+		trUsed, err = getTaskRunV1beta1(taskrunGroupResource, cs, taskRunOpts.UseTaskRun, taskRunOpts.CliParams.Namespace())
 		if err != nil {
 			return err
 		}
@@ -282,8 +285,12 @@ func (intOpts *InteractiveOpts) TaskParams(task *v1beta1.Task, skipParams map[st
 			if param.Default != nil {
 				if param.Type == "string" {
 					defaultValue = param.Default.StringVal
-				} else {
+				}
+				if param.Type == "array" {
 					defaultValue = strings.Join(param.Default.ArrayVal, ",")
+				}
+				if param.Type == "object" {
+					defaultValue = fmt.Sprintf("%+v", param.Default.ObjectVal)
 				}
 				ques += fmt.Sprintf(" (Default is `%s`)", defaultValue)
 				input.Default = defaultValue
@@ -523,8 +530,12 @@ func (intOpts *InteractiveOpts) ClusterTaskParams(clustertask *v1beta1.ClusterTa
 			if param.Default != nil {
 				if param.Type == "string" {
 					defaultValue = param.Default.StringVal
-				} else {
+				}
+				if param.Type == "array" {
 					defaultValue = strings.Join(param.Default.ArrayVal, ",")
+				}
+				if param.Type == "object" {
+					defaultValue = fmt.Sprintf("%+v", param.Default.ObjectVal)
 				}
 				ques += fmt.Sprintf(" (Default is `%s`)", defaultValue)
 				input.Default = defaultValue
@@ -668,4 +679,31 @@ func askParam(ques string, askOpts survey.AskOpt, def ...string) (string, error)
 	}
 
 	return ans, nil
+}
+
+func getTaskRunV1beta1(gr schema.GroupVersionResource, c *cli.Clients, trName, ns string) (*v1beta1.TaskRun, error) {
+	var taskrun v1beta1.TaskRun
+	gvr, err := actions.GetGroupVersionResource(gr, c.Tekton.Discovery())
+	if err != nil {
+		return nil, err
+	}
+
+	if gvr.Version == "v1beta1" {
+		err := actions.GetV1(gr, c, trName, ns, metav1.GetOptions{}, &taskrun)
+		if err != nil {
+			return nil, err
+		}
+		return &taskrun, nil
+	}
+
+	var taskrunV1 v1.TaskRun
+	err = actions.GetV1(gr, c, trName, ns, metav1.GetOptions{}, &taskrunV1)
+	if err != nil {
+		return nil, err
+	}
+	err = taskrun.ConvertFrom(context.Background(), &taskrunV1)
+	if err != nil {
+		return nil, err
+	}
+	return &taskrun, nil
 }

--- a/pkg/params/mergeparams.go
+++ b/pkg/params/mergeparams.go
@@ -65,7 +65,7 @@ func parseParam(p []string) (map[string]v1beta1.Param, error) {
 
 		param := v1beta1.Param{
 			Name: r[0],
-			Value: v1beta1.ArrayOrString{
+			Value: v1beta1.ParamValue{
 				Type: paramByType[r[0]],
 			},
 		}
@@ -81,6 +81,19 @@ func parseParam(p []string) (map[string]v1beta1.Param, error) {
 				param.Value.ArrayVal = strings.Split(r[1], ",")
 			}
 		}
+
+		if paramByType[r[0]] == "object" {
+			fields := strings.Split(r[1], ",")
+			object := map[string]string{}
+			for _, field := range fields {
+				r := strings.SplitN(field, ":", 2)
+				if len(r) != 2 {
+					return nil, errors.New(invalidParam + v)
+				}
+				object[strings.TrimSpace(r[0])] = strings.TrimSpace(r[1])
+			}
+			param.Value.ObjectVal = object
+		}
 		params[r[0]] = param
 	}
 	return params, nil
@@ -92,7 +105,11 @@ func FilterParamsByType(params []v1beta1.ParamSpec) {
 			paramByType[p.Name] = v1beta1.ParamTypeString
 			continue
 		}
-		paramByType[p.Name] = v1beta1.ParamTypeArray
+		if p.Type == "array" {
+			paramByType[p.Name] = v1beta1.ParamTypeArray
+			continue
+		}
+		paramByType[p.Name] = v1beta1.ParamTypeObject
 	}
 }
 

--- a/pkg/params/mergeparams_test.go
+++ b/pkg/params/mergeparams_test.go
@@ -26,14 +26,14 @@ func Test_MergeParam_String(t *testing.T) {
 	params := []v1beta1.Param{
 		{
 			Name: "key1",
-			Value: v1beta1.ArrayOrString{
+			Value: v1beta1.ParamValue{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: "value1",
 			},
 		},
 		{
 			Name: "key2",
-			Value: v1beta1.ArrayOrString{
+			Value: v1beta1.ParamValue{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: "value2",
 			},
@@ -83,7 +83,7 @@ func Test_MergeParam_Array(t *testing.T) {
 	params := []v1beta1.Param{
 		{
 			Name: "key1",
-			Value: v1beta1.ArrayOrString{
+			Value: v1beta1.ParamValue{
 				Type:     v1beta1.ParamTypeArray,
 				ArrayVal: []string{"value1", "value2"},
 			},
@@ -138,7 +138,7 @@ func Test_parseParam(t *testing.T) {
 	}{{
 		name: "Test_parseParam No Err",
 		args: args{
-			p: []string{"key1=value1", "key2=value2", "key3=value3,value4,value5", "key4=value4"},
+			p: []string{"key1=value1", "key2=value2", "key3=value3,value4,value5", "key4=value4", "key5=a:b,c:d"},
 			pt: []v1beta1.ParamSpec{
 				{
 					Name: "key1",
@@ -156,27 +156,36 @@ func Test_parseParam(t *testing.T) {
 					Name: "key4",
 					Type: "array",
 				},
+				{
+					Name: "key5",
+					Type: "object",
+				},
 			},
 		},
 		want: map[string]v1beta1.Param{
-			"key1": {Name: "key1", Value: v1beta1.ArrayOrString{
+			"key1": {Name: "key1", Value: v1beta1.ParamValue{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: "value1",
 			},
 			},
-			"key2": {Name: "key2", Value: v1beta1.ArrayOrString{
+			"key2": {Name: "key2", Value: v1beta1.ParamValue{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: "value2",
 			},
 			},
-			"key3": {Name: "key3", Value: v1beta1.ArrayOrString{
+			"key3": {Name: "key3", Value: v1beta1.ParamValue{
 				Type:     v1beta1.ParamTypeArray,
 				ArrayVal: []string{"value3", "value4", "value5"},
 			},
 			},
-			"key4": {Name: "key4", Value: v1beta1.ArrayOrString{
+			"key4": {Name: "key4", Value: v1beta1.ParamValue{
 				Type:     v1beta1.ParamTypeArray,
 				ArrayVal: []string{"value4"},
+			},
+			},
+			"key5": {Name: "key5", Value: v1beta1.ParamValue{
+				Type:      v1beta1.ParamTypeObject,
+				ObjectVal: map[string]string{"a": "b", "c": "d"},
 			},
 			},
 		},
@@ -199,14 +208,14 @@ func Test_parseParam(t *testing.T) {
 		want: map[string]v1beta1.Param{
 			"key1": {
 				Name: "key1",
-				Value: v1beta1.ArrayOrString{
+				Value: v1beta1.ParamValue{
 					Type:      v1beta1.ParamTypeString,
 					StringVal: "value1",
 				},
 			},
 			"key2": {
 				Name: "key2",
-				Value: v1beta1.ArrayOrString{
+				Value: v1beta1.ParamValue{
 					Type:     v1beta1.ParamTypeArray,
 					ArrayVal: make([]string, 0),
 				},

--- a/pkg/params/validation.go
+++ b/pkg/params/validation.go
@@ -18,12 +18,15 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+var allowedParamTypes = sets.NewString("string", "array", "object")
 
 func ValidateParamType(params []v1beta1.ParamSpec) error {
 	paramsWithInvalidType := make([]v1beta1.ParamSpec, 0)
 	for _, param := range params {
-		if param.Type != "string" && param.Type != "array" {
+		if !allowedParamTypes.Has(string(param.Type)) {
 			paramsWithInvalidType = append(paramsWithInvalidType, param)
 		}
 	}

--- a/pkg/task/tasklastrun.go
+++ b/pkg/task/tasklastrun.go
@@ -26,6 +26,15 @@ import (
 
 var taskrunGroupResource = schema.GroupVersionResource{Group: "tekton.dev", Resource: "taskruns"}
 
+// LastRun returns the name of last taskrun for a given task/clustertask
+func LastRunName(cs *cli.Clients, resourceName, ns, kind string) (string, error) {
+	latest, err := LastRun(cs, resourceName, ns, kind)
+	if err != nil {
+		return "", err
+	}
+	return latest.Name, nil
+}
+
 // LastRun returns the last taskrun for a given task/clustertask
 func LastRun(cs *cli.Clients, resourceName, ns, kind string) (*v1.TaskRun, error) {
 	options := metav1.ListOptions{}

--- a/pkg/task/tasklastrun_test.go
+++ b/pkg/task/tasklastrun_test.go
@@ -30,6 +30,128 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
+func TestTaskrunLatestName_two_run_v1beta1(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	var (
+		firstRunCreated   = clock.Now().Add(10 * time.Minute)
+		firstRunStarted   = firstRunCreated.Add(2 * time.Second)
+		firstRunCompleted = firstRunStarted.Add(10 * time.Minute)
+
+		secondRunCreated   = firstRunCreated.Add(1 * time.Minute)
+		secondRunStarted   = secondRunCreated.Add(2 * time.Second)
+		secondRunCompleted = secondRunStarted.Add(5 * time.Minute)
+	)
+	taskruns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tr-1",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/task": "task"},
+				CreationTimestamp: metav1.Time{Time: firstRunCreated},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: firstRunStarted},
+					CompletionTime: &metav1.Time{Time: firstRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tr-2",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/task": "task"},
+				CreationTimestamp: metav1.Time{Time: secondRunCompleted},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: secondRunStarted},
+					CompletionTime: &metav1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tr-3",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/clusterTask": "task"},
+				CreationTimestamp: metav1.Time{Time: secondRunCompleted},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "task",
+					Kind: v1beta1.ClusterTaskKind,
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1beta1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: secondRunStarted},
+					CompletionTime: &metav1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+	}
+	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{
+		TaskRuns: taskruns,
+	})
+	cs.Pipeline.Resources = cb.APIResourceList("v1beta1", []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, _ := tdc.Client(
+		cb.UnstructuredV1beta1TR(taskruns[0], "v1beta1"),
+		cb.UnstructuredV1beta1TR(taskruns[1], "v1beta1"),
+		cb.UnstructuredV1beta1TR(taskruns[2], "v1beta1"),
+	)
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Dynamic: dc}
+	client, err := p.Clients()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	lastRun, err := LastRunName(client, "task", "ns", "Task")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	test.AssertOutput(t, "tr-2", lastRun)
+}
+
 func TestTaskrunLatest_two_run_v1beta1(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
@@ -294,6 +416,128 @@ func TestTaskrunLatestForClusterTask_two_run_v1beta1(t *testing.T) {
 	}
 
 	test.AssertOutput(t, "tr-2", lastRun.Name)
+}
+
+func TestTaskrunLatestName_two_run(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	var (
+		firstRunCreated   = clock.Now().Add(10 * time.Minute)
+		firstRunStarted   = firstRunCreated.Add(2 * time.Second)
+		firstRunCompleted = firstRunStarted.Add(10 * time.Minute)
+
+		secondRunCreated   = firstRunCreated.Add(1 * time.Minute)
+		secondRunStarted   = secondRunCreated.Add(2 * time.Second)
+		secondRunCompleted = secondRunStarted.Add(5 * time.Minute)
+	)
+	taskruns := []*v1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tr-1",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/task": "task"},
+				CreationTimestamp: metav1.Time{Time: firstRunCreated},
+			},
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{
+					Name: "task",
+					Kind: v1.NamespacedTaskKind,
+				},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: firstRunStarted},
+					CompletionTime: &metav1.Time{Time: firstRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tr-2",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/task": "task"},
+				CreationTimestamp: metav1.Time{Time: secondRunCompleted},
+			},
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{
+					Name: "task",
+					Kind: v1.NamespacedTaskKind,
+				},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: secondRunStarted},
+					CompletionTime: &metav1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tr-3",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/clusterTask": "task"},
+				CreationTimestamp: metav1.Time{Time: secondRunCompleted},
+			},
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{
+					Name: "task",
+					Kind: "ClusterTask",
+				},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						},
+					},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: secondRunStarted},
+					CompletionTime: &metav1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+	}
+	cs, _ := test.SeedTestData(t, test.Data{
+		TaskRuns: taskruns,
+	})
+	cs.Pipeline.Resources = cb.APIResourceList("v1", []string{"taskrun"})
+	tdc := testDynamic.Options{}
+	dc, _ := tdc.Client(
+		cb.UnstructuredTR(taskruns[0], "v1"),
+		cb.UnstructuredTR(taskruns[1], "v1"),
+		cb.UnstructuredTR(taskruns[2], "v1"),
+	)
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Dynamic: dc}
+	client, err := p.Clients()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	lastRun, err := LastRunName(client, "task", "ns", "Task")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	test.AssertOutput(t, "tr-2", lastRun)
 }
 
 func TestTaskrunLatest_two_run(t *testing.T) {

--- a/test/e2e/clustertask/start_test.go
+++ b/test/e2e/clustertask/start_test.go
@@ -258,7 +258,6 @@ Waiting for logs to be available...
 		}
 	})
 
-	/*TODO: this should be fixed with start command
 	t.Run("Start TaskRun using tkn ct start with --last option", func(t *testing.T) {
 		// Get last TaskRun for read-clustertask
 		lastTaskRun := builder.GetTaskRunListWithClusterTaskName(c, clusterTaskName, true).Items[0]
@@ -283,7 +282,7 @@ Waiting for logs to be available...
 		if d := cmp.Diff(got, expected); d != "" {
 			t.Fatalf("-got, +want: %v", d)
 		}
-	})*/
+	})
 
 	t.Run("Start TaskRun using tkn ct start with --use-taskrun option", func(t *testing.T) {
 		// Get last TaskRun for read-clustertask

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -19,9 +19,11 @@ package task
 
 import (
 	"testing"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
+	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/cli/test/builder"
 	"github.com/tektoncd/cli/test/cli"
 	"github.com/tektoncd/cli/test/framework"
@@ -302,7 +304,6 @@ Waiting for logs to be available...
 		assert.Assert(t, v1beta1.TaskRunReasonCancelled.String() == cancelledRun.Status.Conditions[0].Reason)
 	})
 
-	/*TODO: this should be fixed with start command
 	t.Run("Start TaskRun using tkn task start with --last option", func(t *testing.T) {
 		// Get last TaskRun for read-task
 		lastTaskRun := builder.GetTaskRunListWithTaskName(c, "read-task", true).Items[0]
@@ -327,7 +328,7 @@ Waiting for logs to be available...
 		if d := cmp.Diff(got, expected); d != "" {
 			t.Fatalf("-got, +want: %v", d)
 		}
-	})*/
+	})
 
 	t.Logf("Creating Task task-optional-ws in namespace: %s ", namespace)
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("task-with-optional-workspace.yaml"))


### PR DESCRIPTION
This makes the task and clustertask start to work with v1 taskrun Also add the support for object type params

Part of #1804

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Make task and clustertask start commands to work with v1 apis
```