### PR TITLE
Remove input and output resource in clustertask describe command

### DIFF
--- a/pkg/cmd/clustertask/describe_test.go
+++ b/pkg/cmd/clustertask/describe_test.go
@@ -45,30 +45,6 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 				CreationTimestamp: metav1.Time{Time: clock.Now().Add(1 * time.Minute)},
 			},
 			Spec: v1beta1.TaskSpec{
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name:        "myarg",
@@ -108,24 +84,6 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 			},
 			Spec: v1beta1.TaskSpec{
 				Description: "a test description",
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "myarg",
@@ -179,28 +137,6 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 						},
 					},
 				},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "my-repo",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "git",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "my-image",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-				},
 			},
 			Status: v1beta1.TaskRunStatus{
 				Status: duckv1.Status{
@@ -237,18 +173,6 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 						Value: v1beta1.ArrayOrString{
 							Type:      v1beta1.ParamTypeString,
 							StringVal: "value",
-						},
-					},
-				},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "my-repo",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "git",
-								},
-							},
 						},
 					},
 				},
@@ -295,28 +219,6 @@ func Test_ClusterTaskDescribe(t *testing.T) {
 						Value: v1beta1.ArrayOrString{
 							Type:     v1beta1.ParamTypeArray,
 							ArrayVal: []string{"booms", "booms", "booms"},
-						},
-					},
-				},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "my-repo",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "git",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "my-image",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
 						},
 					},
 				},

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_clustertask_missing_param_default_one_of_everything.golden
@@ -2,16 +2,6 @@ Command "describe" is deprecated, ClusterTasks are deprecated, this command will
 Name:          clustertask-one-everything
 Description:   a test description
 
-Input Resources
-
- NAME      TYPE
- my-repo   git
-
-Output Resources
-
- NAME         TYPE
- code-image   image
-
 Params
 
  NAME    TYPE     DESCRIPTION   DEFAULT VALUE

--- a/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_full_clustertask_multiple_taskruns.golden
+++ b/pkg/cmd/clustertask/testdata/Test_ClusterTaskDescribe-Describe_full_clustertask_multiple_taskruns.golden
@@ -1,17 +1,6 @@
 Command "describe" is deprecated, ClusterTasks are deprecated, this command will be removed in future releases.
 Name:   clustertask-full
 
-Input Resources
-
- NAME       TYPE
- my-repo    git
- my-image   image
-
-Output Resources
-
- NAME         TYPE
- code-image   image
-
 Params
 
  NAME    TYPE     DESCRIPTION            DEFAULT VALUE


### PR DESCRIPTION
As Pipelineresources have been removed in 0.46 pipeline so this patch removes input and output resource in the clustertask describe command

Closes part of: #1657

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
This will remove input and output resource in the clustertask describe command
```