### PR TITLE
Remove PipelineResource support in pipeline

### DIFF
--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_using_--filename_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_using_--filename_v1beta1.golden
@@ -1,5 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -8,11 +6,6 @@ metadata:
   namespace: ns
 spec:
   pipelineSpec:
-    resources:
-    - name: source-repo
-      type: git
-    - name: web-image
-      type: image
     tasks:
     - name: build-skaffold-web
       params:
@@ -20,13 +13,6 @@ spec:
         value: Dockerfile
       - name: pathToContext
         value: /workspace/docker-source/examples/microservices/leeroy-web
-      resources:
-        inputs:
-        - name: docker-source
-          resource: source-repo
-        outputs:
-        - name: builtImage
-          resource: web-image
       taskRef:
         name: build-docker-image-from-git-source
     - name: deploy-web
@@ -35,21 +21,6 @@ spec:
         value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml
       - name: yamlPathToImage
         value: spec.template.spec.containers[0].image
-      resources:
-        inputs:
-        - name: source
-          resource: source-repo
-        - from:
-          - build-skaffold-web
-          name: image
-          resource: web-image
       taskRef:
         name: deploy-using-kubectl
-  resources:
-  - name: source-repo
-    resourceRef:
-      name: scaffold-git
-  - name: web-image
-    resourceRef:
-      name: imageres
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--pipeline-timeout,_--tasks-timeout,_--finally-timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--pipeline-timeout,_--tasks-timeout,_--finally-timeout_specified.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -15,10 +14,6 @@ spec:
     value: value2
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
   timeouts:
     finally: 1s

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--pipeline-timeout,_--tasks-timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--pipeline-timeout,_--tasks-timeout_specified.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -15,10 +14,6 @@ spec:
     value: value2
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
   timeouts:
     pipeline: 2s

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--pipeline-timeout_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--pipeline-timeout_specified.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -15,10 +14,6 @@ spec:
     value: value2
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
   timeouts:
     pipeline: 1s

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--timeout_specified_(deprecated).golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--timeout_specified_(deprecated).golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 Flag --timeout has been deprecated, please use --pipeline-timeout flag instead
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -16,10 +15,6 @@ spec:
     value: value2
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
   timeout: 1s
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -10,9 +9,5 @@ metadata:
 spec:
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--use-param-defaults_and_specified_params.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_--use-param-defaults_and_specified_params.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -13,9 +12,5 @@ spec:
     value: value1
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_PodTemplate.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_PodTemplate.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -20,9 +19,5 @@ spec:
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_only_--dry-run_specified.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -15,9 +14,5 @@ spec:
     value: value2
   pipelineRef:
     name: test-pipeline
