### PR TITLE
Fix tkn pr/tr delete command for keep flag

### DIFF
--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -180,7 +180,12 @@ func deletePipelineRuns(s *cli.Stream, p cli.Params, prNames []string, opts *opt
 		d.WithRelated("PipelineRun", pipelineRunLister(cs, opts.Keep, opts.KeepSince, p.Namespace(), opts.IgnoreRunning), func(pipelineRunName string) error {
 			return actions.Delete(prGroupResource, cs.Dynamic, cs.Tekton.Discovery(), pipelineRunName, p.Namespace(), metav1.DeleteOptions{})
 		})
-		if len(prtodelete) == 0 && opts.Keep > len(prtokeep) {
+
+		if len(prtodelete) == 0 && opts.Keep > 0 && opts.Keep == len(prtokeep) {
+			fmt.Fprintf(s.Out, "Associated %s (%d) for Pipeline:%s is/are equal to keep (%d) \n", opts.Resource, len(prtokeep), opts.ParentResourceName, opts.Keep)
+			return nil
+		}
+		if opts.Keep > len(prtokeep) {
 			fmt.Fprintf(s.Out, "There is/are only %d %s(s) associated for Pipeline: %s \n", len(prtokeep), opts.Resource, opts.ParentResourceName)
 			return nil
 		}

--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -584,6 +584,15 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			want:        "There is/are only 2 PipelineRun(s) associated for Pipeline: pipeline \n",
 		},
 		{
+			name:        "Attempt to delete PieplineRun by keeping more than existing PipelineRun for a Pipeline",
+			command:     []string{"delete", "-i", "-f", "--keep", "2", "--pipeline", "pipeline", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Associated PipelineRun (2) for Pipeline:pipeline is/are equal to keep (2) \n",
+		},
+		{
 			name:        "Delete all of a pipeline by default ignore-running",
 			command:     []string{"rm", "-p", "pipeline", "-n", "ns"},
 			dynamic:     seeds[12].dynamicClient,
@@ -1205,6 +1214,15 @@ func TestPipelineRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "There is/are only 2 PipelineRun(s) associated for Pipeline: pipeline \n",
+		},
+		{
+			name:        "Attempt to delete PieplineRun by keeping more than existing PipelineRun for a Pipeline",
+			command:     []string{"delete", "-i", "-f", "--keep", "2", "--pipeline", "pipeline", "-n", "ns"},
+			dynamic:     seeds[2].dynamicClient,
+			input:       seeds[2].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Associated PipelineRun (2) for Pipeline:pipeline is/are equal to keep (2) \n",
 		},
 		{
 			name:        "Delete all of a pipeline by default ignore-running",

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -216,14 +216,19 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 		if err != nil {
 			return err
 		}
+
 		numberOfDeletedTr = len(trToDelete)
 		numberOfKeptTr = len(trToKeep)
-
 		// Delete the TaskRuns associated with a Task or ClusterTask
 		d.WithRelated("TaskRun", taskRunLister(p, opts.Keep, opts.KeepSince, opts.ParentResource, cs, opts.IgnoreRunning, opts.IgnoreRunningPipelinerun), func(taskRunName string) error {
 			return actions.Delete(taskrunGroupResource, cs.Dynamic, cs.Tekton.Discovery(), taskRunName, p.Namespace(), metav1.DeleteOptions{})
 		})
-		if len(trToDelete) == 0 && opts.Keep > len(trToKeep) {
+
+		if opts.Keep > 0 && opts.Keep == len(trToKeep) && len(trToDelete) == 0 {
+			fmt.Fprintf(s.Out, "Associated %s (%d) for Task:%s is/are equal to keep (%d) \n", opts.Resource, len(trToKeep), opts.ParentResourceName, opts.Keep)
+			return nil
+		}
+		if opts.Keep > len(trToKeep) {
 			fmt.Fprintf(s.Out, "There is/are only %d %s(s) associated for %s: %s \n", len(trToKeep), opts.Resource, opts.ParentResource, opts.ParentResourceName)
 			return nil
 		}

--- a/pkg/cmd/taskrun/delete_test.go
+++ b/pkg/cmd/taskrun/delete_test.go
@@ -801,6 +801,15 @@ func TestTaskRunDelete_v1beta1(t *testing.T) {
 			want:        "taskruns.tekton.dev \"nonexistent\" not found",
 		},
 		{
+			name:        "Attempt to delete TaskRun by keeping equal to existing TaskRun for a Task",
+			command:     []string{"delete", "-i", "-f", "--keep", "1", "--task", "random", "-n", "ns"},
+			dynamic:     seeds[10].dynamicClient,
+			input:       seeds[10].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Associated TaskRun (1) for Task:random is/are equal to keep (1) \n",
+		},
+		{
 			name:        "Attempt to delete TaskRun by keeping more than existing TaskRun for a Task",
 			command:     []string{"delete", "-i", "-f", "--keep", "2", "--task", "random", "-n", "ns"},
 			dynamic:     seeds[10].dynamicClient,
@@ -1655,6 +1664,15 @@ func TestTaskRunDelete(t *testing.T) {
 			inputStream: nil,
 			wantError:   false,
 			want:        "There is/are only 1 TaskRun(s) associated for Task: random \n",
+		},
+		{
+			name:        "Attempt to delete TaskRun by keeping equal to existing TaskRun for a Task",
+			command:     []string{"delete", "-i", "-f", "--keep", "1", "--task", "random", "-n", "ns"},
+			dynamic:     seeds[10].dynamicClient,
+			input:       seeds[10].pipelineClient,
+			inputStream: nil,
+			wantError:   false,
+			want:        "Associated TaskRun (1) for Task:random is/are equal to keep (1) \n",
 		},
 		{
 			name:        "Delete all of task with default --ignore-running",


### PR DESCRIPTION
This patch fix the tkn pr delete command for keep flag and now if value of keep flag is equal to number of associated taskruns/pipelineruns for a task/pipeline then it returns exit code 0 and with a message

fixes : #1895

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
This patch fix the tkn tr/pr delete command for keep flag
```