### PR TITLE
Expose the tkn clinetVersion

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -38,7 +38,7 @@ const (
 
 var (
 	// NOTE: use go build -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(git describe)"
-	clientVersion = devVersion
+	ClientVersion = devVersion
 	// flag to skip check flag in version cmd
 	skipCheckFlag = "false"
 	// NOTE: use go build -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.namespace=tekton-pipelines"
@@ -74,7 +74,7 @@ func Command(p cli.Params) *cobra.Command {
 			if err == nil {
 				switch component {
 				case "":
-					fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
+					fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", ClientVersion)
 					chainsVersion, _ := version.GetChainsVersion(cs, namespace)
 					if chainsVersion != "" {
 						fmt.Fprintf(cmd.OutOrStdout(), "Chains version: %s\n", chainsVersion)
@@ -99,7 +99,7 @@ func Command(p cli.Params) *cobra.Command {
 						fmt.Fprintf(cmd.OutOrStdout(), "Operator version: %s\n", operatorVersion)
 					}
 				case "client":
-					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", clientVersion)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ClientVersion)
 				case "chains":
 					chainsVersion, _ := version.GetChainsVersion(cs, namespace)
 					if chainsVersion == "" {
@@ -136,9 +136,9 @@ func Command(p cli.Params) *cobra.Command {
 			} else {
 				switch component {
 				case "":
-					fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
+					fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", ClientVersion)
 				case "client":
-					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", clientVersion)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ClientVersion)
 				case "chains", "pipeline", "triggers", "dashboard", "operator":
 					fmt.Fprintf(cmd.OutOrStdout(), "unknown\n")
 				default:
@@ -146,7 +146,7 @@ func Command(p cli.Params) *cobra.Command {
 				}
 			}
 
-			if !check || clientVersion == devVersion {
+			if !check || ClientVersion == devVersion {
 				return nil
 			}
 
@@ -245,7 +245,7 @@ func checkRelease(client *Client) (string, error) {
 		return "", err
 	}
 
-	current, err := parseVersion(clientVersion)
+	current, err := parseVersion(ClientVersion)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func TestVersionGood(t *testing.T) {
-	v := clientVersion
-	defer func() { clientVersion = v }()
+	v := ClientVersion
+	defer func() { ClientVersion = v }()
 
 	scenarios := []struct {
 		name          string
@@ -60,7 +60,7 @@ func TestVersionGood(t *testing.T) {
 	}
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
-			clientVersion = s.clientVersion
+			ClientVersion = s.clientVersion
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				okResponse, _ := json.Marshal(GHVersion{
 					TagName: s.serverVersion,
@@ -79,7 +79,7 @@ func TestVersionGood(t *testing.T) {
 		})
 	}
 
-	clientVersion = "v1.2.3"
+	ClientVersion = "v1.2.3"
 
 	seedData, _ := test.SeedV1beta1TestData(t, pipelinetest.Data{})
 
@@ -172,8 +172,8 @@ func TestGetComponentVersions(t *testing.T) {
 }
 
 func TestVersionBad(t *testing.T) {
-	v := clientVersion
-	defer func() { clientVersion = v }()
+	v := ClientVersion
+	defer func() { ClientVersion = v }()
 
 	scenarios := []struct {
 		name          string
@@ -197,7 +197,7 @@ func TestVersionBad(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
-			clientVersion = s.clientVersion
+			ClientVersion = s.clientVersion
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				okResponse, _ := json.Marshal(GHVersion{
 					TagName: s.serverVersion,


### PR DESCRIPTION
This patch exposes tkn clinetVersion for external access

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
This will expose tkn clinetVersion for external access
```
