### PR TITLE
Remove PipelineResource support in clustertask

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,7 +29,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
-	"github.com/tektoncd/cli/pkg/cmd/pipelineresource"
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/file"
 	"github.com/tektoncd/cli/pkg/flags"
@@ -43,7 +41,6 @@ import (
 	"github.com/tektoncd/cli/pkg/workspaces"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,14 +50,10 @@ var (
 	errClusterTaskAlreadyPresent = "ClusterTask with name %s already exists"
 )
 
-const invalidResource = "invalid input format for resource parameter: "
-
 type startOptions struct {
 	cliparams             cli.Params
 	stream                *cli.Stream
 	Params                []string
-	InputResources        []string
-	OutputResources       []string
 	ServiceAccountName    string
 	Last                  bool
 	Labels                []string
@@ -188,11 +181,6 @@ For passing the workspaces via flags:
 			return startClusterTask(opt, args)
 		},
 	}
-
-	c.Flags().StringSliceVarP(&opt.InputResources, "inputresource", "i", []string{}, "pass the input resource name and ref as name=ref")
-	c.Flags().StringSliceVarP(&opt.OutputResources, "outputresource", "o", []string{}, "pass the output resource name and ref as name=ref")
-	_ = c.Flags().MarkDeprecated("inputresource", "pipelineresources have been deprecated, this flag will be removed soon")
-	_ = c.Flags().MarkDeprecated("outputresource", "pipelineresources have been deprecated, this flag will be removed soon")
 	c.Flags().StringArrayVarP(&opt.Params, "param", "p", []string{}, "pass the param as key=value for string type, or key=value1,value2,... for array type, or key=\"key1:value1, key2:value2\" for object type")
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	c.Flags().BoolVarP(&opt.Last, "last", "L", false, "re-run the ClusterTask using last TaskRun values")
@@ -263,21 +251,6 @@ func startClusterTask(opt startOptions, args []string) error {
 		}
 		tr.Spec.Timeout = &metav1.Duration{Duration: timeoutDuration}
 	}
