### PR TITLE
Bump golangci-lint to 1.53.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
 
-GOLANGCI_VERSION = v1.52.2
+GOLANGCI_VERSION = v1.53.3
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 
@@ -100,7 +100,7 @@ $(BIN)/golangci-lint: ; $(info $(M) getting golangci-lint $(GOLANGCI_VERSION))
 
 .PHONY: lint-go
 lint-go: | $(GOLANGCILINT) ; $(info $(M) running golangci-lint…) @ ## Run golangci-lint
-	$Q $(GOLANGCILINT) run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --deadline 5m
+	$Q $(GOLANGCILINT) run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --timeout 10m
 	@rm -f $(GOLANGCILINT)
 
 GOIMPORTS = $(BIN)/goimports

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -54,7 +54,7 @@ spec:
         - name: flags
           value: "-v --timeout 20m"
         - name: version
-          value: v1.52.2
+          value: v1.53.3
       workspaces:
         - name: source
           workspace: shared-workspace


### PR DESCRIPTION
Bump golangci-lint to 1.53.3 and also
increase timeout to 10m as jobs are failing sometimes in CI

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Bump golangci-lint to 1.53.3
```