### PR TITLE
Upgrade golangci version to v1.52.2 and fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,4 +16,4 @@ linters:
   - gocritic
   - revive
   - misspell
-  - deadcode
+  - unused

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
 
-GOLANGCI_VERSION = v1.47.2
+GOLANGCI_VERSION = v1.52.2
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
+func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
@@ -80,7 +80,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		buf.WriteString(fmt.Sprintf("%s\n\n", cmd.Example))
 	}
 
-	if err := printOptions(buf, cmd, name); err != nil {
+	if err := printOptions(buf, cmd); err != nil {
 		return err
 	}
 	if hasSeeAlso(cmd) {
@@ -154,10 +154,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
 		return err
 	}
-	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {
-		return err
-	}
-	return nil
+	return GenMarkdownCustom(cmd, f, linkHandler)
 }
 
 // Test to see if we have a reason to print See Also information in docs

--- a/pkg/actions/get.go
+++ b/pkg/actions/get.go
@@ -56,12 +56,7 @@ func GetV1(gr schema.GroupVersionResource, c *cli.Clients, objname, ns string, o
 	if err != nil {
 		return err
 	}
-
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj); err != nil {
-		return err
-	}
-
-	return nil
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
 }
 
 func GetUnstructured(gr schema.GroupVersionResource, c *cli.Clients, objname, ns string, op metav1.GetOptions) (*unstructured.Unstructured, error) {

--- a/pkg/actions/list.go
+++ b/pkg/actions/list.go
@@ -49,10 +49,7 @@ func ListV1(gr schema.GroupVersionResource, c *cli.Clients, opts metav1.ListOpti
 		return err
 	}
 
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj); err != nil {
-		return err
-	}
-	return nil
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
 }
 
 // list takes a partial resource and fetches a list of that resource's objects in the cluster using the dynamic client.

--- a/pkg/actions/patch.go
+++ b/pkg/actions/patch.go
@@ -38,9 +38,5 @@ func Patch(gr schema.GroupVersionResource, clients *cli.Clients, objName string,
 		return err
 	}
 
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj); err != nil {
-		return err
-	}
-
-	return nil
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
 }

--- a/pkg/cmd/clustertask/delete.go
+++ b/pkg/cmd/clustertask/delete.go
@@ -122,15 +122,15 @@ func deleteClusterTasks(opts *options.DeleteOptions, s *cli.Stream, p cli.Params
 		if err != nil {
 			return err
 		}
-		d.Delete(s, cts)
+		d.Delete(cts)
 	case opts.DeleteRelated:
 		d.WithRelated("TaskRun", taskRunLister(cs, p), func(taskRunName string) error {
 			return actions.Delete(trGroupResource, cs.Dynamic, cs.Tekton.Discovery(), taskRunName, p.Namespace(), metav1.DeleteOptions{})
 		})
-		deletedClusterTaskNames := d.Delete(s, ctNames)
-		d.DeleteRelated(s, deletedClusterTaskNames)
+		deletedClusterTaskNames := d.Delete(ctNames)
+		d.DeleteRelated(deletedClusterTaskNames)
 	default:
-		d.Delete(s, ctNames)
+		d.Delete(ctNames)
 
 	}
 

--- a/pkg/cmd/clustertriggerbinding/delete.go
+++ b/pkg/cmd/clustertriggerbinding/delete.go
@@ -116,7 +116,7 @@ func deleteClusterTriggerBindings(s *cli.Stream, p cli.Params, ctbNames []string
 			return err
 		}
 	}
-	d.Delete(s, ctbNames)
+	d.Delete(ctbNames)
 
 	if !deleteAll {
 		d.PrintSuccesses(s)

--- a/pkg/cmd/eventlistener/delete.go
+++ b/pkg/cmd/eventlistener/delete.go
@@ -116,7 +116,7 @@ func deleteEventListeners(s *cli.Stream, p cli.Params, elNames []string, deleteA
 			return err
 		}
 	}
