### PR TITLE
Support for Manifest annotations in `bundle push`

### DIFF
--- a/docs/cmd/tkn_bundle_push.md
+++ b/docs/cmd/tkn_bundle_push.md
@@ -29,6 +29,7 @@ Input:
 ### Options
 
 ```
+      --annotate strings         OCI Manifest annotation in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple annotations.
   -f, --filenames strings        List of fully-qualified file paths containing YAML or JSON defined Tekton objects to include in this bundle
   -h, --help                     help for push
       --remote-bearer string     A Bearer token to authenticate against the repository

--- a/docs/man/man1/tkn-bundle-push.1
+++ b/docs/man/man1/tkn-bundle-push.1
@@ -42,6 +42,10 @@ Input:
 
 .SH OPTIONS
 .PP
+\fB\-\-annotate\fP=[]
+    OCI Manifest annotation in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple annotations.
+
+.PP
 \fB\-f\fP, \fB\-\-filenames\fP=[]
     List of fully\-qualified file paths containing YAML or JSON defined Tekton objects to include in this bundle
 

--- a/pkg/bundle/builder.go
+++ b/pkg/bundle/builder.go
@@ -21,8 +21,8 @@ import (
 
 // BuildTektonBundle will return a complete OCI Image usable as a Tekton Bundle built by parsing, decoding, and
 // compressing the provided contents as Tekton objects.
-func BuildTektonBundle(contents []string, log io.Writer) (v1.Image, error) {
-	img := empty.Image
+func BuildTektonBundle(contents []string, annotations map[string]string, log io.Writer) (v1.Image, error) {
+	img := mutate.Annotations(empty.Image, annotations).(v1.Image)
 
 	if len(contents) > tkremote.MaximumBundleObjects {
 		return nil, fmt.Errorf("bundle contains more than the maximum %d allow objects", tkremote.MaximumBundleObjects)

--- a/pkg/bundle/builder_test.go
+++ b/pkg/bundle/builder_test.go
@@ -34,7 +34,8 @@ func TestBuildTektonBundle(t *testing.T) {
 		return
 	}
 
-	img, err := BuildTektonBundle([]string{string(raw)}, &bytes.Buffer{})
+	annotations := map[string]string{"org.opencontainers.image.license": "Apache-2.0", "org.opencontainers.image.url": "https://example.org"}
+	img, err := BuildTektonBundle([]string{string(raw)}, annotations, &bytes.Buffer{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -52,6 +53,11 @@ func TestBuildTektonBundle(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 		return
+	}
+
+	ann := manifest.Annotations
+	if len(ann) != len(annotations) || fmt.Sprint(ann) != fmt.Sprint(annotations) {
+		t.Errorf("Requested annotations were not set wanted: %s, got %s", annotations, ann)
 	}
 
 	if len(manifest.Layers) != 1 {
@@ -123,7 +129,7 @@ func TestBadObj(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = BuildTektonBundle([]string{string(raw)}, &bytes.Buffer{})
+	_, err = BuildTektonBundle([]string{string(raw)}, nil, &bytes.Buffer{})
 	noNameErr := errors.New("kubernetes resources should have a name")
 	if err == nil {
 		t.Errorf("expected error: %v", noNameErr)
@@ -146,7 +152,7 @@ func TestLessThenMaxBundle(t *testing.T) {
 		return
 	}
 	// no error for less then max
-	_, err = BuildTektonBundle([]string{string(raw)}, &bytes.Buffer{})
+	_, err = BuildTektonBundle([]string{string(raw)}, nil, &bytes.Buffer{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -174,7 +180,7 @@ func TestJustEnoughBundleSize(t *testing.T) {
 		justEnoughObj = append(justEnoughObj, string(raw))
 	}
 	// no error for the max
-	_, err := BuildTektonBundle(justEnoughObj, &bytes.Buffer{})
+	_, err := BuildTektonBundle(justEnoughObj, nil, &bytes.Buffer{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -203,7 +209,7 @@ func TestTooManyInBundle(t *testing.T) {
 	}
 
 	// expect error when we hit the max
-	_, err := BuildTektonBundle(toMuchObj, &bytes.Buffer{})
+	_, err := BuildTektonBundle(toMuchObj, nil, &bytes.Buffer{})
 	if err == nil {
 		t.Errorf("expected error: %v", toManyObjErr)
 	}

--- a/pkg/cmd/bundle/list_test.go
+++ b/pkg/cmd/bundle/list_test.go
@@ -104,7 +104,7 @@ func TestListCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			img, err := bundle.BuildTektonBundle([]string{examplePullTask, examplePullPipeline}, &bytes.Buffer{})
+			img, err := bundle.BuildTektonBundle([]string{examplePullTask, examplePullPipeline}, nil, &bytes.Buffer{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/params/mergeparams.go
+++ b/pkg/params/mergeparams.go
@@ -121,7 +121,12 @@ func ParseParams(params []string) (map[string]string, error) {
 		if len(r) != 2 {
 			return nil, errors.New(invalidParam + p)
 		}
-		parsedParams[r[0]] = r[1]
+		key := strings.TrimSpace(r[0])
+		val := strings.TrimSpace(r[1])
+		if key == "" {
+			return nil, errors.New(invalidParam + p)
+		}
+		parsedParams[key] = val
 	}
 	return parsedParams, nil
 }

--- a/pkg/params/mergeparams_test.go
+++ b/pkg/params/mergeparams_test.go
@@ -246,15 +246,51 @@ func Test_parseParam(t *testing.T) {
 }
 
 func Test_ParseParams(t *testing.T) {
+	t.Run("happy day", func(t *testing.T) {
+		pass := []string{"abc=bcd", "one=two"}
+		got, err := ParseParams(pass)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("expected two elements, got: %v", got)
+		}
+		test.AssertOutput(t, "bcd", got["abc"])
+		test.AssertOutput(t, "two", got["one"])
+	})
 
-	pass := []string{"abc=bcd", "one=two"}
-	got, _ := ParseParams(pass)
-	test.AssertOutput(t, "bcd", got["abc"])
+	t.Run("missing =", func(t *testing.T) {
+		pass := []string{"abc"}
+		_, err := ParseParams(pass)
+		if err == nil {
+			t.Errorf("Expected error")
+		}
+		test.AssertOutput(t, "invalid input format for param parameter: abc", err.Error())
+	})
 
-	pass = []string{"abc"}
-	_, err := ParseParams(pass)
-	if err == nil {
-		t.Errorf("Expected error")
-	}
-	test.AssertOutput(t, "invalid input format for param parameter: abc", err.Error())
+	t.Run("missing key and value", func(t *testing.T) {
+		pass := []string{"="}
+		_, err := ParseParams(pass)
+		if err == nil {
+			t.Errorf("Expected error")
+		}
+		test.AssertOutput(t, "invalid input format for param parameter: =", err.Error())
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		pass := []string{"=val"}
+		_, err := ParseParams(pass)
+		if err == nil {
+			t.Errorf("Expected error")
+		}
+		test.AssertOutput(t, "invalid input format for param parameter: =val", err.Error())
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		got, err := ParseParams([]string{"key="})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		test.AssertOutput(t, "", got["key"])
+	})
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds `--annotate` parameter to `tkn bundle push` to set any OCI Manifest annotations on the bundle image.

Fixes #1933

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Add support for OCI Manifest Annotations via "--annotate" parameter to "tkn bundle push"
```