### PR TITLE
Make pipeline start commands to work with v1 apis

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -70,7 +70,7 @@ my-secret, my-empty-dir and my-volume-claim-template)
   -l, --labels strings                pass labels as label=value.
   -L, --last                          re-run the Pipeline using last PipelineRun values
   -o, --output string                 format of PipelineRun (yaml, json or name)
-  -p, --param stringArray             pass the param as key=value for string type, or key=value1,value2,... for array type
+  -p, --param stringArray             pass the param as key=value for string type, or key=value1,value2,... for array type, or key="key1:value1, key2:value2" for object type
       --pipeline-timeout string       timeout for PipelineRun
       --pod-template string           local or remote file containing a PodTemplate definition
       --prefix-name string            specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -57,7 +57,7 @@ Parameters, at least those that have no default value
 
 .PP
 \fB\-p\fP, \fB\-\-param\fP=[]
-    pass the param as key=value for string type, or key=value1,value2,... for array type
+    pass the param as key=value for string type, or key=value1,value2,... for array type, or key="key1:value1, key2:value2" for object type
 
 .PP
 \fB\-\-pipeline\-timeout\fP=""

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -2835,8 +2835,6 @@ func Test_start_pipeline(t *testing.T) {
 }
 
 func Test_start_pipeline_last(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	pipelineName := "test-pipeline"
 	ps := []*v1beta1.Pipeline{
 		{
@@ -3039,8 +3037,6 @@ func Test_start_pipeline_last(t *testing.T) {
 }
 
 func Test_start_pipeline_last_override_timeout_deprecated(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	pipelineName := "test-pipeline"
 	ps := []*v1beta1.Pipeline{
 		{
@@ -3233,8 +3229,6 @@ func Test_start_pipeline_last_override_timeout_deprecated(t *testing.T) {
 }
 
 func Test_start_pipeline_last_without_res_param(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	pipelineName := "test-pipeline"
 
 	ps := []*v1beta1.Pipeline{
@@ -3417,8 +3411,6 @@ func Test_start_pipeline_last_without_res_param(t *testing.T) {
 }
 
 func Test_start_pipeline_last_merge(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	pipelineName := "test-pipeline"
 
 	ps := []*v1beta1.Pipeline{
@@ -4075,8 +4067,6 @@ func Test_start_pipeline_allkindparam(t *testing.T) {
 }
 
 func Test_start_pipeline_last_generate_name(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	pipelineName := "test-pipeline"
 
 	ps := []*v1beta1.Pipeline{
@@ -4254,8 +4244,6 @@ func Test_start_pipeline_last_generate_name(t *testing.T) {
 }
 
 func Test_start_pipeline_last_with_prefix_name(t *testing.T) {
-	// TODO: this should be fixed with start command
-	t.Skip()
 	pipelineName := "test-pipeline"
 
 	ps := []*v1beta1.Pipeline{

--- a/pkg/pipeline/pipelinelastrun.go
+++ b/pkg/pipeline/pipelinelastrun.go
@@ -23,6 +23,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// LastRun returns the name of last pipelinerun for a given pipeline
+func LastRunName(cs *cli.Clients, resourceName, ns string) (string, error) {
+	latest, err := LastRun(cs, resourceName, ns)
+	if err != nil {
+		return "", err
+	}
+	return latest.Name, nil
+}
+
 // DynamicLastRun returns the last run for a given pipeline
 func LastRun(cs *cli.Clients, pipeline string, ns string) (*v1.PipelineRun, error) {
 	options := metav1.ListOptions{}

--- a/pkg/pipeline/pipelinelastrun_test.go
+++ b/pkg/pipeline/pipelinelastrun_test.go
@@ -28,6 +28,128 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
+func TestPipelineRunLastName_two_run(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	//  Time --->
+	//  |---5m ---|------------ ││--││------------- ---│--│
+	//	now      pipeline       ││  │`secondRun stated │  `*first*RunCompleted
+	//                          ││  `secondRun         `*second*RunCompleted
+	//	                        │`firstRun started
+	//	                        `firstRun
+	// NOTE: firstRun completed **after** second but latest should still be
+	// second run based on creationTimestamp
+
+	var (
+		version         = "v1"
+		pipelineCreated = clock.Now().Add(-5 * time.Minute)
+		runDuration     = 5 * time.Minute
+
+		firstRunCreated   = clock.Now().Add(10 * time.Minute)
+		firstRunStarted   = firstRunCreated.Add(2 * time.Second)
+		firstRunCompleted = firstRunStarted.Add(2 * runDuration) // take twice as long
+
+		secondRunCreated   = firstRunCreated.Add(1 * time.Minute)
+		secondRunStarted   = secondRunCreated.Add(2 * time.Second)
+		secondRunCompleted = secondRunStarted.Add(runDuration) // takes less thus completes
+	)
+
+	pdata := []*v1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.Time{Time: pipelineCreated},
+			},
+		},
+	}
+
+	prdata := []*v1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-1",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: firstRunCreated},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: firstRunStarted},
+					CompletionTime: &metav1.Time{Time: firstRunCompleted},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pipeline-run-2",
+				Namespace:         "ns",
+				Labels:            map[string]string{"tekton.dev/pipeline": "pipeline"},
+				CreationTimestamp: metav1.Time{Time: secondRunCreated},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "pipeline",
+				},
+			},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Status: corev1.ConditionTrue,
+							Reason: v1.PipelineRunReasonSuccessful.String(),
+						},
+					},
+				},
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: secondRunStarted},
+					CompletionTime: &metav1.Time{Time: secondRunCompleted},
+				},
+			},
+		},
+	}
+
+	cs, _ := test.SeedTestData(t, test.Data{
+		Pipelines:    pdata,
+		PipelineRuns: prdata,
+	})
+
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"pipeline", "pipelinerun"})
+	tdc := testDynamic.Options{}
+	dc, err := tdc.Client(
+		cb.UnstructuredP(pdata[0], version),
+		cb.UnstructuredPR(prdata[0], version),
+		cb.UnstructuredPR(prdata[1], version),
+	)
+	if err != nil {
+		t.Errorf("unable to create dynamic client: %v", err)
+	}
+
+	p := &test.Params{Tekton: cs.Pipeline, Clock: clock, Kube: cs.Kube, Dynamic: dc}
+	client, err := p.Clients()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	lastRun, err := LastRunName(client, "pipeline", "ns")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	test.AssertOutput(t, "pipeline-run-2", lastRun)
+}
+
 func TestPipelineRunLast_two_run(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	//  Time --->

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
+	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/cli/test/builder"
 	"github.com/tektoncd/cli/test/cli"
 	"github.com/tektoncd/cli/test/framework"
@@ -257,7 +258,6 @@ Waiting for logs to be available...
 		})
 	})
 
-	/*TODO: this should be fixed with start command
 	t.Run("Start PipelineRun with tkn pipeline start --last", func(t *testing.T) {
 		// Get last PipelineRun for output-pipeline
 		pipelineRunLast := builder.GetPipelineRunListWithName(c, tePipelineName, true).Items[0]
@@ -284,7 +284,6 @@ Waiting for logs to be available...
 			t.Fatalf("-got, +want: %v", d)
 		}
 	})
-	*/
 
 	t.Logf("Creating Pipeline pipeline-with-workspace in namespace: %s", namespace)
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("pipeline-with-workspace.yaml"))


### PR DESCRIPTION
This will make sure the pipeline start cmd work with v1 apis

Also add support for object type params

Part of https://github.com/tektoncd/cli/issues/1804

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Make pipeline start commands to work with v1 apis
```