-
-	if tr.Spec.Resources == nil {
-		tr.Spec.Resources = &v1beta1.TaskRunResources{}
-	}
-	inputRes, err := mergeRes(tr.Spec.Resources.Inputs, opt.InputResources)
-	if err != nil {
-		return err
-	}
-	tr.Spec.Resources.Inputs = inputRes
-
-	outRes, err := mergeRes(tr.Spec.Resources.Outputs, opt.OutputResources)
-	if err != nil {
-		return err
-	}
-	tr.Spec.Resources.Outputs = outRes
 
 	labels, err := labels.MergeLabels(tr.ObjectMeta.Labels, opt.Labels)
 	if err != nil {
@@ -375,48 +348,6 @@ func startClusterTask(opt startOptions, args []string) error {
 	return taskrun.Run(runLogOpts)
 }
 
-func mergeRes(r []v1beta1.TaskResourceBinding, optRes []string) ([]v1beta1.TaskResourceBinding, error) {
-	res, err := parseRes(optRes)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(res) == 0 {
-		return r, nil
-	}
-
-	for i := range r {
-		if v, ok := res[r[i].Name]; ok {
-			r[i] = v
-			delete(res, v.Name)
-		}
-	}
-	for _, v := range res {
-		r = append(r, v)
-	}
-	sort.Slice(r, func(i, j int) bool { return r[i].Name < r[j].Name })
-	return r, nil
-}
-
-func parseRes(res []string) (map[string]v1beta1.TaskResourceBinding, error) {
-	resources := map[string]v1beta1.TaskResourceBinding{}
-	for _, v := range res {
-		r := strings.SplitN(v, "=", 2)
-		if len(r) != 2 {
-			return nil, errors.New(invalidResource + v)
-		}
-		resources[r[0]] = v1beta1.TaskResourceBinding{
-			PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-				Name: r[0],
-				ResourceRef: &v1beta1.PipelineResourceRef{
-					Name: r[1],
-				},
-			},
-		}
-	}
-	return resources, nil
-}
-
 func printTaskRun(output string, s *cli.Stream, tr interface{}) error {
 	format := strings.ToLower(output)
 
@@ -448,21 +379,6 @@ func (opt *startOptions) getInputs() error {
 		SkipOptionalWorkspace: opt.SkipOptionalWorkspace,
 	}
 
-	if opt.clustertask.Spec.Resources != nil && !opt.Last && opt.UseTaskRun == "" {
-		if len(opt.InputResources) == 0 {
-			if err := intOpts.ClusterTaskInputResources(opt.clustertask, createPipelineResource); err != nil {
-				return err
-			}
-			opt.InputResources = append(opt.InputResources, intOpts.InputResources...)
-		}
-		if len(opt.OutputResources) == 0 {
-			if err := intOpts.ClusterTaskOutputResources(opt.clustertask, createPipelineResource); err != nil {
-				return err
-			}
-			opt.OutputResources = append(opt.OutputResources, intOpts.OutputResources...)
-		}
-	}
-
 	params.FilterParamsByType(opt.clustertask.Spec.Params)
 	if !opt.Last && opt.UseTaskRun == "" {
 		skipParams, err := params.ParseParams(opt.Params)
@@ -483,40 +399,4 @@ func (opt *startOptions) getInputs() error {
 	}
 
 	return nil
-}
-
-func createPipelineResource(resType v1alpha1.PipelineResourceType, askOpt survey.AskOpt, p cli.Params, s *cli.Stream) (*v1alpha1.PipelineResource, error) {
-	res := pipelineresource.Resource{
-		AskOpts: askOpt,
-		Params:  p,
-		PipelineResource: v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace()},
-			Spec:       v1alpha1.PipelineResourceSpec{Type: resType},
-		}}
-
-	if err := res.AskMeta(); err != nil {
-		return nil, err
-	}
-
-	resourceTypeParams := map[v1alpha1.PipelineResourceType]func() error{
-		v1alpha1.PipelineResourceTypeGit:         res.AskGitParams,
-		v1alpha1.PipelineResourceTypeStorage:     res.AskStorageParams,
-		v1alpha1.PipelineResourceTypeImage:       res.AskImageParams,
-		v1alpha1.PipelineResourceTypePullRequest: res.AskPullRequestParams,
-	}
-	if res.PipelineResource.Spec.Type != "" {
-		if err := resourceTypeParams[res.PipelineResource.Spec.Type](); err != nil {
-			return nil, err
-		}
-	}
-	cs, err := p.Clients()
-	if err != nil {
-		return nil, err
-	}
-	newRes, err := cs.Resource.TektonV1alpha1().PipelineResources(p.Namespace()).Create(context.Background(), &res.PipelineResource, metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-	fmt.Fprintf(s.Out, "New %s resource \"%s\" has been created\n", newRes.Spec.Type, newRes.Name)
-	return newRes, nil
 }

--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -127,30 +127,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
 			},
 			Spec: v1beta1.TaskSpec{
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "myarg",
@@ -187,24 +163,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
 			},
 			Spec: v1beta1.TaskSpec{
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "myarg",
@@ -229,30 +187,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 				CreationTimestamp: metav1.Time{Time: clock.Now().Add(-1 * time.Minute)},
 			},
 			Spec: v1beta1.TaskSpec{
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "myarg",
@@ -332,28 +266,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 					{
 						Name:  "print",
 						Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"booms", "booms", "booms"}},
-					},
-				},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "my-repo",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "git",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "code-image",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
 					},
 				},
 				ServiceAccountName: "svc",
@@ -521,12 +433,9 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Start clustertask",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-p", "myarg=value1",
 				"-p", "print=boom,boom",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,claimName=pvc3",
 				"-s=svc1"},
 			dynamic:     seeds[0].dynamicClient,
@@ -534,9 +443,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want: "Command \"start\" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.\n" +
-				"Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon\n" +
-				"Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon\n" +
-				"Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon\n" +
 				"TaskRun started: taskrun-1\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-1 -f -n ns\n",
 		},
 		{
@@ -560,48 +466,11 @@ func Test_ClusterTask_Start(t *testing.T) {
 				"TaskRun started: taskrun-4\n\nIn order to track the TaskRun progress run:\ntkn taskrun logs taskrun-4 -f -n ns\n",
 		},
 		{
-			name: "Invalid input format",
-			command: []string{"start", "clustertask-1",
-				"-i", "my-repo git",
-				"-i", "my-image=image",
-				"-p", "myarg=value1",
-				"-p", "print=boom,boom",
-				"-l", "key=value",
-				"-o", "code-image=output-image",
-				"-w", "name=test,claimName=pvc3",
-				"-s=svc1"},
-			dynamic:     seeds[0].dynamicClient,
-			input:       seeds[0].pipelineClient,
-			inputStream: nil,
-			wantError:   true,
-			want:        "invalid input format for resource parameter: my-repo git",
-		},
-		{
-			name: "Invalid output format",
-			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
-				"-p", "myarg=value1",
-				"-p", "print=boom,boom",
-				"-l", "key=value",
-				"-o", "code-image output-image",
-				"-w", "name=test,claimName=pvc3",
-				"-s=svc1"},
-			dynamic:     seeds[0].dynamicClient,
-			input:       seeds[0].pipelineClient,
-			inputStream: nil,
-			wantError:   true,
-			want:        "invalid input format for resource parameter: code-image output-image",
-		},
-		{
 			name: "Invalid param format",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-p", "myarg value1",
 				"-p", "print=boom,boom",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,claimName=pvc3",
 				"-s=svc1"},
 			dynamic:     seeds[0].dynamicClient,