-	d.Delete(s, elNames)
+	d.Delete(elNames)
 
 	if !deleteAll {
 		d.PrintSuccesses(s)

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -122,15 +122,15 @@ func deletePipelines(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, p
 		if err != nil {
 			return err
 		}
-		d.Delete(s, pNames)
+		d.Delete(pNames)
 	case opts.DeleteRelated:
 		d.WithRelated("PipelineRun", pipelineRunLister(cs, p.Namespace()), func(pipelineRunName string) error {
 			return actions.Delete(pipelinerunGroupResource, cs.Dynamic, cs.Tekton.Discovery(), pipelineRunName, p.Namespace(), metav1.DeleteOptions{})
 		})
-		deletedPipelineNames := d.Delete(s, pNames)
-		d.DeleteRelated(s, deletedPipelineNames)
+		deletedPipelineNames := d.Delete(pNames)
+		d.DeleteRelated(deletedPipelineNames)
 	default:
-		d.Delete(s, pNames)
+		d.Delete(pNames)
 	}
 	if !opts.DeleteAllNs {
 		d.PrintSuccesses(s)

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -44,8 +44,8 @@ func Command(p cli.Params) *cobra.Command {
 		logCommand(p),
 		startCommand(p),
 		exportCommand(p),
-		signCommand(p),
-		verifyCommand(p),
+		signCommand(),
+		verifyCommand(),
 	)
 	return cmd
 }

--- a/pkg/cmd/pipeline/sign.go
+++ b/pkg/cmd/pipeline/sign.go
@@ -33,7 +33,7 @@ type signOptions struct {
 	targetFile string
 }
 
-func signCommand(p cli.Params) *cobra.Command {
+func signCommand() *cobra.Command {
 	opts := &signOptions{}
 	f := cliopts.NewPrintFlags("trustedresources")
 	eg := `Sign a Pipeline pipeline.yaml:

--- a/pkg/cmd/pipeline/verify.go
+++ b/pkg/cmd/pipeline/verify.go
@@ -32,7 +32,7 @@ type verifyOptions struct {
 	kmsKey  string
 }
 
-func verifyCommand(p cli.Params) *cobra.Command {
+func verifyCommand() *cobra.Command {
 	opts := &verifyOptions{}
 	f := cliopts.NewPrintFlags("trustedresources")
 	eg := `Verify a Pipeline signed.yaml:

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -153,12 +153,12 @@ func deletePipelineRuns(s *cli.Stream, p cli.Params, prNames []string, opts *opt
 		}
 		numberOfDeletedPr = len(prtodelete)
 		numberOfKeptPr = len(prtokeep)
-		d.Delete(s, prtodelete)
+		d.Delete(prtodelete)
 	case opts.ParentResourceName == "":
 		d = deleter.New("PipelineRun", func(pipelineRunName string) error {
 			return actions.Delete(prGroupResource, cs.Dynamic, cs.Tekton.Discovery(), pipelineRunName, p.Namespace(), metav1.DeleteOptions{})
 		})
-		d.Delete(s, prNames)
+		d.Delete(prNames)
 	default:
 		d = deleter.New("Pipeline", func(_ string) error {
 			return errors.New("the Pipeline should not be deleted")
@@ -184,7 +184,7 @@ func deletePipelineRuns(s *cli.Stream, p cli.Params, prNames []string, opts *opt
 			fmt.Fprintf(s.Out, "There is/are only %d %s(s) associated for Pipeline: %s \n", len(prtokeep), opts.Resource, opts.ParentResourceName)
 			return nil
 		}
-		d.DeleteRelated(s, []string{opts.ParentResourceName})
+		d.DeleteRelated([]string{opts.ParentResourceName})
 	}
 
 	if !opts.DeleteAllNs {

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -123,15 +123,15 @@ func deleteTask(opts *options.DeleteOptions, s *cli.Stream, p cli.Params, taskNa
 		if err != nil {
 			return err
 		}
-		d.Delete(s, taskNames)
+		d.Delete(taskNames)
 	case opts.DeleteRelated:
 		d.WithRelated("TaskRun", taskRunLister(cs, p.Namespace()), func(taskRunName string) error {
 			return actions.Delete(taskrunGroupResource, cs.Dynamic, cs.Tekton.Discovery(), taskRunName, p.Namespace(), metav1.DeleteOptions{})
 		})
-		deletedTaskNames := d.Delete(s, taskNames)
-		d.DeleteRelated(s, deletedTaskNames)
+		deletedTaskNames := d.Delete(taskNames)
+		d.DeleteRelated(deletedTaskNames)
 	default:
-		d.Delete(s, taskNames)
+		d.Delete(taskNames)
 	}
 	if !opts.DeleteAllNs {
 		d.PrintSuccesses(s)

--- a/pkg/cmd/task/sign.go
+++ b/pkg/cmd/task/sign.go
@@ -38,7 +38,7 @@ type signOptions struct {
 	targetFile string
 }
 
-func signCommand(p cli.Params) *cobra.Command {
+func signCommand() *cobra.Command {
 	opts := &signOptions{}
 	f := cliopts.NewPrintFlags("trustedresources")
 	eg := `Sign a Task task.yaml:

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -44,8 +44,8 @@ func Command(p cli.Params) *cobra.Command {
 		logCommand(p),
 		startCommand(p),
 		createCommand(p),
-		signCommand(p),
-		verifyCommand(p),
+		signCommand(),
+		verifyCommand(),
 	)
 	return cmd
 }

--- a/pkg/cmd/task/verify.go
+++ b/pkg/cmd/task/verify.go
@@ -32,7 +32,7 @@ type verifyOptions struct {
 	kmsKey  string
 }
 
-func verifyCommand(p cli.Params) *cobra.Command {
+func verifyCommand() *cobra.Command {
 	opts := &verifyOptions{}
 	f := cliopts.NewPrintFlags("trustedresources")
 	eg := `Verify a Task signed.yaml:

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -171,7 +171,7 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 		}
 		numberOfDeletedTr = len(trToDelete)
 		numberOfKeptTr = len(trToKeep)
-		d.Delete(s, trToDelete)
+		d.Delete(trToDelete)
 	case opts.ParentResourceName == "":
 		d = deleter.New("TaskRun", func(taskRunName string) error {
 			return actions.Delete(taskrunGroupResource, cs.Dynamic, cs.Tekton.Discovery(), taskRunName, p.Namespace(), metav1.DeleteOptions{})
@@ -196,7 +196,7 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 			}
 			processedTrNames = append(processedTrNames, tr.Name)
 		}
-		d.Delete(s, processedTrNames)
+		d.Delete(processedTrNames)
 	default:
 		d = deleter.New(opts.ParentResource, func(_ string) error {
 			err := fmt.Sprintf("the %s should not be deleted", opts.ParentResource)
@@ -227,7 +227,7 @@ func deleteTaskRuns(s *cli.Stream, p cli.Params, trNames []string, opts *options
 			fmt.Fprintf(s.Out, "There is/are only %d %s(s) associated for %s: %s \n", len(trToKeep), opts.Resource, opts.ParentResource, opts.ParentResourceName)
 			return nil
 		}
-		d.DeleteRelated(s, []string{opts.ParentResourceName})
+		d.DeleteRelated([]string{opts.ParentResourceName})
 	}
 
 	if !opts.DeleteAllNs {

--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -117,7 +117,7 @@ func deleteTriggerBindings(s *cli.Stream, p cli.Params, tbNames []string, delete
 			return err
 		}
 	}
-	d.Delete(s, tbNames)
+	d.Delete(tbNames)
 
 	if !deleteAll {
 		d.PrintSuccesses(s)

--- a/pkg/cmd/triggertemplate/delete.go
+++ b/pkg/cmd/triggertemplate/delete.go
@@ -120,7 +120,7 @@ func deleteTriggerTemplates(s *cli.Stream, p cli.Params, ttNames []string, delet
 			return err
 		}
 	}
-	d.Delete(s, ttNames)
+	d.Delete(ttNames)
 
 	if !deleteAll {
 		d.PrintSuccesses(s)

--- a/pkg/deleter/deleter_test.go
+++ b/pkg/deleter/deleter_test.go
@@ -33,7 +33,7 @@ func TestDelete(t *testing.T) {
 			stderr := &strings.Builder{}
 			streams := &cli.Stream{Out: stdout, Err: stderr}
 			d := New("FooBar", tc.deleteFunc)
-			d.Delete(streams, tc.names)
+			d.Delete(tc.names)
 			d.PrintSuccesses(streams)
 			if err := d.Errors(); err != nil {
 				if tc.expectedErr == "" {
@@ -74,7 +74,7 @@ func TestDeleteRelated(t *testing.T) {
 			d := New("FooBar", successfulDeleteFunc())
 			if tc.relatedKind != "" {
 				d.WithRelated(tc.relatedKind, tc.listFunc, tc.deleteFunc)
-				d.DeleteRelated(streams, []string{"foo"})
+				d.DeleteRelated([]string{"foo"})
 			}
 			d.PrintSuccesses(streams)
 			if err := d.Errors(); err != nil {
@@ -121,8 +121,8 @@ func TestDeleteAndDeleteRelated(t *testing.T) {
 			streams := &cli.Stream{Out: stdout, Err: stderr}
 			d := New(tc.kind, tc.deleteFunc)
 			d.WithRelated(tc.relatedKind, tc.listRelatedFunc, tc.deleteRelatedFunc)
-			deletedNames := d.Delete(streams, tc.names)
-			d.DeleteRelated(streams, deletedNames)
+			deletedNames := d.Delete(tc.names)
+			d.DeleteRelated(deletedNames)
 			d.PrintSuccesses(streams)
 			if err := d.Errors(); err != nil {
 				if tc.expectedErr == "" {

--- a/pkg/formatted/completion.go
+++ b/pkg/formatted/completion.go
@@ -26,6 +26,6 @@ func BaseCompletion(target string, args []string) ([]string, cobra.ShellCompDire
 }
 
 // ParentCompletion do completion of command to the Parent
-func ParentCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func ParentCompletion(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return BaseCompletion(cmd.Parent().Name(), args)
 }

--- a/pkg/test/dynamic/clientset/errorclient.go
+++ b/pkg/test/dynamic/clientset/errorclient.go
@@ -42,46 +42,46 @@ func (i errorResourceInterface) err() error {
 	return fmt.Errorf("resource %+v not supported", i.resource)
 }
 
-func (i errorResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) Create(_ context.Context, _ *unstructured.Unstructured, _ metav1.CreateOptions, _ ...string) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) Update(_ context.Context, _ *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) UpdateStatus(_ context.Context, _ *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+func (i errorResourceInterface) Delete(_ context.Context, _ string, _ metav1.DeleteOptions, _ ...string) error {
 	return i.err()
 }
 
-func (i errorResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (i errorResourceInterface) DeleteCollection(_ context.Context, _ metav1.DeleteOptions, _ metav1.ListOptions) error {
 	return i.err()
 }
 
-func (i errorResourceInterface) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) Get(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (i errorResourceInterface) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (i errorResourceInterface) Watch(_ context.Context, _ metav1.ListOptions) (watch.Interface, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) Patch(_ context.Context, _ string, _ types.PatchType, _ []byte, _ metav1.PatchOptions, _ ...string) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) Apply(_ context.Context, _ string, _ *unstructured.Unstructured, _ metav1.ApplyOptions, _ ...string) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }
 
-func (i errorResourceInterface) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+func (i errorResourceInterface) ApplyStatus(_ context.Context, _ string, _ *unstructured.Unstructured, _ metav1.ApplyOptions) (*unstructured.Unstructured, error) {
 	return nil, i.err()
 }

--- a/pkg/test/params.go
+++ b/pkg/test/params.go
@@ -35,8 +35,6 @@ type Params struct {
 	Dynamic              dynamic.Interface
 }
 
-var _ cli.Params = &Params{}
-
 func (p *Params) SetNamespace(ns string) {
 	p.ns = ns
 }
@@ -44,7 +42,7 @@ func (p *Params) Namespace() string {
 	return p.ns
 }
 
-func (p *Params) SetNoColour(b bool) {
+func (p *Params) SetNoColour(_ bool) {
 }
 
 func (p *Params) SetKubeConfigPath(path string) {
@@ -75,7 +73,7 @@ func (p *Params) KubeClient() (k8s.Interface, error) {
 	return p.Kube, nil
 }
 
-func (p *Params) Clients(config ...*rest.Config) (*cli.Clients, error) {
+func (p *Params) Clients(_ ...*rest.Config) (*cli.Clients, error) {
 	if p.Cls != nil {
 		return p.Cls, nil
 	}

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -76,10 +76,5 @@ func VerifyInterface(
 
 	h := sha256.New()
 	h.Write(ts)
-
-	if err := verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(h.Sum(nil))); err != nil {
-		return err
-	}
-
-	return nil
+	return verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(h.Sum(nil)))
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -87,9 +87,8 @@ func getDeployments(c *cli.Clients, newLabel, oldLabel, ns string) (*v1.Deployme
 		if err != nil {
 			if strings.Contains(err.Error(), fmt.Sprintf(`cannot list resource "deployments" in API group "apps" in the namespace "%s"`, n)) {
 				continue
-			} else {
-				return nil, err
 			}
+			return nil, err
 		}
 		if len(deployments.Items) != 0 {
 			break

--- a/pkg/workspaces/workspaces.go
+++ b/pkg/workspaces/workspaces.go
@@ -90,7 +90,7 @@ func parseWorkspace(w []string, httpClient http.Client) (map[string]v1beta1.Work
 		}
 
 		if vctFile, err := getPar(r, volumeClaimTemplateFile); err == nil {
-			err = setWorkspaceVCTemplate(r, &wB, vctFile, httpClient)
+			err = setWorkspaceVCTemplate(&wB, vctFile, httpClient)
 			if err != nil {
 				return nil, err
 			}
@@ -99,7 +99,7 @@ func parseWorkspace(w []string, httpClient http.Client) (map[string]v1beta1.Work
 		}
 
 		if csiFile, err := getPar(r, csiFile); err == nil {
-			err = setWorkspaceCSITemplate(r, &wB, csiFile, httpClient)
+			err = setWorkspaceCSITemplate(&wB, csiFile, httpClient)
 			if err != nil {
 				return nil, err
 			}
@@ -244,7 +244,7 @@ func setWorkspaceEmptyDir(r []string, wB *v1beta1.WorkspaceBinding) error {
 	return nil
 }
 
-func setWorkspaceVCTemplate(r []string, wB *v1beta1.WorkspaceBinding, vctFile string, httpClient http.Client) error {
+func setWorkspaceVCTemplate(wB *v1beta1.WorkspaceBinding, vctFile string, httpClient http.Client) error {
 	pvc, err := parseVolumeClaimTemplate(vctFile, httpClient)
 	if err != nil {
 		return err
@@ -254,7 +254,7 @@ func setWorkspaceVCTemplate(r []string, wB *v1beta1.WorkspaceBinding, vctFile st
 	return nil
 }
 
-func setWorkspaceCSITemplate(r []string, wB *v1beta1.WorkspaceBinding, vctFile string, httpClient http.Client) error {
+func setWorkspaceCSITemplate(wB *v1beta1.WorkspaceBinding, vctFile string, httpClient http.Client) error {
 	csi, err := parseCSITemplate(vctFile, httpClient)
 	if err != nil {
 		return err

--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -147,7 +147,7 @@ func GetPipelineRunListWithName(c *framework.Clients, pname string, sortByStartT
 	return pipelineRunList
 }
 
-func GetTaskRunListByLabel(c *framework.Clients, tname string, sortByStartTime bool, label string) *v1.TaskRunList {
+func GetTaskRunListByLabel(c *framework.Clients, sortByStartTime bool, label string) *v1.TaskRunList {
 	opts := metav1.ListOptions{
 		LabelSelector: label,
 	}
@@ -168,12 +168,12 @@ func GetTaskRunListByLabel(c *framework.Clients, tname string, sortByStartTime b
 
 func GetTaskRunListWithTaskName(c *framework.Clients, tname string, sortByStartTime bool) *v1.TaskRunList {
 	label := fmt.Sprintf("tekton.dev/task=%s", tname)
-	return GetTaskRunListByLabel(c, tname, sortByStartTime, label)
+	return GetTaskRunListByLabel(c, sortByStartTime, label)
 }
 
 func GetTaskRunListWithClusterTaskName(c *framework.Clients, ctname string, sortByStartTime bool) *v1.TaskRunList {
 	label := fmt.Sprintf("tekton.dev/clusterTask=%s", ctname)
-	return GetTaskRunListByLabel(c, ctname, sortByStartTime, label)
+	return GetTaskRunListByLabel(c, sortByStartTime, label)
 }
 
 func GetPipelineRunList(c *framework.Clients) *v1.PipelineRunList {

--- a/test/e2e/eventlistener/eventListener_test.go
+++ b/test/e2e/eventlistener/eventListener_test.go
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package eventListener
+package eventlistener
 
 import (
 	"context"

--- a/test/framework/helper.go
+++ b/test/framework/helper.go
@@ -132,7 +132,7 @@ func DeleteNamespace(namespace string, cs *Clients) {
 	}
 }
 
-func getDefaultSA(kubeClient kubernetes.Interface, namespace string) string {
+func getDefaultSA(kubeClient kubernetes.Interface) string {
 	configDefaultsCM, err := kubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(context.Background(), config.GetDefaultsConfigName(), metav1.GetOptions{})
 	if err != nil {
 		log.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetDefaultsConfigName(), err)
@@ -145,7 +145,7 @@ func getDefaultSA(kubeClient kubernetes.Interface, namespace string) string {
 }
 
 func VerifyServiceAccountExistence(namespace string, kubeClient kubernetes.Interface) {
-	defaultSA := getDefaultSA(kubeClient, namespace)
+	defaultSA := getDefaultSA(kubeClient)
 	log.Printf("Verify SA %q is created in namespace %q", defaultSA, namespace)
 
 	if err := wait.PollImmediate(Interval, Apitimeout, func() (bool, error) {


### PR DESCRIPTION
This patch updgrade golangci version to v1.52.2
and replace deadcode with unused as it was deprecated in the v1.49.0 and also fixes lint errors

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
This will upgrade golangci version to v1.52.2 and fix lint errors
```