### PR TITLE
Adapt for changes in TEP-0100

### DIFF
--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -1114,12 +1114,11 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 		prstart      = clockwork.NewFakeClock()
 		ns           = "namespace"
 
-		task1Name         = "output-task"
-		tr1Name           = "output-task-1"
-		tr1StartTime      = prstart.Now().Add(20 * time.Second)
-		tr1CompletionTime = prstart.Now().Add(30 * time.Second)
-		tr1Pod            = "output-task-pod-123456"
-		tr1Step1Name      = "writefile-step"
+		task1Name    = "output-task"
+		tr1Name      = "output-task-1"
+		tr1StartTime = prstart.Now().Add(20 * time.Second)
+		tr1Pod       = "output-task-pod-123456"
+		tr1Step1Name = "writefile-step"
 
 		// these are pipeline tasks for which pipeline has not
 		// scheduled any taskrun
@@ -1235,17 +1234,11 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 					},
 				},
 				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
-						tr1Name: {
+					ChildReferences: []v1beta1.ChildStatusReference{
+						{
+							Name:             tr1Name,
+							TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
 							PipelineTaskName: task1Name,
-							Status: &v1beta1.TaskRunStatus{
-								Status: duckv1.Status{},
-								TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-									StartTime:      &metav1.Time{Time: tr1StartTime},
-									CompletionTime: &metav1.Time{Time: tr1CompletionTime},
-								},
-							},
-							WhenExpressions: nil,
 						},
 					},
 				},
@@ -1377,17 +1370,11 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 					},
 				},
 				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
-						"output-taskrun2": {
+					ChildReferences: []v1beta1.ChildStatusReference{
+						{
+							Name:             "output-taskrun2",
+							TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
 							PipelineTaskName: "output-task2",
-							Status: &v1beta1.TaskRunStatus{
-								Status: duckv1.Status{},
-								TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-									StartTime:      &metav1.Time{Time: tr1StartTime},
-									CompletionTime: &metav1.Time{Time: tr1CompletionTime},
-								},
-							},
-							WhenExpressions: nil,
 						},
 					},
 				},

--- a/test/builder/validate.go
+++ b/test/builder/validate.go
@@ -15,7 +15,6 @@
 package builder
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -68,26 +67,6 @@ func SortResourcesByTypeAndName(pres []v1beta1.PipelineDeclaredResource) []v1bet
 }
 
 // Pipeline Run Describe command
-
-func PipelineRunHasFailed(pr *v1beta1.PipelineRun) string {
-	if len(pr.Status.Conditions) == 0 {
-		return ""
-	}
-
-	if pr.Status.Conditions[0].Status == corev1.ConditionFalse {
-		for _, taskrunStatus := range pr.Status.TaskRuns {
-			if len(taskrunStatus.Status.Conditions) == 0 {
-				continue
-			}
-			if taskrunStatus.Status.Conditions[0].Status == corev1.ConditionFalse {
-				return fmt.Sprintf("%s (%s)", pr.Status.Conditions[0].Message,
-					taskrunStatus.Status.Conditions[0].Message)
-			}
-		}
-		return pr.Status.Conditions[0].Message
-	}
-	return ""
-}
 
 type TaskrunList []tkr
 


### PR DESCRIPTION
# Changes

The `EmbeddedStatus` feature flag was removed in[1], with that the `TaskRuns` field is no longer available in the `v1beta1.PipelineRun`'s `Status`. This adapts the test utilizing that field and allows the upgrade to Tekton Pipeline v0.45.0.

The `PipelineRunHasFailed` function in `test/builder/validate.go` doesn't seem to be used, so I removed it rather than adapting it to use `ChildReferences`.

I've tested this by running `make` with Tekton Pipeline at v0.44.0 and at v0.45.0.

[1] https://github.com/tektoncd/pipeline/pull/6049

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
