### PR TITLE
Remove support for `pullRequest` resource

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -144,7 +144,7 @@ For passing the workspaces via flags:
        storage: 1Gi
 - In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
   but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
-  
+
   driver: secrets-store.csi.k8s.io
   readOnly: true
   volumeAttributes:
@@ -499,10 +499,9 @@ func createPipelineResource(resType v1alpha1.PipelineResourceType, askOpt survey
 	}
 
 	resourceTypeParams := map[v1alpha1.PipelineResourceType]func() error{
-		v1alpha1.PipelineResourceTypeGit:         res.AskGitParams,
-		v1alpha1.PipelineResourceTypeStorage:     res.AskStorageParams,
-		v1alpha1.PipelineResourceTypeImage:       res.AskImageParams,
-		v1alpha1.PipelineResourceTypePullRequest: res.AskPullRequestParams,
+		v1alpha1.PipelineResourceTypeGit:     res.AskGitParams,
+		v1alpha1.PipelineResourceTypeStorage: res.AskStorageParams,
+		v1alpha1.PipelineResourceTypeImage:   res.AskImageParams,
 	}
 	if res.PipelineResource.Spec.Type != "" {
 		if err := resourceTypeParams[res.PipelineResource.Spec.Type](); err != nil {

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -137,7 +137,7 @@ For passing the workspaces via flags:
        storage: 1Gi
 - In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
   but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
-  
+
   driver: secrets-store.csi.k8s.io
   readOnly: true
   volumeAttributes:
@@ -757,10 +757,9 @@ func (opt *startOptions) createPipelineResource(resName string, resType v1alpha1
 	}
 
 	resourceTypeParams := map[v1alpha1.PipelineResourceType]func() error{
-		v1alpha1.PipelineResourceTypeGit:         res.AskGitParams,
-		v1alpha1.PipelineResourceTypeStorage:     res.AskStorageParams,
-		v1alpha1.PipelineResourceTypeImage:       res.AskImageParams,
-		v1alpha1.PipelineResourceTypePullRequest: res.AskPullRequestParams,
+		v1alpha1.PipelineResourceTypeGit:     res.AskGitParams,
+		v1alpha1.PipelineResourceTypeStorage: res.AskStorageParams,
+		v1alpha1.PipelineResourceTypeImage:   res.AskImageParams,
 	}
 	if res.PipelineResource.Spec.Type != "" {
 		if err := resourceTypeParams[res.PipelineResource.Spec.Type](); err != nil {

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -1820,60 +1820,6 @@ func TestPipelineStart_Interactive_v1beta1(t *testing.T) {
 		},
 	})
 
-	// With pullRequest resource
-	cs9, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{
-		Pipelines: []*v1beta1.Pipeline{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pullrequestpipeline",
-					Namespace: "ns",
-				},
-				Spec: v1beta1.PipelineSpec{
-					Tasks: []v1beta1.PipelineTask{
-						{
-							Name: "unit-test-1",
-							TaskRef: &v1beta1.TaskRef{
-								Name: "unit-test-task",
-							},
-							Resources: &v1beta1.PipelineTaskResources{
-								Inputs: []v1beta1.PipelineTaskInputResource{
-									{
-										Name:     "pullres",
-										Resource: "pullreqres",
-									},
-								},
-							},
-						},
-					},
-					Resources: []v1beta1.PipelineDeclaredResource{
-						{
-							Name: "pullreqres",
-							Type: v1beta1.PipelineResourceTypePullRequest,
-						},
-					},
-				},
-			},
-		},
-
-		PipelineResources: []*v1alpha1.PipelineResource{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pullreqres",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypePullRequest,
-					Params: []v1alpha1.ResourceParam{
-						{
-							Name:  "url",
-							Value: "https://github.com/tektoncd/cli/pull/1",
-						},
-					},
-				},
-			},
-		},
-	})
-
 	cs12, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{
 		Pipelines: []*v1beta1.Pipeline{
 			{
@@ -1900,8 +1846,8 @@ func TestPipelineStart_Interactive_v1beta1(t *testing.T) {
 					},
 					Resources: []v1beta1.PipelineDeclaredResource{
 						{
-							Name: "pullreqres",
-							Type: v1beta1.PipelineResourceTypePullRequest,
+							Name: "git",
+							Type: v1beta1.PipelineResourceTypeGit,
 						},
 					},
 					Workspaces: []v1beta1.PipelineWorkspaceDeclaration{
@@ -2421,99 +2367,6 @@ func TestPipelineStart_Interactive_v1beta1(t *testing.T) {
 					}
 
 					if runs.Items != nil && runs.Items[0].Spec.PipelineRef.Name != "storagepipeline" {
-						return errors.New("pipelinerun not found")
-					}
-
-					c.Close()
-					return nil
-				},
-			},
-		},
-		{
-			name:               "Create new pullRequest resource with existing resource",
-			namespace:          "ns",
-			input:              cs9,
-			last:               false,
-			serviceAccountName: "svc1",
-			serviceAccounts:    []string{"task1=svc1"},
-			prompt: prompt.Prompt{
-				CmdArgs: []string{"pullrequestpipeline"},
-				Procedure: func(c *expect.Console) error {
-					if _, err := c.ExpectString("Choose the pullRequest resource to use for pullreqres"); err != nil {
-						return err
-					}
-
-					if _, err := c.Send(string(terminal.KeyArrowDown)); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("create new \"pullRequest\" resource"); err != nil {
-						return err
-					}
-
-					if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("Enter a name for a pipeline resource :"); err != nil {
-						return err
-					}
-
-					if _, err := c.SendLine("newpullreq"); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("Enter a value for url :"); err != nil {
-						return err
-					}
-
-					if _, err := c.SendLine("https://github.com/tektoncd/cli/pull/1"); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("Do you want to set secrets ?"); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("Yes"); err != nil {
-						return err
-					}
-
-					if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("Secret Key for githubToken"); err != nil {
-						return err
-					}
-
-					if _, err := c.SendLine("githubToken"); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectString("Secret Name for githubToken "); err != nil {
-						return err
-					}
-
-					if _, err := c.SendLine("githubTokenName"); err != nil {
-						return err
-					}
-
-					if _, err := c.Send(string(terminal.KeyEnter)); err != nil {
-						return err
-					}
-
-					if _, err := c.ExpectEOF(); err != nil {
-						return err
-					}
-
-					tekton := cs9.Pipeline.TektonV1beta1()
-					runs, err := tekton.PipelineRuns("ns").List(context.Background(), metav1.ListOptions{})
-					if err != nil {
-						return err
-					}
-
-					if runs.Items != nil && runs.Items[0].Spec.PipelineRef.Name != "pullrequestpipeline" {
 						return errors.New("pipelinerun not found")
 					}
 

--- a/pkg/cmd/pipeline/start_v1_test.go
+++ b/pkg/cmd/pipeline/start_v1_test.go
@@ -2805,21 +2805,6 @@ func Test_getPipelineResourceByFormat(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "scaffold-pull",
-				Namespace: "ns",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypePullRequest,
-				Params: []v1alpha1.ResourceParam{
-					{
-						Name:  "url",
-						Value: "https://github.com/tektoncd/cli/pulls/9",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
 				Name:      "scaffold-storage",
 				Namespace: "ns",
 			},
@@ -2857,12 +2842,6 @@ func Test_getPipelineResourceByFormat(t *testing.T) {
 	expected = []string{"scaffold-image (docker.io/tektoncd/cli)"}
 	if !reflect.DeepEqual(output, expected) {
 		t.Errorf("output image = %v, want %v", output, expected)
-	}
-
-	output = getOptionsByType(resFormat, "pullRequest")
-	expected = []string{"scaffold-pull (https://github.com/tektoncd/cli/pulls/9)"}
-	if !reflect.DeepEqual(output, expected) {
-		t.Errorf("output pullRequest = %v, want %v", output, expected)
 	}
 
 	output = getOptionsByType(resFormat, "storage")

--- a/pkg/cmd/pipelineresource/create.go
+++ b/pkg/cmd/pipelineresource/create.go
@@ -93,10 +93,9 @@ func (res *Resource) createInteractive() error {
 	}
 
 	resourceTypeParams := map[v1alpha1.PipelineResourceType]func() error{
-		v1alpha1.PipelineResourceTypeGit:         res.AskGitParams,
-		v1alpha1.PipelineResourceTypeStorage:     res.AskStorageParams,
-		v1alpha1.PipelineResourceTypeImage:       res.AskImageParams,
-		v1alpha1.PipelineResourceTypePullRequest: res.AskPullRequestParams,
+		v1alpha1.PipelineResourceTypeGit:     res.AskGitParams,
+		v1alpha1.PipelineResourceTypeStorage: res.AskStorageParams,
+		v1alpha1.PipelineResourceTypeImage:   res.AskImageParams,
 	}
 	if res.PipelineResource.Spec.Type != "" {
 		if err := resourceTypeParams[res.PipelineResource.Spec.Type](); err != nil {
@@ -255,36 +254,6 @@ func (res *Resource) AskImageParams() error {
 	if digestParam.Name != "" {
 		res.PipelineResource.Spec.Params = append(res.PipelineResource.Spec.Params, digestParam)
 	}
-
-	return nil
-}
-
-func (res *Resource) AskPullRequestParams() error {
-	urlParam, err := askParam("url", res.AskOpts)
-	if err != nil {
-		return err
-	}
-	if urlParam.Name != "" {
-		res.PipelineResource.Spec.Params = append(res.PipelineResource.Spec.Params, urlParam)
-	}
-
-	// ask for the secrets
-	qsOpts := []string{"Yes", "No"}
-	qs := "Do you want to set secrets ?"
-
-	ans, e := askToSelect(qs, qsOpts, res.AskOpts)
-	if e != nil {
-		return e
-	}
-	if ans == qsOpts[1] {
-		return nil
-	}
-
-	secret, err := askSecret("githubToken", res.AskOpts)
-	if err != nil {
-		return err
-	}
-	res.PipelineResource.Spec.SecretParams = append(res.PipelineResource.Spec.SecretParams, secret)
 
 	return nil
 }

--- a/pkg/cmd/task/start.go
+++ b/pkg/cmd/task/start.go
@@ -152,7 +152,7 @@ For passing the workspaces via flags:
        storage: 1Gi
 - In case of binding a CSI workspace, you can pass it like -w name=my-csi,csiFile=csi.yaml
   but you need to create a csi.yaml file before hand. Sample contents of the file are as follows:
-  
+
   driver: secrets-store.csi.k8s.io
   readOnly: true
   volumeAttributes:
@@ -583,10 +583,9 @@ func createPipelineResource(resType v1alpha1.PipelineResourceType, askOpt survey
 	}
 
 	resourceTypeParams := map[v1alpha1.PipelineResourceType]func() error{
-		v1alpha1.PipelineResourceTypeGit:         res.AskGitParams,
-		v1alpha1.PipelineResourceTypeStorage:     res.AskStorageParams,
-		v1alpha1.PipelineResourceTypeImage:       res.AskImageParams,
-		v1alpha1.PipelineResourceTypePullRequest: res.AskPullRequestParams,
+		v1alpha1.PipelineResourceTypeGit:     res.AskGitParams,
+		v1alpha1.PipelineResourceTypeStorage: res.AskStorageParams,
+		v1alpha1.PipelineResourceTypeImage:   res.AskImageParams,
 	}
 	if res.PipelineResource.Spec.Type != "" {
 		if err := resourceTypeParams[res.PipelineResource.Spec.Type](); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tekton Pipeline in v0.45.0 removed support for the `pullRequest`[1] resource. In accordance with TEP-74[2]. This removes support for it in the CLI as well.

An alternative might be to redeclare in CLI or restore the `v1alpha1.PipelineResourceTypePullRequest` constant in Tekton Pipeline. Please let me know if you'd like to take this approach.

I've tested this by running `make` with Tekton Pipeline at v0.44.0 and at v0.45.0.

With this and PR#1985[3] it should be possible to upgrade to Tekton Pipeline to v0.45.0.

[1] https://github.com/tektoncd/pipeline/pull/6011
[2] https://github.com/tektoncd/community/blob/main/teps/0074-deprecate-pipelineresources.md
[3] https://github.com/tektoncd/cli/pull/1985

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
release-note
action required: Pull request pipeline resource is no longer supported, please refer to the migration documentation at https://github.com/tektoncd/pipeline/blob/main/docs/pipelineresources.md#replacing-an-pullrequest-resource
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
