### PR TITLE
Remove PipelineResource in the describe command test

### DIFF
--- a/pkg/cmd/pipeline/describe_test.go
+++ b/pkg/cmd/pipeline/describe_test.go
@@ -319,12 +319,6 @@ func TestPipelineDescribe_with_spec_resource_param_run_v1beta1(t *testing.T) {
 						},
 					},
 				},
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name:        "pipeline-param",
@@ -431,12 +425,6 @@ func TestPipelineDescribe_with_multiple_pipelineruns_v1beta1(t *testing.T) {
 						Timeout: &metav1.Duration{
 							Duration: 5 * time.Minute,
 						},
-					},
-				},
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
 					},
 				},
 				Params: []v1beta1.ParamSpec{
@@ -653,28 +641,6 @@ func TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1(t *testi
 						},
 					},
 				},
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-					{
-						Name: "code",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-					{
-						Name: "code-image",
-						Type: v1beta1.PipelineResourceTypeImage,
-					},
-					{
-						Name: "artifact-image",
-						Type: v1beta1.PipelineResourceTypeImage,
-					},
-					{
-						Name: "repo",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "pipeline-param",
@@ -796,28 +762,6 @@ func TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1(t
 						},
 					},
 				},
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-					{
-						Name: "code",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-					{
-						Name: "code-image",
-						Type: v1beta1.PipelineResourceTypeImage,
-					},
-					{
-						Name: "artifact-image",
-						Type: v1beta1.PipelineResourceTypeImage,
-					},
-					{
-						Name: "repo",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "pipeline-param",
@@ -919,14 +863,6 @@ func TestPipelineDescribe_custom_output_v1beta1(t *testing.T) {
 				Name:      "pipeline",
 				Namespace: "ns",
 			},
-			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
-			},
 		},
 	}
 	namespaces := []*corev1.Namespace{
@@ -970,12 +906,6 @@ func TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1(t *testing
 				Namespace: "ns",
 			},
 			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Tasks: []v1beta1.PipelineTask{
 					{
 						Name: "task-1",
@@ -1031,12 +961,6 @@ func TestPipelineDescribe_with_results_v1beta1(t *testing.T) {
 				Namespace: "ns",
 			},
 			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Tasks: []v1beta1.PipelineTask{
 					{
 						Name: "task-1",
@@ -1116,12 +1040,6 @@ func TestPipelineDescribe_with_workspaces_v1beta1(t *testing.T) {
 				Namespace: "ns",
 			},
 			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Tasks: []v1beta1.PipelineTask{
 					{
 						Name: "task-1",
@@ -1249,12 +1167,6 @@ func TestPipelineDescribe_with_OptionalWorkspaces_v1beta1(t *testing.T) {
 				Namespace: "ns",
 			},
 			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Tasks: []v1beta1.PipelineTask{
 					{
 						Name: "task-1",

--- a/pkg/cmd/pipeline/export_test.go
+++ b/pkg/cmd/pipeline/export_test.go
@@ -48,12 +48,6 @@ func TestPipelineExport_v1beta1(t *testing.T) {
 				UID:          "f54b8b67-ce52-4509-8a4a-f245b093b62e",
 			},
 			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{
-					{
-						Name: "name",
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-				},
 				Tasks: []v1beta1.PipelineTask{
 					{
 						Name: "task-1",

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_WithoutNameIfOnlyOnePipelinePresent_v1beta1.golden
@@ -1,7 +1,5 @@
 Name:        pipeline
 Namespace:   ns
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Tasks
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_OptionalWorkspaces_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_OptionalWorkspaces_v1beta1.golden
@@ -1,7 +1,5 @@
 Name:        pipeline
 Namespace:   ns
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Results
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_pipelineruns_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_multiple_pipelineruns_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:          pipeline
 Namespace:     ns
 Description:   a test description
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Params
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_results_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_results_v1beta1.golden
@@ -1,7 +1,5 @@
 Name:        pipeline
 Namespace:   ns
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Results
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_output_v1beta1.golden
@@ -19,17 +19,6 @@ spec:
     type: string
   - name: rev-param2
     type: array
-  resources:
-  - name: name
-    type: git
-  - name: code
-    type: git
-  - name: code-image
-    type: image
-  - name: artifact-image
-    type: image
-  - name: repo
-    type: git
   tasks:
   - name: task
     params:

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_multiple_resource_param_run_v1beta1.golden
@@ -1,7 +1,5 @@
 Name:        pipeline
 Namespace:   ns
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"},{"name":"code","type":"git"},{"name":"code-image","type":"image"},{"name":"artifact-image","type":"image"},{"name":"repo","type":"git"}]
 
 Params
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_resource_param_run_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_spec_resource_param_run_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:          pipeline
 Namespace:     ns
 Description:   a test description
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Params
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_workspaces_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineDescribe_with_workspaces_v1beta1.golden
@@ -1,7 +1,5 @@
 Name:        pipeline
 Namespace:   ns
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"name","type":"git"}]
 
 Results
 

--- a/pkg/cmd/pipeline/testdata/TestPipelineExport_v1beta1.golden
+++ b/pkg/cmd/pipeline/testdata/TestPipelineExport_v1beta1.golden
@@ -5,9 +5,6 @@ metadata:
     pipeline.dev: cli
   generateName: generate-name
 spec:
-  resources:
-  - name: name
-    type: git
   results:
   - description: This is a description for result 1
     name: result-1

--- a/pkg/cmd/pipelinerun/cancel_test.go
+++ b/pkg/cmd/pipelinerun/cancel_test.go
@@ -140,20 +140,6 @@ func Test_cancel_pipelinerun_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -226,20 +212,6 @@ func Test_cancel_pipelinerun_client_err_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -375,20 +347,6 @@ func Test_finished_pipelinerun_success_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -530,20 +488,6 @@ func Test_finished_pipelinerun_failure_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -684,20 +628,6 @@ func Test_finished_pipelinerun_cancel_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -839,20 +769,6 @@ func Test_finished_pipelinerun_timeout_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -994,20 +910,6 @@ func Test_finished_pipelinerun_cancelled_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -1148,20 +1050,6 @@ func Test_cancel_pipelinerun_with_grace_stopped_v1beta1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",
@@ -1302,20 +1190,6 @@ func Test_cancel_pipelinerun_with_grace_cancelled_v1bea1(t *testing.T) {
 					Name: "pipelineName",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "git-repo",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-repo",
-						},
-					},
-					{
-						Name: "build-image",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "some-image",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "pipeline-param-1",

--- a/pkg/cmd/pipelinerun/describe_test.go
+++ b/pkg/cmd/pipelinerun/describe_test.go
@@ -745,14 +745,6 @@ func TestPipelineRunDescribe_with_resources_taskrun_v1beta1(t *testing.T) {
 					Name: "pipeline",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "test-resource",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-resource-ref",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "test-param",
@@ -996,11 +988,6 @@ func TestPipelineRunDescribe_no_resourceref_v1beta1(t *testing.T) {
 					Name: "pipeline",
 				},
 				ServiceAccountName: "test-sa",
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "test-resource",
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "test-param",
@@ -1417,20 +1404,6 @@ func TestPipelineRunDescribe_v1beta1(t *testing.T) {
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline",
 				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-					{
-						Name: "res-2",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res2",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "p-1",
@@ -1565,20 +1538,6 @@ func TestPipelineRunDescribe_taskrun_with_no_status_v1beta1(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline",
-				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-					{
-						Name: "res-2",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res2",
-						},
-					},
 				},
 				Params: []v1beta1.Param{
 					{
@@ -1730,20 +1689,6 @@ func TestPipelineRunDescribe_last_v1beta1(t *testing.T) {
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline",
 				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-					{
-						Name: "res-2",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res2",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "p-1",
@@ -1801,20 +1746,6 @@ func TestPipelineRunDescribe_last_v1beta1(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline2",
-				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1x",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-					{
-						Name: "res-2x",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res2",
-						},
-					},
 				},
 				Params: []v1beta1.Param{
 					{
@@ -1939,14 +1870,6 @@ func TestPipelineRunDescribe_with_results_v1beta1(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline",
-				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
 				},
 				Params: []v1beta1.Param{
 					{
@@ -2120,14 +2043,6 @@ func TestPipelineRunDescribe_with_workspaces_v1beta1(t *testing.T) {
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline",
 				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name: "p-1",
@@ -2297,20 +2212,6 @@ func TestPipelineRunDescribeWithSkippedTasks_v1beta1(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "pipeline",
-				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-					{
-						Name: "res-2",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res2",
-						},
-					},
 				},
 				Params: []v1beta1.Param{
 					{
@@ -2627,20 +2528,6 @@ func TestPipelineRunDescribeWithTimeouts_v1beta1(t *testing.T) {
 				Timeouts: &v1beta1.TimeoutFields{
 					Tasks:    &metav1.Duration{Duration: 50 * time.Minute},
 					Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
-				},
-				Resources: []v1beta1.PipelineResourceBinding{
-					{
-						Name: "res-1",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res",
-						},
-					},
-					{
-						Name: "res-2",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: "test-res2",
-						},
-					},
 				},
 				Params: []v1beta1.Param{
 					{

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithSkippedTasks_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithSkippedTasks_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run
 Namespace:      ns
 Pipeline Ref:   pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1","resourceRef":{"name":"test-res"}},{"name":"res-2","resourceRef":{"name":"test-res2"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithTimeouts_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribeWithTimeouts_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run
 Namespace:      ns
 Pipeline Ref:   pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1","resourceRef":{"name":"test-res"}},{"name":"res-2","resourceRef":{"name":"test-res2"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_last_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run2
 Namespace:      ns
 Pipeline Ref:   pipeline2
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1x","resourceRef":{"name":"test-res"}},{"name":"res-2x","resourceRef":{"name":"test-res2"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_no_resourceref_v1beta1.golden
@@ -4,8 +4,6 @@ Pipeline Ref:      pipeline
 Service Account:   test-sa
 Labels:
  tekton.dev/pipeline=pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"test-resource"}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_taskrun_with_no_status_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_taskrun_with_no_status_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run
 Namespace:      ns
 Pipeline Ref:   pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1","resourceRef":{"name":"test-res"}},{"name":"res-2","resourceRef":{"name":"test-res2"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run
 Namespace:      ns
 Pipeline Ref:   pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1","resourceRef":{"name":"test-res"}},{"name":"res-2","resourceRef":{"name":"test-res2"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_resources_taskrun_v1beta1.golden
@@ -4,8 +4,6 @@ Pipeline Ref:      pipeline
 Service Account:   test-sa
 Labels:
  tekton.dev/pipeline=pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"test-resource","resourceRef":{"name":"test-resource-ref"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_results_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_results_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run
 Namespace:      ns
 Pipeline Ref:   pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1","resourceRef":{"name":"test-res"}}]
 
 Status
 

--- a/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_workspaces_v1beta1.golden
+++ b/pkg/cmd/pipelinerun/testdata/TestPipelineRunDescribe_with_workspaces_v1beta1.golden
@@ -1,8 +1,6 @@
 Name:           pipeline-run
 Namespace:      ns
 Pipeline Ref:   pipeline
-Annotations:
- tekton.dev/v1beta1Resources=[{"name":"res-1","resourceRef":{"name":"test-res"}}]
 
 Status
 

--- a/pkg/cmd/task/describe_test.go
+++ b/pkg/cmd/task/describe_test.go
@@ -717,42 +717,6 @@ func TestTaskDescribe_Full_v1beta1(t *testing.T) {
 			},
 			Spec: v1beta1.TaskSpec{
 				Description: "a test description",
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "my-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "source-repo",
-								Type: v1beta1.PipelineResourceTypeGit,
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResource{
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "code-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-						{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "artifact-image",
-								Type: v1beta1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
 				Params: []v1beta1.ParamSpec{
 					{
 						Name: "myarg",

--- a/pkg/cmd/task/testdata/TestTaskDescribe_Full_v1beta1.golden
+++ b/pkg/cmd/task/testdata/TestTaskDescribe_Full_v1beta1.golden
@@ -2,8 +2,6 @@ Name:          task-1
 Namespace:     ns
 Description:   a test description
 Version:       0.1
-Annotations:
- tekton.dev/v1beta1Resources={"inputs":[{"name":"my-repo","type":"git"},{"name":"my-image","type":"image"},{"name":"source-repo","type":"git"}],"outputs":[{"name":"code-image","type":"image"},{"name":"artifact-image","type":"image"}]}
 
 Params
 

--- a/pkg/cmd/taskrun/describe_test.go
+++ b/pkg/cmd/taskrun/describe_test.go
@@ -198,44 +198,6 @@ func TestTaskRunDescribe_only_taskrun_v1beta1(t *testing.T) {
 					Name: "t1",
 				},
 				Timeout: &metav1.Duration{Duration: 1 * time.Hour},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "git",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "git",
-								},
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-input",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output2",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name:  "input",
@@ -487,35 +449,6 @@ func TestTaskRunDescribe_no_resourceref_v1beta1(t *testing.T) {
 					Name: "t1",
 				},
 				Timeout: &metav1.Duration{Duration: 1 * time.Hour},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "git",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-input",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output2",
-							},
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name:  "input",
@@ -616,35 +549,6 @@ func TestTaskRunDescribe_step_sidecar_status_defaults_and_failures_v1beta1(t *te
 					Name: "t1",
 				},
 				Timeout: &metav1.Duration{Duration: 1 * time.Hour},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "git",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-input",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output2",
-							},
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name:  "input",
@@ -748,35 +652,6 @@ func TestTaskRunDescribe_step_status_pending_one_sidecar_v1beta1(t *testing.T) {
 					Name: "t1",
 				},
 				Timeout: &metav1.Duration{Duration: 1 * time.Hour},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "git",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-input",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output2",
-							},
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name:  "input",
@@ -888,35 +763,6 @@ func TestTaskRunDescribe_step_status_running_multiple_sidecars_v1beta1(t *testin
 					Name: "t1",
 				},
 				Timeout: &metav1.Duration{Duration: 1 * time.Hour},
-				Resources: &v1beta1.TaskRunResources{
-					Inputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "git",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-input",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "image",
-								},
-							},
-						},
-					},
-					Outputs: []v1beta1.TaskResourceBinding{
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output",
-							},
-						},
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "image-output2",
-							},
-						},
-					},
-				},
 				Params: []v1beta1.Param{
 					{
 						Name:  "input",

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref_v1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_no_resourceref_v1beta1.golden
@@ -2,8 +2,6 @@ Name:        tr-1
 Namespace:   ns
 Task Ref:    t1
 Timeout:     1h0m0s
-Annotations:
- tekton.dev/v1beta1Resources={"inputs":[{"name":"git"},{"name":"image-input","resourceRef":{"name":"image"}}],"outputs":[{"name":"image-output"},{"name":"image-output2"}]}
 
 Status
 

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun_v1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_only_taskrun_v1beta1.golden
@@ -2,8 +2,6 @@ Name:        tr-1
 Namespace:   ns
 Task Ref:    t1
 Timeout:     1h0m0s
-Annotations:
- tekton.dev/v1beta1Resources={"inputs":[{"name":"git","resourceRef":{"name":"git"}},{"name":"image-input","resourceRef":{"name":"image"}}],"outputs":[{"name":"image-output","resourceRef":{"name":"image"}},{"name":"image-output2","resourceRef":{"name":"image"}}]}
 
 Status
 

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures_v1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_sidecar_status_defaults_and_failures_v1beta1.golden
@@ -2,8 +2,6 @@ Name:        tr-1
 Namespace:   ns
 Task Ref:    t1
 Timeout:     1h0m0s
-Annotations:
- tekton.dev/v1beta1Resources={"inputs":[{"name":"git"},{"name":"image-input","resourceRef":{"name":"image"}}],"outputs":[{"name":"image-output"},{"name":"image-output2"}]}
 
 Status
 

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar_v1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_pending_one_sidecar_v1beta1.golden
@@ -2,8 +2,6 @@ Name:        tr-1
 Namespace:   ns
 Task Ref:    t1
 Timeout:     1h0m0s
-Annotations:
- tekton.dev/v1beta1Resources={"inputs":[{"name":"git"},{"name":"image-input","resourceRef":{"name":"image"}}],"outputs":[{"name":"image-output"},{"name":"image-output2"}]}
 
 Status
 

--- a/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars_v1beta1.golden
+++ b/pkg/cmd/taskrun/testdata/TestTaskRunDescribe_step_status_running_multiple_sidecars_v1beta1.golden
@@ -2,8 +2,6 @@ Name:        tr-1
 Namespace:   ns
 Task Ref:    t1
 Timeout:     1h0m0s
-Annotations:
- tekton.dev/v1beta1Resources={"inputs":[{"name":"git"},{"name":"image-input","resourceRef":{"name":"image"}}],"outputs":[{"name":"image-output"},{"name":"image-output2"}]}
 
 Status
 

--- a/pkg/cmd/triggertemplate/describe_test.go
+++ b/pkg/cmd/triggertemplate/describe_test.go
@@ -32,10 +32,7 @@ import (
 var simpleResourceTemplate = runtime.RawExtension{
 	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1beta1","metadata":{"generateName":"ex2", "creationTimestamp":null},"spec":{},"status":{}}`),
 }
-var pipelineResources = runtime.RawExtension{
-	Raw: []byte(`{"kind":"PipelineResource","apiVersion":"tekton.dev/v1alpha1","metadata":{"name":"ex1", "creationTimestamp":null},"spec":{},"status":{}}`),
-}
-var v1beta1ResourceTemplate = runtime.RawExtension{
+var v1beta1PipelineRunTemplate = runtime.RawExtension{
 	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1beta1","metadata":{"name":"ex1", "generateName":"ex2", "creationTimestamp":null},"spec":{},"status":{}}`),
 }
 var paramResourceTemplate = runtime.RawExtension{
@@ -282,7 +279,7 @@ func TestTriggerTemplateDescribe_WithMultipleParams(t *testing.T) {
 				},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{
 					{
-						RawExtension: v1beta1ResourceTemplate,
+						RawExtension: v1beta1PipelineRunTemplate,
 					},
 				},
 			},
@@ -325,10 +322,7 @@ func TestTriggerTemplateDescribe_WithMultipleResourceTemplate(t *testing.T) {
 				},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{
 					{
-						RawExtension: v1beta1ResourceTemplate,
-					},
-					{
-						RawExtension: pipelineResources,
+						RawExtension: v1beta1PipelineRunTemplate,
 					},
 				},
 			},

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithMultipleResourceTemplate.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithMultipleResourceTemplate.golden
@@ -11,6 +11,5 @@ Params
 
 ResourceTemplates
 
- NAME   GENERATENAME   KIND               APIVERSION
- ex1    ex2            PipelineRun        tekton.dev/v1beta1
- ex1    ---            PipelineResource   tekton.dev/v1alpha1
+ NAME   GENERATENAME   KIND          APIVERSION
+ ex1    ex2            PipelineRun   tekton.dev/v1beta1

--- a/pkg/options/describe.go
+++ b/pkg/options/describe.go
@@ -33,7 +33,6 @@ type DescribeOptions struct {
 	Params                    cli.Params
 	PipelineName              string
 	PipelineRunName           string
-	PipelineResourceName      string
 	ClusterTaskName           string
 	TaskName                  string
 	TaskrunName               string
@@ -90,8 +89,6 @@ func (opts *DescribeOptions) Ask(resource string, options []string) error {
 		opts.PipelineName = ans
 	case ResourceNamePipelineRun:
 		opts.PipelineRunName = strings.Fields(ans)[0]
-	case ResourceNamePipelineResource:
-		opts.PipelineResourceName = ans
 	case ResourceNameClusterTask:
 		opts.ClusterTaskName = ans
 	case ResourceNameTask:

--- a/pkg/options/describe_test.go
+++ b/pkg/options/describe_test.go
@@ -89,12 +89,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 		"sample-task-run3 started 3 minutes ago",
 	}
 
-	options5 := []string{
-		"pipeline-resource1",
-		"pipeline-resource2",
-		"pipeline-resource3",
-	}
-
 	options6 := []string{
 		"clustertask1",
 		"clustertask2",
@@ -153,7 +147,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "sample-pipeline-run1",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -182,7 +175,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "sample-pipeline-run3",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -211,7 +203,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "sample-task-run1",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -240,7 +231,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "sample-task-run3",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -269,7 +259,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "task1",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -298,7 +287,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "task3",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -327,7 +315,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -356,65 +343,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
-				ClusterTaskName:           "",
-				TriggerTemplateName:       "",
-				TriggerBindingName:        "",
-				ClusterTriggerBindingName: "",
-				EventListenerName:         "",
-			},
-		},
-		{
-			name:     "select pipelineresource name",
-			resource: ResourceNamePipelineResource,
-			prompt: prompt.Prompt{
-				CmdArgs: []string{},
-				Procedure: func(c *goexpect.Console) error {
-					if _, err := c.ExpectString("Select pipelineresource:"); err != nil {
-						return err
-					}
-					if _, err := c.SendLine(options5[0]); err != nil {
-						return err
-					}
-					return nil
-				},
-			},
-			options: options5,
-			want: DescribeOptions{
-				PipelineName:              "",
-				PipelineRunName:           "",
-				TaskName:                  "",
-				TaskrunName:               "",
-				PipelineResourceName:      "pipeline-resource1",
-				ClusterTaskName:           "",
-				TriggerTemplateName:       "",
-				TriggerBindingName:        "",
-				ClusterTriggerBindingName: "",
-				EventListenerName:         "",
-			},
-		},
-		{
-			name:     "select pipelineresource name option 3",
-			resource: ResourceNamePipelineResource,
-			prompt: prompt.Prompt{
-				CmdArgs: []string{},
-				Procedure: func(c *goexpect.Console) error {
-					if _, err := c.ExpectString("Select pipelineresource:"); err != nil {
-						return err
-					}
-					if _, err := c.SendLine(options5[2]); err != nil {
-						return err
-					}
-					return nil
-				},
-			},
-			options: options5,
-			want: DescribeOptions{
-				PipelineName:              "",
-				PipelineRunName:           "",
-				TaskName:                  "",
-				TaskrunName:               "",
-				PipelineResourceName:      "pipeline-resource3",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -443,7 +371,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "clustertask1",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -472,7 +399,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "clustertask3",
 				TriggerTemplateName:       "",
 				ClusterTriggerBindingName: "",
@@ -500,7 +426,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "triggertemplate3",
 				TriggerBindingName:        "",
@@ -529,7 +454,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "triggerbinding3",
@@ -558,7 +482,6 @@ func TestDescribeOptions_Ask(t *testing.T) {
 				PipelineRunName:           "",
 				TaskName:                  "",
 				TaskrunName:               "",
-				PipelineResourceName:      "",
 				ClusterTaskName:           "",
 				TriggerTemplateName:       "",
 				TriggerBindingName:        "",
@@ -583,13 +506,12 @@ func TestDescribeOptions_Ask(t *testing.T) {
 			},
 			options: options7,
 			want: DescribeOptions{
-				PipelineName:         "",
-				PipelineRunName:      "",
-				TaskName:             "",
-				TaskrunName:          "",
-				PipelineResourceName: "",
-				ClusterTaskName:      "",
-				EventListenerName:    "eventlistener3",
+				PipelineName:      "",
+				PipelineRunName:   "",
+				TaskName:          "",
+				TaskrunName:       "",
+				ClusterTaskName:   "",
+				EventListenerName: "eventlistener3",
 			},
 		},
 	}

--- a/pkg/options/resource_names.go
+++ b/pkg/options/resource_names.go
@@ -3,7 +3,6 @@ package options
 const (
 	ResourceNamePipeline              = "pipeline"
 	ResourceNamePipelineRun           = "pipelinerun"
-	ResourceNamePipelineResource      = "pipelineresource"
 	ResourceNameTask                  = "task"
 	ResourceNameTaskRun               = "taskrun"
 	ResourceNameClusterTask           = "clustertask"

--- a/pkg/test/dynamic/clientset/tekton.go
+++ b/pkg/test/dynamic/clientset/tekton.go
@@ -22,9 +22,8 @@ import (
 )
 
 var allowedTektonTypes = map[string][]string{
-	"v1alpha1": {"pipelineresources"},
-	"v1beta1":  {"pipelineresources", "pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions"},
-	"v1":       {"pipelineruns", "taskruns", "pipelines", "tasks"},
+	"v1beta1": {"pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions"},
+	"v1":      {"pipelineruns", "taskruns", "pipelines", "tasks"},
 }
 
 var allowedTriggerTektonTypes = map[string][]string{

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -24,7 +24,7 @@ kubectl version 2>/dev/null >/dev/null || {
     exit 1
 }
 
-kubectl get pipelineresource 2>/dev/null >/dev/null || {
+kubectl get pipeline 2>/dev/null >/dev/null || {
     echo "you need to have tekton install onto the cluster"
     exit 1
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -148,7 +148,7 @@ function install_pipeline_crd() {
     fail_test "Build pipeline installation failed"
 
   # Make sure that eveything is cleaned up in the current namespace.
-  for res in pipelineresources tasks pipelines taskruns pipelineruns; do
+  for res in tasks pipelines taskruns pipelineruns; do
     kubectl delete --ignore-not-found=true ${res}.tekton.dev --all
   done
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -123,7 +123,7 @@ run_test  "describe eventlistener" tkn eventlistener describe github-listener-in
 run_test  "show logs" tkn pipelinerun logs output-pipeline-run
 run_test  "show logs" tkn taskrun logs test-template-volume
 
-# delete pipeline, pipelinerun, task, taskrun, and pipelineresource
+# delete pipeline, pipelinerun, task, taskrun, and eventlistener
 run_test  "delete pipeline" tkn pipeline delete output-pipeline -f
 run_test  "delete pipelinerun" tkn pipelinerun delete output-pipeline-run -f
 run_test  "delete task" tkn task delete create-file-verify -f

--- a/test/resources/eventlistener/eventlistener.yaml
+++ b/test/resources/eventlistener/eventlistener.yaml
@@ -109,5 +109,5 @@ rules:
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates
   - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns", "pipelineresources", "taskruns"]
+    resources: ["pipelineruns", "taskruns"]
     verbs: ["create"]

--- a/test/resources/eventlistener/eventlistener_log.yaml
+++ b/test/resources/eventlistener/eventlistener_log.yaml
@@ -114,5 +114,5 @@ rules:
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates
   - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns", "pipelineresources", "taskruns"]
+    resources: ["pipelineruns", "taskruns"]
     verbs: ["create"]

--- a/test/resources/eventlistener/eventlistener_v1beta1.yaml
+++ b/test/resources/eventlistener/eventlistener_v1beta1.yaml
@@ -116,5 +116,5 @@ rules:
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates
   - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns", "pipelineresources", "taskruns"]
+    resources: ["pipelineruns", "taskruns"]
     verbs: ["create"]

--- a/test/resources/eventlistener/eventlistener_v1beta1_log.yaml
+++ b/test/resources/eventlistener/eventlistener_v1beta1_log.yaml
@@ -121,5 +121,5 @@ rules:
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates
   - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns", "pipelineresources", "taskruns"]
+    resources: ["pipelineruns", "taskruns"]
     verbs: ["create"]


### PR DESCRIPTION
This patch will remove PipelineResource in task, clustertask, pipeline, pipelinerun and eventlistener describe command tests and also will remove PipelineResource occurrences in e2e test

Closes part of: #1657 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


# Release Notes

```release-note
This will remove PipelineResource in the describe command tests and also will remove PipelineResource occurrences in e2e test
```