@@ -613,12 +482,9 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Invalid label format",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-p", "myarg=value1",
 				"-p", "print=boom,boom",
 				"-l", "key value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,claimName=pvc3",
 				"-s=svc1"},
 			dynamic:     seeds[0].dynamicClient,
@@ -630,13 +496,10 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Param not in spec",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-p", "myar=value1",
 				"-p", "myarg=value1",
 				"-p", "print=boom,boom",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,claimName=pvc3",
 				"-s=svc1"},
 			dynamic:     seeds[0].dynamicClient,
@@ -648,9 +511,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry run with invalid output",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
 				"-p", "myarg=value1",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -665,9 +526,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry run with no output v1beta1",
 			command: []string{"start", "clustertask-2",
-				"-i", "my-repo=git",
 				"-p", "myarg=value1",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -681,8 +540,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry run with --last",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -697,9 +554,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry run with --timeout v1beta1",
 			command: []string{"start", "clustertask-2",
-				"-i", "my-repo=git",
 				"-p", "myarg=value1",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -714,9 +569,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry run with invalid --timeout v1beta1",
 			command: []string{"start", "clustertask-2",
-				"-i", "my-repo=git",
 				"-p", "myarg=value1",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -732,11 +585,9 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry run with PodTemplate",
 			command: []string{"start", "clustertask-2",
-				"-i", "my-repo=git",
 				"-p", "myarg=value1",
 				"-p", "print=boom",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -751,12 +602,9 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry Run with --use-param-defaults and specified params",
 			command: []string{"start", "clustertask-3",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-p", "myarg=value1",
 				"-p", "print=boom",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,emptyDir=",
 				"-s=svc1",
 				"--dry-run",
@@ -770,10 +618,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry Run with --use-param-defaults and no specified params",
 			command: []string{"start", "clustertask-3",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,emptyDir=",
 				"-s=svc1",
 				"--dry-run",
@@ -787,10 +632,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry Run with --use-param-defaults and --last",
 			command: []string{"start", "clustertask-3",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,emptyDir=",
 				"-s=svc1",
 				"--dry-run",
@@ -805,10 +647,7 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry Run with --use-param-defaults and --use-taskrun",
 			command: []string{"start", "clustertask-3",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,emptyDir=",
 				"-s=svc1",
 				"--dry-run",
@@ -823,12 +662,9 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry Run with --prefix-name v1beta1",
 			command: []string{"start", "clustertask-3",
-				"-i", "my-repo=git",
-				"-i", "my-image=image",
 				"-p", "myarg=value1",
 				"-p", "print=boom",
 				"-l", "key=value",
-				"-o", "code-image=output-image",
 				"-w", "name=test,emptyDir=",
 				"-s=svc1",
 				"--dry-run",
@@ -842,8 +678,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 		{
 			name: "Dry Run with --prefix-name and --last v1beta1",
 			command: []string{"start", "clustertask-1",
-				"-i", "my-repo=git",
-				"-o", "code-image=output-image",
 				"-l", "key=value",
 				"-s=svc1",
 				"--dry-run",
@@ -903,92 +737,6 @@ func Test_ClusterTask_Start(t *testing.T) {
 	}
 }
 
-func Test_mergeResource(t *testing.T) {
-	res := []v1beta1.TaskResourceBinding{{
-		PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-			Name: "source",
-			ResourceRef: &v1beta1.PipelineResourceRef{
-				Name: "git",
-			},
-		},
-	}}
-
-	_, err := mergeRes(res, []string{"test"})
-	if err == nil {
-		t.Errorf("Expected error")
-	}
-
-	res, err = mergeRes(res, []string{})
-	if err != nil {
-		t.Errorf("Did not expect error")
-	}
-	test.AssertOutput(t, 1, len(res))
-
-	res, err = mergeRes(res, []string{"image=test-1"})
-	if err != nil {
-		t.Errorf("Did not expect error")
-	}
-	test.AssertOutput(t, 2, len(res))
-
-	res, err = mergeRes(res, []string{"image=test-new", "image-2=test-2"})
-	if err != nil {
-		t.Errorf("Did not expect error")
-	}
-	test.AssertOutput(t, 3, len(res))
-}
-
-func Test_parseRes(t *testing.T) {
-	type args struct {
-		res []string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    map[string]v1beta1.TaskResourceBinding
-		wantErr bool
-	}{{
-		name: "Test_parseRes No Err",
-		args: args{
-			res: []string{"source=git", "image=docker2"},
-		},
-		want: map[string]v1beta1.TaskResourceBinding{"source": {
-			PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-				Name: "source",
-				ResourceRef: &v1beta1.PipelineResourceRef{
-					Name: "git",
-				},
-			},
-		}, "image": {
-			PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-				Name: "image",
-				ResourceRef: &v1beta1.PipelineResourceRef{
-					Name: "docker2",
-				},
-			},
-		}},
-		wantErr: false,
-	}, {
-		name: "Test_parseRes Err",
-		args: args{
-			res: []string{"value1", "value2"},
-		},
-		wantErr: true,
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseRes(tt.args.res)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseRes() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseRes() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_start_use_taskrun_cancelled_status(t *testing.T) {
 	ctasks := []*v1beta1.ClusterTask{
 		{
@@ -996,24 +744,6 @@ func Test_start_use_taskrun_cancelled_status(t *testing.T) {
 				Name: "clustertask",
 			},
 			Spec: v1beta1.TaskSpec{
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "myarg",

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--prefix-name_and_--last_v1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--prefix-name_and_--last_v1beta1.golden
@@ -1,6 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -17,15 +15,6 @@ spec:
     - booms
     - booms
     - booms
-  resources:
-    inputs:
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--prefix-name_v1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--prefix-name_v1beta1.golden
@@ -1,7 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -16,18 +13,6 @@ spec:
   - name: print
     value:
     - boom
-  resources:
-    inputs:
-    - name: my-image
-      resourceRef:
-        name: image
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
@@ -1,7 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -10,18 +7,6 @@ metadata:
   labels:
     key: value
 spec:
-  resources:
-    inputs:
-    - name: my-image
-      resourceRef:
-        name: image
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--use-param-defaults_and_specified_params.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_Run_with_--use-param-defaults_and_specified_params.golden
@@ -1,7 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -16,18 +13,6 @@ spec:
   - name: print
     value:
     - boom
-  resources:
-    inputs:
-    - name: my-image
-      resourceRef:
-        name: image
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_--last.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_--last.golden
@@ -1,6 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -17,15 +15,6 @@ spec:
     - booms
     - booms
     - booms
-  resources:
-    inputs:
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_--timeout_v1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_--timeout_v1beta1.golden
@@ -1,6 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -12,15 +10,6 @@ spec:
   params:
   - name: myarg
     value: value1
-  resources:
-    inputs:
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_PodTemplate.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_PodTemplate.golden
@@ -1,6 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -20,15 +18,6 @@ spec:
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001
-  resources:
-    inputs:
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_no_output_v1beta1.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTask_Start-Dry_run_with_no_output_v1beta1.golden
@@ -1,6 +1,4 @@
 Command "start" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
-Flag --inputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --outputresource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -12,15 +10,6 @@ spec:
   params:
   - name: myarg
     value: value1
-  resources:
-    inputs:
-    - name: my-repo
-      resourceRef:
-        name: git
-    outputs:
-    - name: code-image
-      resourceRef:
-        name: output-image
   serviceAccountName: svc1
   taskRef:
     kind: ClusterTask


### PR DESCRIPTION
As Pipelineresources have been removed in 0.46 pipeline so this patch removes inputresources and outputresources flag in tkn clustertask start command and updates unit test

Closes part of : #1657


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
 This will remove inputresources and outputresources flag in tkn clustertask start command and updates unit test
```