-  resources:
-  - name: source
-    resourceRef:
-      name: scaffold-git
   serviceAccountName: svc1
 status: {}

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_output=json.golden
@@ -1,4 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 {
 	"kind": "PipelineRun",
 	"apiVersion": "tekton.dev/v1beta1",
@@ -14,14 +13,6 @@ Flag --resource has been deprecated, pipelineresources have been deprecated, thi
 		"pipelineRef": {
 			"name": "test-pipeline"
 		},
-		"resources": [
-			{
-				"name": "source",
-				"resourceRef": {
-					"name": "scaffold-git"
-				}
-			}
-		],
 		"params": [
 			{
 				"name": "pipeline-param",

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_output=json_-f_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_output=json_-f_v1beta1.golden
@@ -1,5 +1,3 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 {
 	"kind": "PipelineRun",
 	"apiVersion": "tekton.dev/v1beta1",
@@ -10,35 +8,11 @@ Flag --resource has been deprecated, pipelineresources have been deprecated, thi
 	},
 	"spec": {
 		"pipelineSpec": {
-			"resources": [
-				{
-					"name": "source-repo",
-					"type": "git"
-				},
-				{
-					"name": "web-image",
-					"type": "image"
-				}
-			],
 			"tasks": [
 				{
 					"name": "build-skaffold-web",
 					"taskRef": {
 						"name": "build-docker-image-from-git-source"
-					},
-					"resources": {
-						"inputs": [
-							{
-								"name": "docker-source",
-								"resource": "source-repo"
-							}
-						],
-						"outputs": [
-							{
-								"name": "builtImage",
-								"resource": "web-image"
-							}
-						]
 					},
 					"params": [
 						{
@@ -56,21 +30,6 @@ Flag --resource has been deprecated, pipelineresources have been deprecated, thi
 					"taskRef": {
 						"name": "deploy-using-kubectl"
 					},
-					"resources": {
-						"inputs": [
-							{
-								"name": "source",
-								"resource": "source-repo"
-							},
-							{
-								"name": "image",
-								"resource": "web-image",
-								"from": [
-									"build-skaffold-web"
-								]
-							}
-						]
-					},
 					"params": [
 						{
 							"name": "path",
@@ -84,20 +43,6 @@ Flag --resource has been deprecated, pipelineresources have been deprecated, thi
 				}
 			]
 		},
-		"resources": [
-			{
-				"name": "source-repo",
-				"resourceRef": {
-					"name": "scaffold-git"
-				}
-			},
-			{
-				"name": "web-image",
-				"resourceRef": {
-					"name": "imageres"
-				}
-			}
-		],
 		"params": [
 			{
 				"name": "pipeline-param",

--- a/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_output=name.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineStart_ExecuteCommand_v1beta1-Dry_Run_with_output=name.golden
@@ -1,2 +1,1 @@
-Flag --resource has been deprecated, pipelineresources have been deprecated, this flag will be removed soon
 

--- a/pkg/cmd/pipeline/testdata/pipeline-invalid.yaml
+++ b/pkg/cmd/pipeline/testdata/pipeline-invalid.yaml
@@ -17,11 +17,6 @@ kind: Pipeline
 metadata:
   name: test-pipeline
 spec:
-  resources:
-    - name: source-repo
-      type: git
-    - name: web-image
-      type: image
   tasks:
     - name: build-skaffold-web
       taskRef:
@@ -33,24 +28,9 @@ spec:
           value: Dockerfile
         - name: pathToContext
           value: /workspace/docker-source/examples/microservices/leeroy-web
-      resources:
-        inputs:
-          - name: docker-source
-            resource: source-repo
-        outputs:
-          - name: builtImage
-            resource: web-image
     - name: deploy-web
       taskRef:
         name: deploy-using-kubectl
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
-          - name: image
-            resource: web-image
-            from:
-              - build-skaffold-web
       params:
         - name: path
           value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml

--- a/pkg/cmd/pipeline/testdata/pipeline-parameter-with-invalid-type.yaml
+++ b/pkg/cmd/pipeline/testdata/pipeline-parameter-with-invalid-type.yaml
@@ -19,11 +19,6 @@ metadata:
 spec:
   params:
     - name: test-param
-  resources:
-    - name: source-repo
-      type: git
-    - name: web-image
-      type: image
   tasks:
     - name: build-skaffold-web
       taskRef:
@@ -33,24 +28,9 @@ spec:
           value: Dockerfile
         - name: pathToContext
           value: /workspace/docker-source/examples/microservices/leeroy-web
-      resources:
-        inputs:
-          - name: docker-source
-            resource: source-repo
-        outputs:
-          - name: builtImage
-            resource: web-image
     - name: deploy-web
       taskRef:
         name: deploy-using-kubectl
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
-          - name: image
-            resource: web-image
-            from:
-              - build-skaffold-web
       params:
         - name: path
           value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml

--- a/pkg/cmd/pipeline/testdata/pipeline.yaml
+++ b/pkg/cmd/pipeline/testdata/pipeline.yaml
@@ -17,11 +17,6 @@ kind: Pipeline
 metadata:
   name: test-pipeline
 spec:
-  resources:
-    - name: source-repo
-      type: git
-    - name: web-image
-      type: image
   tasks:
     - name: build-skaffold-web
       taskRef:
@@ -31,24 +26,9 @@ spec:
           value: Dockerfile
         - name: pathToContext
           value: /workspace/docker-source/examples/microservices/leeroy-web
-      resources:
-        inputs:
-          - name: docker-source
-            resource: source-repo
-        outputs:
-          - name: builtImage
-            resource: web-image
     - name: deploy-web
       taskRef:
         name: deploy-using-kubectl
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
-          - name: image
-            resource: web-image
-            from:
-              - build-skaffold-web
       params:
         - name: path
           value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml


### PR DESCRIPTION
As Pipelineresources have been removed in 0.46 pipeline so this patch removes resource support in tkn pipeline start command and updates unit test

Closes part of : #1657 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
This  will remove resource support in tkn pipeline start command and updates unit test
```