### PR TITLE
Use own FakeClock func instead of from library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ $(BIN)/golangci-lint: ; $(info $(M) getting golangci-lint $(GOLANGCI_VERSION))
 .PHONY: lint-go
 lint-go: | $(GOLANGCILINT) ; $(info $(M) running golangci-lint…) @ ## Run golangci-lint
 	$Q $(GOLANGCILINT) run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --deadline 5m
+	@rm -f $(GOLANGCILINT)
 
 GOIMPORTS = $(BIN)/goimports
 $(BIN)/goimports: PACKAGE=golang.org/x/tools/cmd/goimports

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hinshun/vt10x v0.0.0-20220228203356-1ab2cad5fd82
-	github.com/jonboulle/clockwork v0.3.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/ktr0731/go-fuzzyfinder v0.7.0
 	github.com/letsencrypt/boulder v0.0.0-20221109233200-85aa52084eaf
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1921,8 +1921,9 @@ github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwA
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
 github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/txtarfs v0.0.0-20210218200122-0702f000015a/go.mod h1:izVPOvVRsHiKkeGCT6tYBNWyDVuzj9wAaBb5R9qamfw=

--- a/pkg/clustertask/clustertask_test.go
+++ b/pkg/clustertask/clustertask_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
@@ -31,7 +30,7 @@ import (
 
 func TestClusterTask_GetAllTaskNames(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	ctdata := []*v1beta1.ClusterTask{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -125,7 +124,7 @@ func TestClusterTask_GetAllTaskNames(t *testing.T) {
 
 func TestClusterTask_List(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	ctdata := []*v1beta1.ClusterTask{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -218,7 +217,7 @@ func TestClusterTask_List(t *testing.T) {
 
 func TestClusterTask_Get(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	ctdata := []*v1beta1.ClusterTask{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -260,7 +259,7 @@ func TestClusterTask_Get(t *testing.T) {
 
 func TestClusterTask_Create(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	ctdata := []*v1beta1.ClusterTask{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/clustertriggerbinding/clustertriggerbinding_test.go
+++ b/pkg/clustertriggerbinding/clustertriggerbinding_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestTrigger_GetAllClusterTriggerBinding(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ctb := []*v1beta1.ClusterTriggerBinding{
 		{
@@ -112,7 +111,7 @@ func TestTrigger_GetAllClusterTriggerBinding(t *testing.T) {
 }
 
 func TestClusterTriggerBinding_List(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ctb := []*v1beta1.ClusterTriggerBinding{
 		{
@@ -201,7 +200,7 @@ func TestClusterTriggerBinding_List(t *testing.T) {
 }
 
 func TestClusterTriggerBinding_Get(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ctb := []*v1beta1.ClusterTriggerBinding{
 		{

--- a/pkg/cmd/clustertask/delete_test.go
+++ b/pkg/cmd/clustertask/delete_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -34,7 +33,7 @@ import (
 
 func TestClusterTaskDelete(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskCreated := clock.Now().Add(-1 * time.Minute)
 
 	type clients struct {

--- a/pkg/cmd/clustertask/describe_test.go
+++ b/pkg/cmd/clustertask/describe_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -37,7 +36,7 @@ import (
 )
 
 func Test_ClusterTaskDescribe(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	clustertasks := []*v1beta1.ClusterTask{
 		{
@@ -483,7 +482,7 @@ func TestClusterTask_custom_output(t *testing.T) {
 	name := "clustertask"
 	expected := "Command \"describe\" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.\nclustertask.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	cstasks := []*v1beta1.ClusterTask{
 		{
@@ -531,7 +530,7 @@ func TestClusterTaskV1beta1_custom_output(t *testing.T) {
 	name := "clustertask"
 	expected := "Command \"describe\" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.\nclustertask.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	cstasks := []*v1beta1.ClusterTask{
 		{
@@ -574,7 +573,7 @@ func TestClusterTaskV1beta1_custom_output(t *testing.T) {
 }
 
 func TestClusterTaskDescribe_With_Results(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	clustertasks := []*v1beta1.ClusterTask{
 		{
@@ -628,7 +627,7 @@ func TestClusterTaskDescribe_With_Results(t *testing.T) {
 }
 
 func TestClusterTaskDescribe_With_Workspaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	clustertasks := []*v1beta1.ClusterTask{
 		{

--- a/pkg/cmd/clustertask/list_test.go
+++ b/pkg/cmd/clustertask/list_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -50,7 +49,7 @@ func TestClusterTaskList_Empty(t *testing.T) {
 }
 
 func TestClusterTaskListOnlyClusterTasksv1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	clustertasks := []*v1beta1.ClusterTask{
 		{
@@ -120,7 +119,7 @@ func TestClusterTaskListOnlyClusterTasksv1beta1(t *testing.T) {
 }
 
 func TestClusterTaskListNoHeadersv1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	clustertasks := []*v1beta1.ClusterTask{
 		{

--- a/pkg/cmd/clustertask/logs_test.go
+++ b/pkg/cmd/clustertask/logs_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
@@ -38,7 +37,7 @@ func init() {
 }
 
 func TestClusterTaskLog(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	clustertask1 := []*v1beta1.ClusterTask{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -128,7 +127,7 @@ func TestClusterTaskLog(t *testing.T) {
 func TestLogs_Auto_Select_FirstClusterTask(t *testing.T) {
 	taskName := "dummyTask"
 	ns := "dummyNamespaces"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ctdata := []*v1beta1.ClusterTask{
 		{

--- a/pkg/cmd/clustertask/start_test.go
+++ b/pkg/cmd/clustertask/start_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
@@ -114,7 +113,7 @@ func newDynamicClientOpt(version, taskRunName string, objs ...runtime.Object) te
 }
 
 func Test_ClusterTask_Start(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	type clients struct {
 		pipelineClient pipelinev1beta1test.Clients
 		dynamicClient  dynamic.Interface

--- a/pkg/cmd/pipeline/delete_test.go
+++ b/pkg/cmd/pipeline/delete_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -35,7 +34,7 @@ import (
 
 func TestPipelineDelete_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1beta1.Pipeline{
 		{
@@ -351,7 +350,7 @@ func TestPipelineDelete_v1beta1(t *testing.T) {
 
 func TestPipelineDelete(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1.Pipeline{
 		{

--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -76,7 +75,7 @@ func TestPipelineDescribe_invalid_pipeline(t *testing.T) {
 }
 
 func TestPipelineDescribe_empty(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelines := []*v1.Pipeline{
 		{
@@ -118,7 +117,7 @@ func TestPipelineDescribe_empty(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -197,7 +196,7 @@ func TestPipelineDescribe_with_run_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_spec_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelines := []*v1beta1.Pipeline{
 		{
@@ -294,7 +293,7 @@ func TestPipelineDescribe_with_spec_run_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_spec_resource_param_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -407,7 +406,7 @@ func TestPipelineDescribe_with_spec_resource_param_run_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_multiple_pipelineruns_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 
 		{
@@ -576,7 +575,7 @@ func TestPipelineDescribe_with_multiple_pipelineruns_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_taskSpec_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -627,7 +626,7 @@ func TestPipelineDescribe_with_taskSpec_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -770,7 +769,7 @@ func TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1(t *testi
 }
 
 func TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -913,7 +912,7 @@ func TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1(t
 }
 
 func TestPipelineDescribe_custom_output_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -963,7 +962,7 @@ func TestPipelineDescribe_custom_output_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1024,7 +1023,7 @@ func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1(t *testing
 }
 
 func TestPipelineDescribe_with_results_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1109,7 +1108,7 @@ func TestPipelineDescribe_with_results_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_workspaces_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1242,7 +1241,7 @@ func TestPipelineDescribe_with_annotations_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_OptionalWorkspaces_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1338,7 +1337,7 @@ func TestPipelineDescribe_with_OptionalWorkspaces_v1beta1(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelines := []*v1.Pipeline{
 		{
@@ -1417,7 +1416,7 @@ func TestPipelineDescribe_with_run(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_spec_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelines := []*v1.Pipeline{
 		{
@@ -1514,7 +1513,7 @@ func TestPipelineDescribe_with_spec_run(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_multiple_pipelineruns(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 
 		{
@@ -1677,7 +1676,7 @@ func TestPipelineDescribe_with_multiple_pipelineruns(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_taskSpec(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1728,7 +1727,7 @@ func TestPipelineDescribe_with_taskSpec(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_spec_multiple_param_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1849,7 +1848,7 @@ func TestPipelineDescribe_with_spec_multiple_param_run(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_spec_multiple_param_run_output(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1970,7 +1969,7 @@ func TestPipelineDescribe_with_spec_multiple_param_run_output(t *testing.T) {
 }
 
 func TestPipelineDescribe_custom_output(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2059,7 +2058,7 @@ func TestPipelineDescribe_custom_output(t *testing.T) {
 }
 
 func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2114,7 +2113,7 @@ func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_results(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2193,7 +2192,7 @@ func TestPipelineDescribe_with_results(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_workspaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2320,7 +2319,7 @@ func TestPipelineDescribe_with_annotations(t *testing.T) {
 }
 
 func TestPipelineDescribe_with_OptionalWorkspaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/pipeline/export_test.go
+++ b/pkg/cmd/pipeline/export_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestPipelineExport_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -133,7 +132,7 @@ func TestPipelineExport_v1beta1(t *testing.T) {
 }
 
 func TestPipelineExport(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelines := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/pipeline/list_test.go
+++ b/pkg/cmd/pipeline/list_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -86,7 +85,7 @@ func TestPipelinesList_empty_v1beta1(t *testing.T) {
 }
 
 func TestPipelineList_only_pipelines_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1beta1"
 
 	pdata := []*v1beta1.Pipeline{
@@ -144,7 +143,7 @@ func TestPipelineList_only_pipelines_v1beta1(t *testing.T) {
 }
 
 func TestPipelineList_only_pipelines_no_headers_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1beta1"
 
 	pdata := []*v1beta1.Pipeline{
@@ -202,7 +201,7 @@ func TestPipelineList_only_pipelines_no_headers_v1beta1(t *testing.T) {
 }
 
 func TestPipelineList_only_pipelines_all_namespaces_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	version := "v1beta1"
 
@@ -280,7 +279,7 @@ func TestPipelineList_only_pipelines_all_namespaces_v1beta1(t *testing.T) {
 
 func TestPipelineList_only_pipelines_all_namespaces_no_headers_v1beta1(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1beta1"
 
 	pdata := []*v1beta1.Pipeline{
@@ -356,7 +355,7 @@ func TestPipelineList_only_pipelines_all_namespaces_no_headers_v1beta1(t *testin
 }
 
 func TestPipelinesList_with_single_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1beta1"
 	pdata := []*v1beta1.Pipeline{
 		{
@@ -439,7 +438,7 @@ func TestPipelinesList_with_single_run_v1beta1(t *testing.T) {
 
 func TestPipelinesList_latest_run_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	//  Time --->
 	//  |---5m ---|------------ ││--││------------- ---│--│
 	//	now      pipeline       ││  │`secondRun stated │  `*first*RunCompleted
@@ -616,7 +615,7 @@ func TestPipelinesList_empty(t *testing.T) {
 }
 
 func TestPipelineList_only_pipelines(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1"
 
 	pdata := []*v1.Pipeline{
@@ -674,7 +673,7 @@ func TestPipelineList_only_pipelines(t *testing.T) {
 }
 
 func TestPipelineList_only_pipelines_no_headers(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1"
 
 	pdata := []*v1.Pipeline{
@@ -732,7 +731,7 @@ func TestPipelineList_only_pipelines_no_headers(t *testing.T) {
 }
 
 func TestPipelineList_only_pipelines_all_namespaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	version := "v1"
 
@@ -810,7 +809,7 @@ func TestPipelineList_only_pipelines_all_namespaces(t *testing.T) {
 
 func TestPipelineList_only_pipelines_all_namespaces_no_headers(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1"
 
 	pdata := []*v1.Pipeline{
@@ -886,7 +885,7 @@ func TestPipelineList_only_pipelines_all_namespaces_no_headers(t *testing.T) {
 }
 
 func TestPipelinesList_with_single_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1"
 	pdata := []*v1.Pipeline{
 		{
@@ -969,7 +968,7 @@ func TestPipelinesList_with_single_run(t *testing.T) {
 
 func TestPipelinesList_latest_run(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	//  Time --->
 	//  |---5m ---|------------ ││--││------------- ---│--│
 	//	now      pipeline       ││  │`secondRun stated │  `*first*RunCompleted
@@ -1094,7 +1093,7 @@ func TestPipelinesList_latest_run(t *testing.T) {
 
 func TestPipelineList_in_all_namespaces_with_output_yaml_flag(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1"
 
 	pdata := []*v1.Pipeline{

--- a/pkg/cmd/pipeline/logs_test.go
+++ b/pkg/cmd/pipeline/logs_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	goexpect "github.com/Netflix/go-expect"
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/test"
@@ -56,7 +55,7 @@ const (
 )
 
 func TestPipelineLog_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pdata := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -293,7 +292,7 @@ func TestPipelineLog_v1beta1(t *testing.T) {
 }
 
 func TestPipelineLog(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pdata := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -532,7 +531,7 @@ func TestPipelineLog(t *testing.T) {
 func TestPipelineLog_Interactive_v1beta1(t *testing.T) {
 	t.Skip("Skipping due of flakiness")
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{
 		Pipelines: []*v1beta1.Pipeline{
@@ -934,7 +933,7 @@ func TestPipelineLog_Interactive_v1beta1(t *testing.T) {
 func TestPipelineLog_Interactive(t *testing.T) {
 	t.Skip("Skipping due of flakiness")
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	cs, _ := test.SeedTestData(t, test.Data{
 		Pipelines: []*v1.Pipeline{
@@ -1336,7 +1335,7 @@ func TestPipelineLog_Interactive(t *testing.T) {
 func TestLogs_Auto_Select_FirstPipeline(t *testing.T) {
 	pipelineName := "blahblah"
 	ns := "chouchou"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1beta1.Pipeline{
 		{

--- a/pkg/cmd/pipeline/start_test.go
+++ b/pkg/cmd/pipeline/start_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
 	"github.com/google/go-cmp/cmp"
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/pipeline"
@@ -117,7 +116,7 @@ func newV1beta1PipelineClient(objs ...runtime.Object) (*fakepipelineclientset.Cl
 }
 
 func TestPipelineStart_ExecuteCommand_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	namespaces := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2696,7 +2695,7 @@ func Test_start_pipeline_with_prefix_name_v1beta1(t *testing.T) {
 }
 
 func Test_lastPipelineRun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pr1Started := clock.Now().Add(10 * time.Second)
 	pr2Started := clock.Now().Add(-2 * time.Hour)

--- a/pkg/cmd/pipeline/start_v1_test.go
+++ b/pkg/cmd/pipeline/start_v1_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
 	"github.com/google/go-cmp/cmp"
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/pipeline"
@@ -116,7 +115,7 @@ func newPipelineClient(objs ...runtime.Object) (*fakepipelineclientset.Clientset
 }
 
 func TestPipelineStart_ExecuteCommand(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	namespaces := []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2748,7 +2747,7 @@ func Test_parseTaskSvc(t *testing.T) {
 }
 
 func Test_lastPipelineRun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pr1Started := clock.Now().Add(10 * time.Second)
 	pr2Started := clock.Now().Add(-2 * time.Hour)

--- a/pkg/cmd/pipelineresource/describe_test.go
+++ b/pkg/cmd/pipelineresource/describe_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	pipelinetest "github.com/tektoncd/pipeline/test"
@@ -157,7 +156,7 @@ func TestPipelineResourcesDescribe_custom_output(t *testing.T) {
 	name := "pipeline-resource"
 	expected := "Command \"describe\" is deprecated, PipelineResource commands are deprecated, they will be removed soon as it get removed from API.\npipelineresource.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	prs := []*v1alpha1.PipelineResource{
 		{

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -36,7 +35,7 @@ import (
 func TestPipelineRunDelete_v1beta1(t *testing.T) {
 
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{
@@ -659,7 +658,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 
 func TestPipelineRunDelete(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -63,7 +62,7 @@ func TestPipelineRunDescribe_not_found_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_only_taskrun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -161,7 +160,7 @@ func TestPipelineRunDescribe_only_taskrun_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_multiple_taskrun_ordering_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -288,7 +287,7 @@ func TestPipelineRunDescribe_multiple_taskrun_ordering_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_multiple_taskrun_without_status_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -401,7 +400,7 @@ func TestPipelineRunDescribe_multiple_taskrun_without_status_v1beta1(t *testing.
 }
 
 func TestPipelineRunDescribe_failed_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -532,7 +531,7 @@ func TestPipelineRunDescribe_last_no_PipelineRun_present_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_failed_withoutTRCondition_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -624,7 +623,7 @@ func TestPipelineRunDescribe_failed_withoutTRCondition_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_failed_withoutPRCondition_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -707,7 +706,7 @@ func TestPipelineRunDescribe_failed_withoutPRCondition_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_with_resources_taskrun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -823,7 +822,7 @@ func TestPipelineRunDescribe_with_resources_taskrun_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_without_start_time_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelineRuns := []*v1beta1.PipelineRun{
 		{
@@ -872,7 +871,7 @@ func TestPipelineRunDescribe_without_start_time_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_without_pipelineref_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelineRuns := []*v1beta1.PipelineRun{
 		{
@@ -915,7 +914,7 @@ func TestPipelineRunDescribe_without_pipelineref_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelineRuns := []*v1beta1.PipelineRun{
 		{
@@ -958,7 +957,7 @@ func TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent_v1beta1(t *t
 }
 
 func TestPipelineRunDescribe_no_resourceref_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -1071,7 +1070,7 @@ func TestPipelineRunDescribe_no_resourceref_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_cancelled_pipelinerun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -1170,7 +1169,7 @@ func TestPipelineRunDescribe_cancelled_pipelinerun_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_without_tr_start_time_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -1351,7 +1350,7 @@ func TestPipelineRunDescribe_custom_output_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1beta1.TaskRun{
 		{
@@ -1514,7 +1513,7 @@ func TestPipelineRunDescribe_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_taskrun_with_no_status_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1beta1.TaskRun{
 		{
@@ -1663,7 +1662,7 @@ func TestPipelineRunDescribe_taskrun_with_no_status_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_last_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname1 := "pipeline-run"
 	pipelinerunname2 := "pipeline-run2"
 	taskRuns := []*v1beta1.TaskRun{
@@ -1900,7 +1899,7 @@ func TestPipelineRunDescribe_last_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_with_results_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1beta1.TaskRun{
 		{
@@ -2080,7 +2079,7 @@ func TestPipelineRunDescribe_zero_timeout_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_with_workspaces_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1beta1.TaskRun{
 		{
@@ -2232,7 +2231,7 @@ func TestPipelineRunDescribe_with_workspaces_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribeWithSkippedTasks_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1beta1.TaskRun{
 		{
@@ -2427,7 +2426,7 @@ func TestPipelineRunDescribeWithSkippedTasks_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -2558,7 +2557,7 @@ func TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun_v1beta1(t *t
 }
 
 func TestPipelineRunDescribeWithTimeouts_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1beta1.TaskRun{
 		{

--- a/pkg/cmd/pipelinerun/describe_v1_test.go
+++ b/pkg/cmd/pipelinerun/describe_v1_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -83,7 +82,7 @@ func TestPipelineRunDescribe_not_found(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_only_taskrun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -183,7 +182,7 @@ func TestPipelineRunDescribe_only_taskrun(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_multiple_taskrun_ordering(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -312,7 +311,7 @@ func TestPipelineRunDescribe_multiple_taskrun_ordering(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_multiple_taskrun_without_status(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -427,7 +426,7 @@ func TestPipelineRunDescribe_multiple_taskrun_without_status(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_failed(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -562,7 +561,7 @@ func TestPipelineRunDescribe_last_no_PipelineRun_present(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_failed_withoutTRCondition(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -658,7 +657,7 @@ func TestPipelineRunDescribe_failed_withoutTRCondition(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_failed_withoutPRCondition(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -745,7 +744,7 @@ func TestPipelineRunDescribe_failed_withoutPRCondition(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_with_resources_taskrun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -857,7 +856,7 @@ func TestPipelineRunDescribe_with_resources_taskrun(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_without_start_time(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelineRuns := []*v1.PipelineRun{
 		{
@@ -908,7 +907,7 @@ func TestPipelineRunDescribe_without_start_time(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_without_pipelineref(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelineRuns := []*v1.PipelineRun{
 		{
@@ -951,7 +950,7 @@ func TestPipelineRunDescribe_without_pipelineref(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pipelineRuns := []*v1.PipelineRun{
 		{
@@ -994,7 +993,7 @@ func TestPipelineRunDescribe_withoutNameOfOnlyOnePipelineRunPresent(t *testing.T
 }
 
 func TestPipelineRunDescribe_no_resourceref(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1106,7 +1105,7 @@ func TestPipelineRunDescribe_no_resourceref(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_cancelled_pipelinerun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1207,7 +1206,7 @@ func TestPipelineRunDescribe_cancelled_pipelinerun(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_without_tr_start_time(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1390,7 +1389,7 @@ func TestPipelineRunDescribe_custom_output(t *testing.T) {
 }
 
 func TestPipelineRunDescribe(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1.TaskRun{
 		{
@@ -1539,7 +1538,7 @@ func TestPipelineRunDescribe(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_taskrun_with_no_status(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1.TaskRun{
 		{
@@ -1674,7 +1673,7 @@ func TestPipelineRunDescribe_taskrun_with_no_status(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_last(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname1 := "pipeline-run"
 	pipelinerunname2 := "pipeline-run2"
 	taskRuns := []*v1.TaskRun{
@@ -1883,7 +1882,7 @@ func TestPipelineRunDescribe_last(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_with_results(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1.TaskRun{
 		{
@@ -2055,7 +2054,7 @@ func TestPipelineRunDescribe_zero_timeout(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_with_workspaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1.TaskRun{
 		{
@@ -2199,7 +2198,7 @@ func TestPipelineRunDescribe_with_workspaces(t *testing.T) {
 }
 
 func TestPipelineRunDescribeWithSkippedTasks(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1.TaskRun{
 		{
@@ -2380,7 +2379,7 @@ func TestPipelineRunDescribeWithSkippedTasks(t *testing.T) {
 }
 
 func TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -2513,7 +2512,7 @@ func TestPipelineRunDescribe_cancelled_pipelinerun_multiple_taskrun(t *testing.T
 }
 
 func TestPipelineRunDescribeWithTimeouts(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelinerunname := "pipeline-run"
 	taskRuns := []*v1.TaskRun{
 		{

--- a/pkg/cmd/pipelinerun/export_test.go
+++ b/pkg/cmd/pipelinerun/export_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -33,7 +32,7 @@ import (
 )
 
 func TestPipelineRunExport_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelineruns := []*v1beta1.PipelineRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -101,7 +100,7 @@ func TestPipelineRunExport_v1beta1(t *testing.T) {
 }
 
 func TestPipelineRunExport(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pipelineruns := []*v1.PipelineRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/pipelinerun/list_test.go
+++ b/pkg/cmd/pipelinerun/list_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestListPipelineRuns_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	runDuration := 1 * time.Minute
 
 	pr1Started := clock.Now().Add(10 * time.Second)
@@ -285,7 +285,7 @@ func TestListPipelineRuns_v1beta1(t *testing.T) {
 
 func TestListPipelineRuns(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	runDuration := 1 * time.Minute
 
 	pr1Started := clock.Now().Add(10 * time.Second)

--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/pods/fake"
@@ -184,7 +183,7 @@ func TestLog_no_pipelinerun_argument(t *testing.T) {
 }
 
 func TestLog_run_found_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pdata := []*v1beta1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -250,7 +249,7 @@ func TestLog_run_found_v1beta1(t *testing.T) {
 }
 
 func TestLog_run_found(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pdata := []*v1.Pipeline{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -411,7 +410,7 @@ func TestPipelinerunLogs_v1beta1(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"
@@ -752,7 +751,7 @@ func TestPipelinerunLogs(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"
@@ -1111,7 +1110,7 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"
@@ -1296,7 +1295,7 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:         "ns",
 				Name:              "output-task2",
-				CreationTimestamp: metav1.Time{Time: clockwork.NewFakeClock().Now()},
+				CreationTimestamp: metav1.Time{Time: test.FakeClock().Now()},
 			},
 		},
 	}
@@ -1324,7 +1323,7 @@ func TestPipelinerunLog_completed_taskrun_only_v1beta1(t *testing.T) {
 					},
 				},
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now()},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now()},
 					PodName:   "output-task-pod-embedded",
 					Steps: []v1beta1.StepState{
 						{
@@ -1508,7 +1507,7 @@ func TestPipelinerunLog_follow_mode_v1beta1(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"
@@ -1697,7 +1696,7 @@ func TestPipelinerunLog_follow_mode(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"
@@ -3274,7 +3273,7 @@ func TestPipelinerunLog_finally_v1beta1(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"
@@ -3524,7 +3523,7 @@ func TestPipelinerunLog_finally(t *testing.T) {
 	var (
 		pipelineName = "output-pipeline"
 		prName       = "output-pipeline-1"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		ns           = "namespace"
 
 		task1Name    = "output-task"

--- a/pkg/cmd/task/delete_test.go
+++ b/pkg/cmd/task/delete_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -35,7 +34,7 @@ import (
 
 func TestTaskDelete_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskCreated := clock.Now().Add(-1 * time.Minute)
 
 	tdata := []*v1beta1.Task{
@@ -348,7 +347,7 @@ func TestTaskDelete_v1beta1(t *testing.T) {
 
 func TestTaskDelete(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskCreated := clock.Now().Add(-1 * time.Minute)
 
 	tdata := []*v1.Task{

--- a/pkg/cmd/task/describe_test.go
+++ b/pkg/cmd/task/describe_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -539,7 +538,7 @@ func TestTaskDescribe_custom_output_v1beta1(t *testing.T) {
 	name := "task"
 	expected := "task.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1beta1.Task{
 		{
@@ -586,7 +585,7 @@ func TestTaskDescribe_custom_output(t *testing.T) {
 	name := "task"
 	expected := "task.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1.Task{
 		{
@@ -708,7 +707,7 @@ func TestTaskDescribe_WithoutNameIfOnlyOneTaskPresent(t *testing.T) {
 }
 
 func TestTaskDescribe_Full_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -912,7 +911,7 @@ func TestTaskDescribe_Full_v1beta1(t *testing.T) {
 }
 
 func TestTaskDescribe_Full(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tasks := []*v1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -80,7 +79,7 @@ func TestTaskList_Empty_v1beta1(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1beta1.Task{
 		{
@@ -172,7 +171,7 @@ func TestTaskList_Only_Tasks_v1beta1(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1beta1.Task{
 		{
@@ -264,7 +263,7 @@ func TestTaskList_Only_Tasks_no_headers_v1beta1(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_all_namespaces_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1beta1.Task{
 		{
@@ -405,7 +404,7 @@ func TestTaskList_Only_Tasks_all_namespaces_v1beta1(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_all_namespaces_no_headers_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tasks := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -593,7 +592,7 @@ func TestTaskList_Empty(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1.Task{
 		{
@@ -685,7 +684,7 @@ func TestTaskList_Only_Tasks(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_no_headers(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1.Task{
 		{
@@ -777,7 +776,7 @@ func TestTaskList_Only_Tasks_no_headers(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_all_namespaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1.Task{
 		{
@@ -918,7 +917,7 @@ func TestTaskList_Only_Tasks_all_namespaces(t *testing.T) {
 }
 
 func TestTaskList_Only_Tasks_all_namespaces_no_headers(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tasks := []*v1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1058,7 +1057,7 @@ func TestTaskList_Only_Tasks_all_namespaces_no_headers(t *testing.T) {
 }
 
 func TestTaskList_in_all_namespaces_with_output_yaml_flag(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tasks := []*v1.Task{
 		{

--- a/pkg/cmd/task/logs_test.go
+++ b/pkg/cmd/task/logs_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	goexpect "github.com/Netflix/go-expect"
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/options"
 	"github.com/tektoncd/cli/pkg/pods/fake"
@@ -49,7 +48,7 @@ const (
 )
 
 func TestTaskLog_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	task1 := []*v1beta1.Task{
 		{
@@ -185,7 +184,7 @@ func TestTaskLog_v1beta1(t *testing.T) {
 }
 
 func TestTaskLog(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	task1 := []*v1.Task{
 		{
@@ -323,7 +322,7 @@ func TestTaskLog(t *testing.T) {
 func TestTaskLogInteractive_v1beta1(t *testing.T) {
 	t.Skip("Skipping due of flakiness")
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskCreated := clock.Now()
 
 	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{
@@ -795,7 +794,7 @@ func TestTaskLogInteractive_v1beta1(t *testing.T) {
 func TestTaskLogInteractive(t *testing.T) {
 	t.Skip("Skipping due of flakiness")
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskCreated := clock.Now()
 
 	cs, _ := test.SeedTestData(t, test.Data{
@@ -1267,7 +1266,7 @@ func TestTaskLogInteractive(t *testing.T) {
 func TestLogs_Auto_Select_FirstTask_v1beta1(t *testing.T) {
 	taskName := "dummyTask"
 	ns := "dummyNamespaces"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tdata := []*v1beta1.Task{
 		{
@@ -1354,7 +1353,7 @@ func TestLogs_Auto_Select_FirstTask_v1beta1(t *testing.T) {
 func TestLogs_Auto_Select_FirstTask(t *testing.T) {
 	taskName := "dummyTask"
 	ns := "dummyNamespaces"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tdata := []*v1.Task{
 		{

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
@@ -36,7 +35,7 @@ import (
 )
 
 func TestTaskRunDelete_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{
@@ -893,7 +892,7 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDelete(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{
@@ -2222,7 +2221,7 @@ tr0-1   ---       ---        Succeeded
 }
 
 func Test_TaskRuns_Delete_With_Running_PipelineRun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{
@@ -2446,7 +2445,7 @@ func Test_TaskRuns_Delete_With_Running_PipelineRun_v1beta1(t *testing.T) {
 }
 
 func Test_TaskRuns_Delete_With_Running_PipelineRun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{
@@ -2670,7 +2669,7 @@ func Test_TaskRuns_Delete_With_Running_PipelineRun(t *testing.T) {
 }
 
 func Test_TaskRuns_Delete_With_Successful_PipelineRun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	ns := []*corev1.Namespace{
 		{

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -94,7 +93,7 @@ func TestTaskRunDescribe_not_found(t *testing.T) {
 }
 
 func TestTaskRunDescribe_empty_taskrun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -155,7 +154,7 @@ func TestTaskRunDescribe_empty_taskrun_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_only_taskrun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -165,7 +164,7 @@ func TestTaskRunDescribe_only_taskrun_v1beta1(t *testing.T) {
 			},
 			Status: v1beta1.TaskRunStatus{
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1beta1.StepState{
 						{
 							Name: "step1",
@@ -285,7 +284,7 @@ func TestTaskRunDescribe_only_taskrun_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_failed_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -351,7 +350,7 @@ func TestTaskRunDescribe_failed_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_no_taskref_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -444,7 +443,7 @@ func TestTaskRunDescribe_last_no_taskrun_present_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_no_resourceref_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -454,7 +453,7 @@ func TestTaskRunDescribe_no_resourceref_v1beta1(t *testing.T) {
 			},
 			Status: v1beta1.TaskRunStatus{
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1beta1.StepState{
 						{
 							Name: "step1",
@@ -565,7 +564,7 @@ func TestTaskRunDescribe_no_resourceref_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -575,7 +574,7 @@ func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures_v1beta1(t *te
 			},
 			Status: v1beta1.TaskRunStatus{
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1beta1.StepState{
 						{
 							Name: "step1",
@@ -694,7 +693,7 @@ func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures_v1beta1(t *te
 }
 
 func TestTaskRunDescribe_step_status_pending_one_sidecar_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -704,7 +703,7 @@ func TestTaskRunDescribe_step_status_pending_one_sidecar_v1beta1(t *testing.T) {
 			},
 			Status: v1beta1.TaskRunStatus{
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1beta1.StepState{
 						{
 							Name: "step1",
@@ -826,7 +825,7 @@ func TestTaskRunDescribe_step_status_pending_one_sidecar_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_step_status_running_multiple_sidecars_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -836,7 +835,7 @@ func TestTaskRunDescribe_step_status_running_multiple_sidecars_v1beta1(t *testin
 			},
 			Status: v1beta1.TaskRunStatus{
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1beta1.StepState{
 						{
 							Name: "step1",
@@ -966,7 +965,7 @@ func TestTaskRunDescribe_step_status_running_multiple_sidecars_v1beta1(t *testin
 }
 
 func TestTaskRunDescribe_cancel_taskrun_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -1029,7 +1028,7 @@ func TestTaskRunDescribe_custom_output_v1beta1(t *testing.T) {
 	name := "task-run"
 	expected := "taskrun.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1beta1.TaskRun{
 		{
@@ -1122,7 +1121,7 @@ func TestTaskRunDescribe_WithSpec_custom_timeout_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_last_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1beta1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1207,7 +1206,7 @@ func TestTaskRunDescribe_last_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_With_Results_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1beta1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1325,7 +1324,7 @@ func TestTaskRunDescribe_zero_timeout_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_With_Workspaces_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1beta1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1420,7 +1419,7 @@ func TestTaskRunDescribe_With_Workspaces_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_WithoutNameIfOnlyOneTaskRunPresent_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1beta1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1521,7 +1520,7 @@ func TestTaskRunDescribe_with_annotations_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunDescribe_empty_taskrun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1582,7 +1581,7 @@ func TestTaskRunDescribe_empty_taskrun(t *testing.T) {
 }
 
 func TestTaskRunDescribe_only_taskrun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1592,7 +1591,7 @@ func TestTaskRunDescribe_only_taskrun(t *testing.T) {
 			},
 			Status: v1.TaskRunStatus{
 				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1.StepState{
 						{
 							Name: "step1",
@@ -1674,7 +1673,7 @@ func TestTaskRunDescribe_only_taskrun(t *testing.T) {
 }
 
 func TestTaskRunDescribe_failed(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1740,7 +1739,7 @@ func TestTaskRunDescribe_failed(t *testing.T) {
 }
 
 func TestTaskRunDescribe_no_taskref(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1833,7 +1832,7 @@ func TestTaskRunDescribe_last_no_taskrun_present(t *testing.T) {
 }
 
 func TestTaskRunDescribe_no_resourceref(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1843,7 +1842,7 @@ func TestTaskRunDescribe_no_resourceref(t *testing.T) {
 			},
 			Status: v1.TaskRunStatus{
 				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1.StepState{
 						{
 							Name: "step1",
@@ -1925,7 +1924,7 @@ func TestTaskRunDescribe_no_resourceref(t *testing.T) {
 }
 
 func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -1935,7 +1934,7 @@ func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures(t *testing.T)
 			},
 			Status: v1.TaskRunStatus{
 				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1.StepState{
 						{
 							Name: "step1",
@@ -2025,7 +2024,7 @@ func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures(t *testing.T)
 }
 
 func TestTaskRunDescribe_step_status_pending_one_sidecar(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -2035,7 +2034,7 @@ func TestTaskRunDescribe_step_status_pending_one_sidecar(t *testing.T) {
 			},
 			Status: v1.TaskRunStatus{
 				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1.StepState{
 						{
 							Name: "step1",
@@ -2128,7 +2127,7 @@ func TestTaskRunDescribe_step_status_pending_one_sidecar(t *testing.T) {
 }
 
 func TestTaskRunDescribe_step_status_running_multiple_sidecars(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -2138,7 +2137,7 @@ func TestTaskRunDescribe_step_status_running_multiple_sidecars(t *testing.T) {
 			},
 			Status: v1.TaskRunStatus{
 				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime: &metav1.Time{Time: clockwork.NewFakeClock().Now().Add(20 * time.Second)},
+					StartTime: &metav1.Time{Time: test.FakeClock().Now().Add(20 * time.Second)},
 					Steps: []v1.StepState{
 						{
 							Name: "step1",
@@ -2239,7 +2238,7 @@ func TestTaskRunDescribe_step_status_running_multiple_sidecars(t *testing.T) {
 }
 
 func TestTaskRunDescribe_cancel_taskrun(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -2302,7 +2301,7 @@ func TestTaskRunDescribe_custom_output(t *testing.T) {
 	name := "task-run"
 	expected := "taskrun.tekton.dev/" + name
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	trs := []*v1.TaskRun{
 		{
@@ -2395,7 +2394,7 @@ func TestTaskRunDescribe_WithSpec_custom_timeout(t *testing.T) {
 }
 
 func TestTaskRunDescribe_last(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2480,7 +2479,7 @@ func TestTaskRunDescribe_last(t *testing.T) {
 }
 
 func TestTaskRunDescribe_With_Results(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2598,7 +2597,7 @@ func TestTaskRunDescribe_zero_timeout(t *testing.T) {
 }
 
 func TestTaskRunDescribe_With_Workspaces(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2693,7 +2692,7 @@ func TestTaskRunDescribe_With_Workspaces(t *testing.T) {
 }
 
 func TestTaskRunDescribe_WithoutNameIfOnlyOneTaskRunPresent(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskRuns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/taskrun/export_test.go
+++ b/pkg/cmd/taskrun/export_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -33,7 +32,7 @@ import (
 )
 
 func TestTaskRunExport_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskruns := []*v1beta1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -102,7 +101,7 @@ func TestTaskRunExport_v1beta1(t *testing.T) {
 }
 
 func TestTaskRunExport(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	taskruns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -131,7 +131,7 @@ func TestLog_no_taskrun_arg_v1beta1(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task",
 				Namespace:         "ns",
-				CreationTimestamp: metav1.Time{Time: clockwork.NewFakeClock().Now()},
+				CreationTimestamp: metav1.Time{Time: test.FakeClock().Now()},
 			},
 		},
 	}
@@ -271,7 +271,7 @@ func TestLog_no_taskrun_arg(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task",
 				Namespace:         "ns",
-				CreationTimestamp: metav1.Time{Time: clockwork.NewFakeClock().Now()},
+				CreationTimestamp: metav1.Time{Time: test.FakeClock().Now()},
 			},
 		},
 	}
@@ -551,7 +551,7 @@ func TestLog_taskrun_logs_v1beta1(t *testing.T) {
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-1"
-		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trStartTime = test.FakeClock().Now().Add(20 * time.Second)
 		trPod       = "output-task-pod-123456"
 		trStep1Name = "writefile-step"
 		nopStep     = "nop"
@@ -679,7 +679,7 @@ func TestLog_taskrun_logs(t *testing.T) {
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-1"
-		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trStartTime = test.FakeClock().Now().Add(20 * time.Second)
 		trPod       = "output-task-pod-123456"
 		trStep1Name = "writefile-step"
 		nopStep     = "nop"
@@ -807,7 +807,7 @@ func TestLog_taskrun_logs_no_pod_name_v1beta1(t *testing.T) {
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-1"
-		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trStartTime = test.FakeClock().Now().Add(20 * time.Second)
 		trStep1Name = "writefile-step"
 		nopStep     = "nop"
 	)
@@ -894,7 +894,7 @@ func TestLog_taskrun_logs_no_pod_name(t *testing.T) {
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-1"
-		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trStartTime = test.FakeClock().Now().Add(20 * time.Second)
 		trStep1Name = "writefile-step"
 		nopStep     = "nop"
 	)
@@ -978,7 +978,7 @@ func TestLog_taskrun_logs_no_pod_name(t *testing.T) {
 
 func TestLog_taskrun_all_steps_v1beta1(t *testing.T) {
 	var (
-		prstart  = clockwork.NewFakeClock()
+		prstart  = test.FakeClock()
 		ns       = "namespace"
 		taskName = "output-task"
 
@@ -1123,7 +1123,7 @@ func TestLog_taskrun_all_steps_v1beta1(t *testing.T) {
 
 func TestLog_taskrun_all_steps(t *testing.T) {
 	var (
-		prstart  = clockwork.NewFakeClock()
+		prstart  = test.FakeClock()
 		ns       = "namespace"
 		taskName = "output-task"
 
@@ -1272,7 +1272,7 @@ func TestLog_taskrun_given_steps_v1beta1(t *testing.T) {
 		taskName = "output-task"
 
 		trName      = "output-task-run"
-		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trStartTime = test.FakeClock().Now().Add(20 * time.Second)
 		trPod       = "output-task-pod-123456"
 		trInitStep1 = "credential-initializer-mdzbr"
 		trInitStep2 = "place-tools"
@@ -1413,7 +1413,7 @@ func TestLog_taskrun_given_steps(t *testing.T) {
 		taskName = "output-task"
 
 		trName      = "output-task-run"
-		trStartTime = clockwork.NewFakeClock().Now().Add(20 * time.Second)
+		trStartTime = test.FakeClock().Now().Add(20 * time.Second)
 		trPod       = "output-task-pod-123456"
 		trInitStep1 = "credential-initializer-mdzbr"
 		trInitStep2 = "place-tools"
@@ -1550,7 +1550,7 @@ func TestLog_taskrun_given_steps(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_v1beta1(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -1693,7 +1693,7 @@ func TestLog_taskrun_follow_mode_v1beta1(t *testing.T) {
 
 func TestLog_taskrun_follow_mode(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -1841,7 +1841,7 @@ func TestLog_taskrun_last_v1beta1(t *testing.T) {
 		taskName     = "task"
 		trName1      = "taskrun1"
 		trName2      = "taskrun2"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		tr1StartTime = prstart.Now().Add(30 * time.Second)
 		tr2StartTime = prstart.Now().Add(20 * time.Second)
 		trStepName   = "writefile-step"
@@ -1981,7 +1981,7 @@ func TestLog_taskrun_last(t *testing.T) {
 		taskName     = "task"
 		trName1      = "taskrun1"
 		trName2      = "taskrun2"
-		prstart      = clockwork.NewFakeClock()
+		prstart      = test.FakeClock()
 		tr1StartTime = prstart.Now().Add(30 * time.Second)
 		tr2StartTime = prstart.Now().Add(20 * time.Second)
 		trStepName   = "writefile-step"
@@ -2116,7 +2116,7 @@ func TestLog_taskrun_last(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_no_pod_name_v1beta1(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -2256,7 +2256,7 @@ func TestLog_taskrun_follow_mode_no_pod_name_v1beta1(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -2396,7 +2396,7 @@ func TestLog_taskrun_follow_mode_no_pod_name(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_update_pod_name_v1beta1(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -2549,7 +2549,7 @@ func TestLog_taskrun_follow_mode_update_pod_name_v1beta1(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -2702,7 +2702,7 @@ func TestLog_taskrun_follow_mode_update_pod_name(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_update_timeout_v1beta1(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -2850,7 +2850,7 @@ func TestLog_taskrun_follow_mode_update_timeout_v1beta1(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -2998,7 +2998,7 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_no_output_provided_v1beta1(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"
@@ -3137,7 +3137,7 @@ func TestLog_taskrun_follow_mode_no_output_provided_v1beta1(t *testing.T) {
 
 func TestLog_taskrun_follow_mode_no_output_provided(t *testing.T) {
 	var (
-		prstart     = clockwork.NewFakeClock()
+		prstart     = test.FakeClock()
 		ns          = "namespace"
 		taskName    = "output-task"
 		trName      = "output-task-run"

--- a/pkg/eventlistener/eventlistener_test.go
+++ b/pkg/eventlistener/eventlistener_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestEventListener_GetAllEventListenerNames(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	els := []*v1beta1.EventListener{
 		{
@@ -131,7 +130,7 @@ func TestEventListener_GetAllEventListenerNames(t *testing.T) {
 }
 
 func TestEventListener_List(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	els := []*v1beta1.EventListener{
 		{
@@ -229,7 +228,7 @@ func TestEventListener_List(t *testing.T) {
 }
 
 func TestEventListener_Get(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	els := []*v1beta1.EventListener{
 		{
@@ -278,7 +277,7 @@ func TestEventListener_Get(t *testing.T) {
 }
 
 func TestEventListener_GetError(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	els := []*v1beta1.EventListener{
 		{

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -17,7 +17,6 @@ package pipeline
 import (
 	"testing"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
@@ -30,7 +29,7 @@ import (
 )
 
 func TestPipelinesList_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1beta1.Pipeline{
 		{
@@ -138,7 +137,7 @@ func TestPipelinesList_v1beta1(t *testing.T) {
 }
 
 func TestPipelinesList(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1.Pipeline{
 		{
@@ -246,7 +245,7 @@ func TestPipelinesList(t *testing.T) {
 }
 
 func TestPipelineGet_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1beta1.Pipeline{
 		{
@@ -291,7 +290,7 @@ func TestPipelineGet_v1beta1(t *testing.T) {
 }
 
 func TestPipelineGet(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pdata := []*v1.Pipeline{
 		{

--- a/pkg/pipeline/pipelinelastrun_test.go
+++ b/pkg/pipeline/pipelinelastrun_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestPipelineRunLastName_two_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	//  Time --->
 	//  |---5m ---|------------ ││--││------------- ---│--│
 	//	now      pipeline       ││  │`secondRun stated │  `*first*RunCompleted
@@ -151,7 +150,7 @@ func TestPipelineRunLastName_two_run(t *testing.T) {
 }
 
 func TestPipelineRunLast_two_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	//  Time --->
 	//  |---5m ---|------------ ││--││------------- ---│--│
 	//	now      pipeline       ││  │`secondRun stated │  `*first*RunCompleted
@@ -273,7 +272,7 @@ func TestPipelineRunLast_two_run(t *testing.T) {
 }
 
 func TestPipelinerunLatest_no_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	version := "v1"
 
 	pdata := []*v1.Pipeline{

--- a/pkg/pipelinerun/pipelinerun_test.go
+++ b/pkg/pipelinerun/pipelinerun_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestPipelineRunsList_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pr1Started := clock.Now().Add(10 * time.Second)
 	runDuration := 1 * time.Minute
 	prdata := []*v1beta1.PipelineRun{
@@ -199,7 +199,7 @@ func TestPipelineRunsList_v1beta1(t *testing.T) {
 
 func TestPipelineRunsList(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pr1Started := clock.Now().Add(10 * time.Second)
 	runDuration := 1 * time.Minute
 	prdata := []*v1.PipelineRun{
@@ -364,7 +364,7 @@ func TestPipelineRunsList(t *testing.T) {
 
 func TestPipelineRunGet_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pr1Started := clock.Now().Add(10 * time.Second)
 	runDuration := 1 * time.Minute
 
@@ -451,7 +451,7 @@ func TestPipelineRunGet_v1beta1(t *testing.T) {
 
 func TestPipelineRunGet(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	pr1Started := clock.Now().Add(10 * time.Second)
 	runDuration := 1 * time.Minute
 

--- a/pkg/pipelinerun/sort/by_namespace_test.go
+++ b/pkg/pipelinerun/sort/by_namespace_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -71,7 +71,7 @@ func Test_PipelineRunsByNamespace(t *testing.T) {
 
 func Test_PipelineRunsByNamespaceWithStartTime(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pr00Started := clock.Now().Add(10 * time.Second)
 	pr01Started := clock.Now().Add(-1 * time.Hour)

--- a/pkg/pipelinerun/sort/by_start_time_test.go
+++ b/pkg/pipelinerun/sort/by_start_time_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_PipelineRunsByStartTime(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	pr0Started := clock.Now().Add(10 * time.Second)
 	pr1Started := clock.Now().Add(-2 * time.Hour)

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/test"
@@ -33,7 +32,7 @@ import (
 
 func TestTask_GetAllTaskNames_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -146,7 +145,7 @@ func TestTask_GetAllTaskNames_v1beta1(t *testing.T) {
 
 func TestTask_GetAllTaskNames(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -259,7 +258,7 @@ func TestTask_GetAllTaskNames(t *testing.T) {
 
 func TestTask_List_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -355,7 +354,7 @@ func TestTask_List_v1beta1(t *testing.T) {
 
 func TestTask_List(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -452,7 +451,7 @@ func TestTask_List(t *testing.T) {
 
 func TestTask_Get_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -496,7 +495,7 @@ func TestTask_Get_v1beta1(t *testing.T) {
 
 func TestTask_Get(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -541,7 +540,7 @@ func TestTask_Get(t *testing.T) {
 
 func TestTask_Create(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tdata := []*v1beta1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/task/tasklastrun_test.go
+++ b/pkg/task/tasklastrun_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -31,7 +30,7 @@ import (
 )
 
 func TestTaskrunLatestName_two_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)
@@ -153,7 +152,7 @@ func TestTaskrunLatestName_two_run_v1beta1(t *testing.T) {
 }
 
 func TestTaskrunLatest_two_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)
@@ -276,7 +275,7 @@ func TestTaskrunLatest_two_run_v1beta1(t *testing.T) {
 
 func TestTaskrunLatest_no_run_v1beta1(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	cs, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{})
 	cs.Pipeline.Resources = cb.APIResourceList("v1beta1", []string{"taskrun"})
 	tdc := testDynamic.Options{}
@@ -297,7 +296,7 @@ func TestTaskrunLatest_no_run_v1beta1(t *testing.T) {
 }
 
 func TestTaskrunLatestForClusterTask_two_run_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)
@@ -419,7 +418,7 @@ func TestTaskrunLatestForClusterTask_two_run_v1beta1(t *testing.T) {
 }
 
 func TestTaskrunLatestName_two_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)
@@ -541,7 +540,7 @@ func TestTaskrunLatestName_two_run(t *testing.T) {
 }
 
 func TestTaskrunLatest_two_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)
@@ -664,7 +663,7 @@ func TestTaskrunLatest_two_run(t *testing.T) {
 
 func TestTaskrunLatest_no_run(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	cs, _ := test.SeedTestData(t, test.Data{})
 	cs.Pipeline.Resources = cb.APIResourceList("v1", []string{"taskrun"})
 	tdc := testDynamic.Options{}
@@ -685,7 +684,7 @@ func TestTaskrunLatest_no_run(t *testing.T) {
 }
 
 func TestTaskrunLatestForClusterTask_two_run(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)
@@ -807,7 +806,7 @@ func TestTaskrunLatestForClusterTask_two_run(t *testing.T) {
 }
 
 func TestFilterByRef(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	var (
 		firstRunCreated   = clock.Now().Add(10 * time.Minute)

--- a/pkg/taskrun/get_test.go
+++ b/pkg/taskrun/get_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/actions"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
@@ -33,7 +32,7 @@ import (
 
 func TestTaskRunGet_v1beta1(t *testing.T) {
 	version := "v1beta1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tr1Started := clock.Now().Add(10 * time.Second)
 	runDuration := 1 * time.Minute
 
@@ -121,7 +120,7 @@ func TestTaskRunGet_v1beta1(t *testing.T) {
 
 func TestTaskRunGet(t *testing.T) {
 	version := "v1"
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	tr1Started := clock.Now().Add(10 * time.Second)
 	runDuration := 1 * time.Minute
 

--- a/pkg/taskrun/list_test.go
+++ b/pkg/taskrun/list_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestPipelinesList_GetAllTaskRuns_v1beta1(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	trStarted := clock.Now().Add(10 * time.Second)
 	runDuration1 := 1 * time.Minute
 	runDuration2 := 1 * time.Minute
@@ -169,7 +169,7 @@ func TestPipelinesList_GetAllTaskRuns_v1beta1(t *testing.T) {
 }
 
 func TestPipelinesList_GetAllTaskRuns(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 	trStarted := clock.Now().Add(10 * time.Second)
 	runDuration1 := 1 * time.Minute
 	runDuration2 := 1 * time.Minute

--- a/pkg/taskrun/sort/by_namespace_test.go
+++ b/pkg/taskrun/sort/by_namespace_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -65,7 +65,7 @@ func Test_TaskRunsByNamespace(t *testing.T) {
 
 func Test_TaskRunsByNamespaceWithStartTime(t *testing.T) {
 
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tr00Started := clock.Now().Add(10 * time.Second)
 	tr01Started := clock.Now().Add(-1 * time.Hour)

--- a/pkg/taskrun/sort/by_start_time_test.go
+++ b/pkg/taskrun/sort/by_start_time_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/test"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_TaskRunsByStartTime(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tr0Started := clock.Now().Add(10 * time.Second)
 	tr1Started := clock.Now().Add(-2 * time.Hour)

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -18,8 +18,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	pipelinetest "github.com/tektoncd/pipeline/test"
 	triggerstest "github.com/tektoncd/triggers/test"
@@ -91,4 +93,8 @@ func Contains(t *testing.T, container interface{}, obj interface{}) {
 		diffs = append(diffs, diff)
 	}
 	t.Errorf("no matches found in: %s", strings.Join(diffs, "\n"))
+}
+
+func FakeClock() clockwork.FakeClock {
+	return clockwork.NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
 }

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -136,7 +136,7 @@ func (p *Params) Clients(config ...*rest.Config) (*cli.Clients, error) {
 
 func (p *Params) Time() clockwork.Clock {
 	if p.Clock == nil {
-		p.Clock = clockwork.NewFakeClock()
+		p.Clock = FakeClock()
 	}
 	return p.Clock
 }

--- a/pkg/triggerbinding/triggerbinding_test.go
+++ b/pkg/triggerbinding/triggerbinding_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestTrigger_GetAllTriggerBinding(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tb := []*v1beta1.TriggerBinding{
 		{
@@ -132,7 +131,7 @@ func TestTrigger_GetAllTriggerBinding(t *testing.T) {
 }
 
 func TestTriggerBinding_List(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tb := []*v1beta1.TriggerBinding{
 		{
@@ -235,7 +234,7 @@ func TestTriggerBinding_List(t *testing.T) {
 }
 
 func TestTriggerBinding_Get(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tb := []*v1beta1.TriggerBinding{
 		{

--- a/pkg/triggertemplate/triggertemplate_test.go
+++ b/pkg/triggertemplate/triggertemplate_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/test"
 	cb "github.com/tektoncd/cli/pkg/test/builder"
 	testDynamic "github.com/tektoncd/cli/pkg/test/dynamic"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestTriggerTemplate_GetAllTriggerTemplate(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tt := []*v1beta1.TriggerTemplate{
 		{
@@ -132,7 +131,7 @@ func TestTriggerTemplate_GetAllTriggerTemplate(t *testing.T) {
 }
 
 func TestTriggerTemplate_List(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tt := []*v1beta1.TriggerTemplate{
 		{
@@ -235,7 +234,7 @@ func TestTriggerTemplate_List(t *testing.T) {
 }
 
 func TestTriggerTemplate_Get(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	clock := test.FakeClock()
 
 	tt := []*v1beta1.TriggerTemplate{
 		{

--- a/vendor/github.com/jonboulle/clockwork/README.md
+++ b/vendor/github.com/jonboulle/clockwork/README.md
@@ -2,9 +2,9 @@
 
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#utilities)
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jonboulle/clockwork/CI?style=flat-square)](https://github.com/jonboulle/clockwork/actions?query=workflow%3ACI)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jonboulle/clockwork/ci.yaml?style=flat-square)](https://github.com/jonboulle/clockwork/actions?query=workflow%3ACI)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jonboulle/clockwork?style=flat-square)](https://goreportcard.com/report/github.com/jonboulle/clockwork)
-![Go Version](https://img.shields.io/badge/go%20version-%3E=1.11-61CFDD.svg?style=flat-square)
+![Go Version](https://img.shields.io/badge/go%20version-%3E=1.15-61CFDD.svg?style=flat-square)
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/jonboulle/clockwork)
 
 **A simple fake clock for Go.**

--- a/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -1,12 +1,14 @@
 package clockwork
 
 import (
+	"context"
+	"sort"
 	"sync"
 	"time"
 )
 
-// Clock provides an interface that packages can use instead of directly
-// using the time module, so that chronology-related behavior can be tested
+// Clock provides an interface that packages can use instead of directly using
+// the [time] module, so that chronology-related behavior can be tested.
 type Clock interface {
 	After(d time.Duration) <-chan time.Time
 	Sleep(d time.Duration)
@@ -14,18 +16,23 @@ type Clock interface {
 	Since(t time.Time) time.Duration
 	NewTicker(d time.Duration) Ticker
 	NewTimer(d time.Duration) Timer
+	AfterFunc(d time.Duration, f func()) Timer
 }
 
-// FakeClock provides an interface for a clock which can be
-// manually advanced through time
+// FakeClock provides an interface for a clock which can be manually advanced
+// through time.
+//
+// FakeClock maintains a list of "waiters," which consists of all callers
+// waiting on the underlying clock (i.e. Tickers and Timers including callers of
+// Sleep or After). Users can call BlockUntil to block until the clock has an
+// expected number of waiters.
 type FakeClock interface {
 	Clock
 	// Advance advances the FakeClock to a new point in time, ensuring any existing
-	// sleepers are notified appropriately before returning
+	// waiters are notified appropriately before returning.
 	Advance(d time.Duration)
-	// BlockUntil will block until the FakeClock has the given number of
-	// sleepers (callers of Sleep or After)
-	BlockUntil(n int)
+	// BlockUntil blocks until the FakeClock has the given number of waiters.
+	BlockUntil(waiters int)
 }
 
 // NewRealClock returns a Clock which simply delegates calls to the actual time
@@ -36,10 +43,11 @@ func NewRealClock() Clock {
 
 // NewFakeClock returns a FakeClock implementation which can be
 // manually advanced through time for testing. The initial time of the
-// FakeClock will be an arbitrary non-zero time.
+// FakeClock will be the current system time.
+//
+// Tests that require a deterministic time must use NewFakeClockAt.
 func NewFakeClock() FakeClock {
-	// use a fixture that does not fulfill Time.IsZero()
-	return NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
+	return NewFakeClockAt(time.Now())
 }
 
 // NewFakeClockAt returns a FakeClock initialised at the given time.Time.
@@ -68,71 +76,52 @@ func (rc *realClock) Since(t time.Time) time.Duration {
 }
 
 func (rc *realClock) NewTicker(d time.Duration) Ticker {
-	return &realTicker{time.NewTicker(d)}
+	return realTicker{time.NewTicker(d)}
 }
 
 func (rc *realClock) NewTimer(d time.Duration) Timer {
-	return &realTimer{time.NewTimer(d)}
+	return realTimer{time.NewTimer(d)}
+}
+
+func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
+	return realTimer{time.AfterFunc(d, f)}
 }
 
 type fakeClock struct {
-	sleepers []*sleeper
+	// l protects all attributes of the clock, including all attributes of all
+	// waiters and blockers.
+	l        sync.RWMutex
+	waiters  []expirer
 	blockers []*blocker
 	time     time.Time
-
-	l sync.RWMutex
 }
 
-// sleeper represents a caller of After or Sleep
-type sleeper struct {
-	until time.Time
-	done  chan time.Time
-}
-
-// blocker represents a caller of BlockUntil
+// blocker is a caller of BlockUntil.
 type blocker struct {
 	count int
-	ch    chan struct{}
+
+	// ch is closed when the underlying clock has the specificed number of blockers.
+	ch chan struct{}
 }
 
-// After mimics time.After; it waits for the given duration to elapse on the
+// expirer is a timer or ticker that expires at some point in the future.
+type expirer interface {
+	// expire the expirer at the given time, returning the desired duration until
+	// the next expiration, if any.
+	expire(now time.Time) (next *time.Duration)
+
+	// Get and set the expiration time.
+	expiry() time.Time
+	setExpiry(time.Time)
+}
+
+// After mimics [time.After]; it waits for the given duration to elapse on the
 // fakeClock, then sends the current time on the returned channel.
 func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
-	fc.l.Lock()
-	defer fc.l.Unlock()
-	now := fc.time
-	done := make(chan time.Time, 1)
-	if d.Nanoseconds() <= 0 {
-		// special case - trigger immediately
-		done <- now
-	} else {
-		// otherwise, add to the set of sleepers
-		s := &sleeper{
-			until: now.Add(d),
-			done:  done,
-		}
-		fc.sleepers = append(fc.sleepers, s)
-		// and notify any blockers
-		fc.blockers = notifyBlockers(fc.blockers, len(fc.sleepers))
-	}
-	return done
+	return fc.NewTimer(d).Chan()
 }
 
-// notifyBlockers notifies all the blockers waiting until the at least the given
-// number of sleepers are waiting on the fakeClock. It returns an updated slice
-// of blockers (i.e. those still waiting)
-func notifyBlockers(blockers []*blocker, count int) (newBlockers []*blocker) {
-	for _, b := range blockers {
-		if b.count <= count {
-			close(b.ch)
-		} else {
-			newBlockers = append(newBlockers, b)
-		}
-	}
-	return
-}
-
-// Sleep blocks until the given duration has passed on the fakeClock
+// Sleep blocks until the given duration has passed on the fakeClock.
 func (fc *fakeClock) Sleep(d time.Duration) {
 	<-fc.After(d)
 }
@@ -140,82 +129,221 @@ func (fc *fakeClock) Sleep(d time.Duration) {
 // Now returns the current time of the fakeClock
 func (fc *fakeClock) Now() time.Time {
 	fc.l.RLock()
-	t := fc.time
-	fc.l.RUnlock()
-	return t
+	defer fc.l.RUnlock()
+	return fc.time
 }
 
-// Since returns the duration that has passed since the given time on the fakeClock
+// Since returns the duration that has passed since the given time on the
+// fakeClock.
 func (fc *fakeClock) Since(t time.Time) time.Duration {
 	return fc.Now().Sub(t)
 }
 
-// NewTicker returns a ticker that will expire only after calls to fakeClock
-// Advance have moved the clock passed the given duration
+// NewTicker returns a Ticker that will expire only after calls to
+// fakeClock.Advance() have moved the clock past the given duration.
 func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
-	ft := &fakeTicker{
-		c:      make(chan time.Time, 1),
-		stop:   make(chan bool, 1),
-		clock:  fc,
-		period: d,
+	var ft *fakeTicker
+	ft = &fakeTicker{
+		firer: newFirer(),
+		d:     d,
+		reset: func(d time.Duration) { fc.set(ft, d) },
+		stop:  func() { fc.stop(ft) },
 	}
-	ft.runTickThread()
+	fc.set(ft, d)
 	return ft
 }
 
-// NewTimer returns a timer that will fire only after calls to fakeClock
-// Advance have moved the clock passed the given duration
+// NewTimer returns a Timer that will fire only after calls to
+// fakeClock.Advance() have moved the clock past the given duration.
 func (fc *fakeClock) NewTimer(d time.Duration) Timer {
-	stopped := uint32(0)
-	if d <= 0 {
-		stopped = 1
-	}
-	ft := &fakeTimer{
-		c:       make(chan time.Time, 1),
-		stop:    make(chan struct{}, 1),
-		reset:   make(chan reset, 1),
-		clock:   fc,
-		stopped: stopped,
-	}
+	return fc.newTimer(d, nil)
+}
 
-	ft.run(d)
+// AfterFunc mimics [time.AfterFunc]; it returns a Timer that will invoke the
+// given function only after calls to fakeClock.Advance() have moved the clock
+// past the given duration.
+func (fc *fakeClock) AfterFunc(d time.Duration, f func()) Timer {
+	return fc.newTimer(d, f)
+}
+
+// newTimer returns a new timer, using an optional afterFunc.
+func (fc *fakeClock) newTimer(d time.Duration, afterfunc func()) *fakeTimer {
+	var ft *fakeTimer
+	ft = &fakeTimer{
+		firer: newFirer(),
+		reset: func(d time.Duration) bool {
+			fc.l.Lock()
+			defer fc.l.Unlock()
+			// fc.l must be held across the calls to stopExpirer & setExpirer.
+			stopped := fc.stopExpirer(ft)
+			fc.setExpirer(ft, d)
+			return stopped
+		},
+		stop: func() bool { return fc.stop(ft) },
+
+		afterFunc: afterfunc,
+	}
+	fc.set(ft, d)
 	return ft
 }
 
-// Advance advances fakeClock to a new point in time, ensuring channels from any
-// previous invocations of After are notified appropriately before returning
+// Advance advances fakeClock to a new point in time, ensuring waiters and
+// blockers are notified appropriately before returning.
 func (fc *fakeClock) Advance(d time.Duration) {
 	fc.l.Lock()
 	defer fc.l.Unlock()
 	end := fc.time.Add(d)
-	var newSleepers []*sleeper
-	for _, s := range fc.sleepers {
-		if end.Sub(s.until) >= 0 {
-			s.done <- end
-		} else {
-			newSleepers = append(newSleepers, s)
+	// Expire the earliest waiter until the earliest waiter's expiration is after
+	// end.
+	//
+	// We don't iterate because the callback of the waiter might register a new
+	// waiter, so the list of waiters might change as we execute this.
+	for len(fc.waiters) > 0 && !end.Before(fc.waiters[0].expiry()) {
+		w := fc.waiters[0]
+		fc.waiters = fc.waiters[1:]
+
+		// Use the waiter's expriation as the current time for this expiration.
+		now := w.expiry()
+		fc.time = now
+		if d := w.expire(now); d != nil {
+			// Set the new exipration if needed.
+			fc.setExpirer(w, *d)
 		}
 	}
-	fc.sleepers = newSleepers
-	fc.blockers = notifyBlockers(fc.blockers, len(fc.sleepers))
 	fc.time = end
 }
 
-// BlockUntil will block until the fakeClock has the given number of sleepers
-// (callers of Sleep or After)
+// BlockUntil blocks until the fakeClock has the given number of waiters.
+//
+// Prefer BlockUntilContext, which offers context cancellation to prevent
+// deadlock.
+//
+// Deprecation warning: This function might be deprecated in later versions.
 func (fc *fakeClock) BlockUntil(n int) {
-	fc.l.Lock()
-	// Fast path: we already have >= n sleepers.
-	if len(fc.sleepers) >= n {
-		fc.l.Unlock()
+	b := fc.newBlocker(n)
+	if b == nil {
 		return
 	}
-	// Otherwise, we have < n sleepers. Set up a new blocker to wait for more.
+	<-b.ch
+}
+
+// BlockUntilContext blocks until the fakeClock has the given number of waiters
+// or the context is cancelled.
+func (fc *fakeClock) BlockUntilContext(ctx context.Context, n int) error {
+	b := fc.newBlocker(n)
+	if b == nil {
+		return nil
+	}
+
+	select {
+	case <-b.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (fc *fakeClock) newBlocker(n int) *blocker {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	// Fast path: we already have >= n waiters.
+	if len(fc.waiters) >= n {
+		return nil
+	}
+	// Set up a new blocker to wait for more waiters.
 	b := &blocker{
 		count: n,
 		ch:    make(chan struct{}),
 	}
 	fc.blockers = append(fc.blockers, b)
-	fc.l.Unlock()
-	<-b.ch
+	return b
+}
+
+// stop stops an expirer, returning true if the expirer was stopped.
+func (fc *fakeClock) stop(e expirer) bool {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	return fc.stopExpirer(e)
+}
+
+// stopExpirer stops an expirer, returning true if the expirer was stopped.
+//
+// The caller must hold fc.l.
+func (fc *fakeClock) stopExpirer(e expirer) bool {
+	for i, t := range fc.waiters {
+		if t == e {
+			// Remove element, maintaining order.
+			copy(fc.waiters[i:], fc.waiters[i+1:])
+			fc.waiters[len(fc.waiters)-1] = nil
+			fc.waiters = fc.waiters[:len(fc.waiters)-1]
+			return true
+		}
+	}
+	return false
+}
+
+// set sets an expirer to expire at a future point in time.
+func (fc *fakeClock) set(e expirer, d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	fc.setExpirer(e, d)
+}
+
+// setExpirer sets an expirer to expire at a future point in time.
+//
+// The caller must hold fc.l.
+func (fc *fakeClock) setExpirer(e expirer, d time.Duration) {
+	if d.Nanoseconds() <= 0 {
+		// special case - trigger immediately, never reset.
+		//
+		// TODO: Explain what cases this covers.
+		e.expire(fc.time)
+		return
+	}
+	// Add the expirer to the set of waiters and notify any blockers.
+	e.setExpiry(fc.time.Add(d))
+	fc.waiters = append(fc.waiters, e)
+	sort.Slice(fc.waiters, func(i int, j int) bool {
+		return fc.waiters[i].expiry().Before(fc.waiters[j].expiry())
+	})
+
+    // Notify blockers of our new waiter.
+	var blocked []*blocker
+	count := len(fc.waiters)
+	for _, b := range fc.blockers {
+		if b.count <= count {
+			close(b.ch)
+			continue
+		}
+		blocked = append(blocked, b)
+	}
+	fc.blockers = blocked
+}
+
+// firer is used by fakeTimer and fakeTicker used to help implement expirer.
+type firer struct {
+	// The channel associated with the firer, used to send expriation times.
+	c chan time.Time
+
+	// The time when the firer expires. Only meaningful if the firer is currently
+	// one of a fakeClock's waiters.
+	exp time.Time
+}
+
+func newFirer() firer {
+	return firer{c: make(chan time.Time, 1)}
+}
+
+func (f *firer) Chan() <-chan time.Time {
+	return f.c
+}
+
+// expiry implements expirer.
+func (f *firer) expiry() time.Time {
+	return f.exp
+}
+
+// setExpiry implements expirer.
+func (f *firer) setExpiry(t time.Time) {
+	f.exp = t
 }

--- a/vendor/github.com/jonboulle/clockwork/ticker.go
+++ b/vendor/github.com/jonboulle/clockwork/ticker.go
@@ -1,72 +1,48 @@
 package clockwork
 
-import (
-	"time"
-)
+import "time"
 
-// Ticker provides an interface which can be used instead of directly
-// using the ticker within the time module. The real-time ticker t
-// provides ticks through t.C which becomes now t.Chan() to make
-// this channel requirement definable in this interface.
+// Ticker provides an interface which can be used instead of directly using
+// [time.Ticker]. The real-time ticker t provides ticks through t.C which
+// becomes t.Chan() to make this channel requirement definable in this
+// interface.
 type Ticker interface {
 	Chan() <-chan time.Time
+	Reset(d time.Duration)
 	Stop()
 }
 
 type realTicker struct{ *time.Ticker }
 
-func (rt *realTicker) Chan() <-chan time.Time {
-	return rt.C
+func (r realTicker) Chan() <-chan time.Time {
+	return r.C
 }
 
 type fakeTicker struct {
-	c      chan time.Time
-	stop   chan bool
-	clock  FakeClock
-	period time.Duration
+	firer
+
+	// reset and stop provide the implementation of the respective exported
+	// functions.
+	reset func(d time.Duration)
+	stop  func()
+
+	// The duration of the ticker.
+	d time.Duration
 }
 
-func (ft *fakeTicker) Chan() <-chan time.Time {
-	return ft.c
+func (f *fakeTicker) Reset(d time.Duration) {
+	f.reset(d)
 }
 
-func (ft *fakeTicker) Stop() {
-	ft.stop <- true
+func (f *fakeTicker) Stop() {
+	f.stop()
 }
 
-// runTickThread initializes a background goroutine to send the tick time to the ticker channel
-// after every period. Tick events are discarded if the underlying ticker channel does not have
-// enough capacity.
-func (ft *fakeTicker) runTickThread() {
-	nextTick := ft.clock.Now().Add(ft.period)
-	next := ft.clock.After(ft.period)
-	go func() {
-		for {
-			select {
-			case <-ft.stop:
-				return
-			case <-next:
-				// We send the time that the tick was supposed to occur at.
-				tick := nextTick
-				// Before sending the tick, we'll compute the next tick time and star the clock.After call.
-				now := ft.clock.Now()
-				// First, figure out how many periods there have been between "now" and the time we were
-				// supposed to have trigged, then advance over all of those.
-				skipTicks := (now.Sub(tick) + ft.period - 1) / ft.period
-				nextTick = nextTick.Add(skipTicks * ft.period)
-				// Now, keep advancing until we are past now. This should happen at most once.
-				for !nextTick.After(now) {
-					nextTick = nextTick.Add(ft.period)
-				}
-				// Figure out how long between now and the next scheduled tick, then wait that long.
-				remaining := nextTick.Sub(now)
-				next = ft.clock.After(remaining)
-				// Finally, we can actually send the tick.
-				select {
-				case ft.c <- tick:
-				default:
-				}
-			}
-		}
-	}()
+func (f *fakeTicker) expire(now time.Time) *time.Duration {
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return &f.d
 }

--- a/vendor/github.com/jonboulle/clockwork/timer.go
+++ b/vendor/github.com/jonboulle/clockwork/timer.go
@@ -1,97 +1,53 @@
 package clockwork
 
-import (
-	"sync/atomic"
-	"time"
-)
+import "time"
 
-// Timer provides an interface which can be used instead of directly
-// using the timer within the time module. The real-time timer t
-// provides events through t.C which becomes now t.Chan() to make
-// this channel requirement definable in this interface.
+// Timer provides an interface which can be used instead of directly using
+// [time.Timer]. The real-time timer t provides events through t.C which becomes
+// t.Chan() to make this channel requirement definable in this interface.
 type Timer interface {
 	Chan() <-chan time.Time
 	Reset(d time.Duration) bool
 	Stop() bool
 }
 
-type realTimer struct {
-	*time.Timer
-}
+type realTimer struct{ *time.Timer }
 
 func (r realTimer) Chan() <-chan time.Time {
 	return r.C
 }
 
 type fakeTimer struct {
-	c       chan time.Time
-	clock   FakeClock
-	stop    chan struct{}
-	reset   chan reset
-	stopped uint32
-}
+	firer
 
-func (f *fakeTimer) Chan() <-chan time.Time {
-	return f.c
+	// reset and stop provide the implmenetation of the respective exported
+	// functions.
+	reset func(d time.Duration) bool
+	stop  func() bool
+
+	// If present when the timer fires, the timer calls afterFunc in its own
+	// goroutine rather than sending the time on Chan().
+	afterFunc func()
 }
 
 func (f *fakeTimer) Reset(d time.Duration) bool {
-	stopped := f.Stop()
-
-	f.reset <- reset{t: f.clock.Now().Add(d), next: f.clock.After(d)}
-	if d > 0 {
-		atomic.StoreUint32(&f.stopped, 0)
-	}
-
-	return stopped
+	return f.reset(d)
 }
 
 func (f *fakeTimer) Stop() bool {
-	if atomic.CompareAndSwapUint32(&f.stopped, 0, 1) {
-		f.stop <- struct{}{}
-		return true
-	}
-	return false
+	return f.stop()
 }
 
-type reset struct {
-	t    time.Time
-	next <-chan time.Time
-}
-
-// run initializes a background goroutine to send the timer event to the timer channel
-// after the period. Events are discarded if the underlying ticker channel does not have
-// enough capacity.
-func (f *fakeTimer) run(initialDuration time.Duration) {
-	nextTick := f.clock.Now().Add(initialDuration)
-	next := f.clock.After(initialDuration)
-
-	waitForReset := func() (time.Time, <-chan time.Time) {
-		for {
-			select {
-			case <-f.stop:
-				continue
-			case r := <-f.reset:
-				return r.t, r.next
-			}
-		}
+func (f *fakeTimer) expire(now time.Time) *time.Duration {
+	if f.afterFunc != nil {
+		go f.afterFunc()
+		return nil
 	}
 
-	go func() {
-		for {
-			select {
-			case <-f.stop:
-			case <-next:
-				atomic.StoreUint32(&f.stopped, 1)
-				select {
-				case f.c <- nextTick:
-				default:
-				}
-
-				next = nil
-			}
-
-			nextTick, next = waitForReset()
-		}
-	}()
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -937,8 +937,8 @@ github.com/jmespath/go-jmespath
 # github.com/joho/godotenv v1.5.1
 ## explicit; go 1.12
 github.com/joho/godotenv
-# github.com/jonboulle/clockwork v0.3.0
-## explicit; go 1.13
+# github.com/jonboulle/clockwork v0.4.0
+## explicit; go 1.15
 github.com/jonboulle/clockwork
 # github.com/josharian/intern v1.0.0
 ## explicit; go 1.5


### PR DESCRIPTION
# Changes

We were using clockwork.NewFakeClock() from the clockwork library. With recent changes the implementation of this function changed and it now returns the current date instead of an older date.

Creating the function FakeClock() in `pkg/test/helpers.go` so that we can manually hardcode the date and not 100% rely on the library.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```