### PR TITLE
Remove default value info for true flag in delete command

### DIFF
--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -32,7 +32,7 @@ or
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-  -i, --ignore-running                ignore running PipelineRun (default: true) (default true)
+  -i, --ignore-running                ignore running PipelineRun (default true)
       --keep int                      Keep n most recent number of PipelineRuns
       --keep-since int                When deleting all PipelineRuns keep the ones that has been completed since n minutes
       --label string                  A selector (label query) to filter on when running with --all, supports '=', '==', and '!='

--- a/docs/cmd/tkn_pipelinerun_list.md
+++ b/docs/cmd/tkn_pipelinerun_list.md
@@ -32,7 +32,7 @@ List all PipelineRuns in a namespace 'foo':
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='
-      --limit int                     limit PipelineRuns listed (default: return all PipelineRuns)
+      --limit int                     Limits the number of PipelineRuns. If the limit value is 0 returns all
       --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file).
       --reverse                       list PipelineRuns in reverse order

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -33,8 +33,8 @@ or
       --clustertask string            The name of a ClusterTask whose TaskRuns should be deleted (does not delete the ClusterTask)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete
-  -i, --ignore-running                ignore running TaskRun (default: true) (default true)
-      --ignore-running-pipelinerun    ignore deleting taskruns of a running PipelineRun (default: true) (default true)
+  -i, --ignore-running                ignore running TaskRun (default true)
+      --ignore-running-pipelinerun    ignore deleting taskruns of a running PipelineRun (default true)
       --keep int                      Keep n most recent number of TaskRuns
       --keep-since int                When deleting all TaskRuns keep the ones that has been completed since n minutes
   -o, --output string                 Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file).

--- a/docs/cmd/tkn_taskrun_list.md
+++ b/docs/cmd/tkn_taskrun_list.md
@@ -32,7 +32,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for list
       --label string                  A selector (label query) to filter on, supports '=', '==', and '!='
-      --limit int                     limit TaskRuns listed (default: return all TaskRuns)
+      --limit int                     Limits the number of TaskRuns. If the limit value is 0 returns all
       --no-headers                    do not print column headers with output (default print column headers with output)
   -o, --output string                 Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file).
       --reverse                       list TaskRuns in reverse order

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -37,7 +37,7 @@ Delete PipelineRuns in a namespace
 
 .PP
 \fB\-i\fP, \fB\-\-ignore\-running\fP[=true]
-    ignore running PipelineRun (default: true)
+    ignore running PipelineRun
 
 .PP
 \fB\-\-keep\fP=0

--- a/docs/man/man1/tkn-pipelinerun-list.1
+++ b/docs/man/man1/tkn-pipelinerun-list.1
@@ -37,7 +37,7 @@ Lists PipelineRuns in a namespace
 
 .PP
 \fB\-\-limit\fP=0
-    limit PipelineRuns listed (default: return all PipelineRuns)
+    Limits the number of PipelineRuns. If the limit value is 0 returns all
 
 .PP
 \fB\-\-no\-headers\fP[=false]

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -41,11 +41,11 @@ Delete TaskRuns in a namespace
 
 .PP
 \fB\-i\fP, \fB\-\-ignore\-running\fP[=true]
-    ignore running TaskRun (default: true)
+    ignore running TaskRun
 
 .PP
 \fB\-\-ignore\-running\-pipelinerun\fP[=true]
-    ignore deleting taskruns of a running PipelineRun (default: true)
+    ignore deleting taskruns of a running PipelineRun
 
 .PP
 \fB\-\-keep\fP=0

--- a/docs/man/man1/tkn-taskrun-list.1
+++ b/docs/man/man1/tkn-taskrun-list.1
@@ -37,7 +37,7 @@ Lists TaskRuns in a namespace
 
 .PP
 \fB\-\-limit\fP=0
-    limit TaskRuns listed (default: return all TaskRuns)
+    Limits the number of TaskRuns. If the limit value is 0 returns all
 
 .PP
 \fB\-\-no\-headers\fP[=false]

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -127,7 +127,7 @@ or
 	c.Flags().StringVarP(&opts.ParentResourceName, "pipeline", "p", "", "The name of a Pipeline whose PipelineRuns should be deleted (does not delete the Pipeline)")
 	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of PipelineRuns")
 	c.Flags().IntVarP(&opts.KeepSince, "keep-since", "", 0, "When deleting all PipelineRuns keep the ones that has been completed since n minutes")
-	c.Flags().BoolVarP(&opts.IgnoreRunning, "ignore-running", "i", true, "ignore running PipelineRun (default: true)")
+	c.Flags().BoolVarP(&opts.IgnoreRunning, "ignore-running", "i", true, "ignore running PipelineRun")
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all PipelineRuns in a namespace (default: false)")
 	c.Flags().StringVarP(&opts.LabelSelector, "label", "", opts.LabelSelector, "A selector (label query) to filter on when running with --all, supports '=', '==', and '!='")
 	return c

--- a/pkg/cmd/pipelinerun/list.go
+++ b/pkg/cmd/pipelinerun/list.go
@@ -131,7 +131,7 @@ List all PipelineRuns in a namespace 'foo':
 	}
 
 	f.AddFlags(c)
-	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit PipelineRuns listed (default: return all PipelineRuns)")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "Limits the number of PipelineRuns. If the limit value is 0 returns all")
 	c.Flags().StringVarP(&opts.LabelSelector, "label", "", opts.LabelSelector, "A selector (label query) to filter on, supports '=', '==', and '!='")
 	c.Flags().BoolVarP(&opts.Reverse, "reverse", "", opts.Reverse, "list PipelineRuns in reverse order")
 	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list PipelineRuns from all namespaces")

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -147,8 +147,8 @@ or
 	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all TaskRuns in a namespace (default: false)")
 	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of TaskRuns")
 	c.Flags().IntVarP(&opts.KeepSince, "keep-since", "", 0, "When deleting all TaskRuns keep the ones that has been completed since n minutes")
-	c.Flags().BoolVarP(&opts.IgnoreRunning, "ignore-running", "i", true, "ignore running TaskRun (default: true)")
-	c.Flags().BoolVarP(&opts.IgnoreRunningPipelinerun, "ignore-running-pipelinerun", "", true, "ignore deleting taskruns of a running PipelineRun (default: true)")
+	c.Flags().BoolVarP(&opts.IgnoreRunning, "ignore-running", "i", true, "ignore running TaskRun")
+	c.Flags().BoolVarP(&opts.IgnoreRunningPipelinerun, "ignore-running-pipelinerun", "", true, "ignore deleting taskruns of a running PipelineRun")
 
 	return c
 }

--- a/pkg/cmd/taskrun/list.go
+++ b/pkg/cmd/taskrun/list.go
@@ -135,7 +135,7 @@ List all TaskRuns of Task 'foo' in namespace 'bar':
 	}
 
 	f.AddFlags(c)
-	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit TaskRuns listed (default: return all TaskRuns)")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "Limits the number of TaskRuns. If the limit value is 0 returns all")
 	c.Flags().StringVarP(&opts.LabelSelector, "label", "", opts.LabelSelector, "A selector (label query) to filter on, supports '=', '==', and '!='")
 	c.Flags().BoolVarP(&opts.Reverse, "reverse", "", opts.Reverse, "list TaskRuns in reverse order")
 	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list TaskRuns from all namespaces")


### PR DESCRIPTION
This patch removes default value info of flag as default value of flag is true and default value info will be added by default

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
This will remove default value info of flag in delete command as default value info will be added by default in case of true flag
```