### PR TITLE
Bump golangci-lint to v1.54.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,10 @@
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    # temporarily disabling G602 due to https://github.com/securego/gosec/issues/1005
+    - path: _test\.go
+      linters:
+        - gosec
 run:
   issues-exit-code: 1
   build-tags:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
 
-GOLANGCI_VERSION = v1.53.3
+GOLANGCI_VERSION = v1.54.2
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 

--- a/pkg/cmd/clustertask/list.go
+++ b/pkg/cmd/clustertask/list.go
@@ -101,11 +101,13 @@ func printClusterTaskDetails(s *cli.Stream, p cli.Params, noHeaders bool) error 
 		fmt.Fprintln(w, header)
 	}
 
-	for _, clustertask := range clustertasks.Items {
+	clusterTaskItems := clustertasks.Items
+
+	for idx := range clusterTaskItems {
 		fmt.Fprintf(w, body,
-			clustertask.Name,
-			formatted.FormatDesc(clustertask.Spec.Description),
-			formatted.Age(&clustertask.CreationTimestamp, p.Time()),
+			clusterTaskItems[idx].Name,
+			formatted.FormatDesc(clusterTaskItems[idx].Spec.Description),
+			formatted.Age(&clusterTaskItems[idx].CreationTimestamp, p.Time()),
 		)
 	}
 	return w.Flush()

--- a/pkg/cmd/clustertriggerbinding/list.go
+++ b/pkg/cmd/clustertriggerbinding/list.go
@@ -115,10 +115,13 @@ func printFormatted(s *cli.Stream, tbs *v1beta1.ClusterTriggerBindingList, p cli
 	if !noHeaders {
 		fmt.Fprintln(w, "NAME\tAGE")
 	}
-	for _, tb := range tbs.Items {
+
+	clusterTriggerBindings := tbs.Items
+
+	for idx := range clusterTriggerBindings {
 		fmt.Fprintf(w, "%s\t%s\n",
-			tb.Name,
-			formatted.Age(&tb.CreationTimestamp, p.Time()),
+			clusterTriggerBindings[idx].Name,
+			formatted.Age(&clusterTriggerBindings[idx].CreationTimestamp, p.Time()),
 		)
 	}
 

--- a/pkg/cmd/eventlistener/list.go
+++ b/pkg/cmd/eventlistener/list.go
@@ -121,26 +121,29 @@ func printFormatted(s *cli.Stream, els *v1beta1.EventListenerList, p cli.Params,
 	if !noHeaders {
 		fmt.Fprintln(w, headers)
 	}
-	for _, el := range els.Items {
+
+	eventListeners := els.Items
+
+	for idx := range eventListeners {
 
 		status := corev1.ConditionStatus("---")
-		if len(el.Status.Conditions) > 0 && len(el.Status.Conditions[0].Status) > 0 {
-			status = el.Status.Conditions[0].Status
+		if len(eventListeners[idx].Status.Conditions) > 0 && len(eventListeners[idx].Status.Conditions[0].Status) > 0 {
+			status = eventListeners[idx].Status.Conditions[0].Status
 		}
 
 		if allNamespaces {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-				el.Namespace,
-				el.Name,
-				formatted.Age(&el.CreationTimestamp, p.Time()),
-				formatted.FormatAddress(getURL(el)),
+				eventListeners[idx].Namespace,
+				eventListeners[idx].Name,
+				formatted.Age(&eventListeners[idx].CreationTimestamp, p.Time()),
+				formatted.FormatAddress(getURL(eventListeners[idx])),
 				status,
 			)
 		} else {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-				el.Name,
-				formatted.Age(&el.CreationTimestamp, p.Time()),
-				formatted.FormatAddress(getURL(el)),
+				eventListeners[idx].Name,
+				formatted.Age(&eventListeners[idx].CreationTimestamp, p.Time()),
+				formatted.FormatAddress(getURL(eventListeners[idx])),
 				status,
 			)
 		}

--- a/pkg/cmd/triggerbinding/list.go
+++ b/pkg/cmd/triggerbinding/list.go
@@ -130,17 +130,20 @@ func printFormatted(s *cli.Stream, tbs *v1beta1.TriggerBindingList, p cli.Params
 	if !noHeaders {
 		fmt.Fprintln(w, headers)
 	}
-	for _, tb := range tbs.Items {
+
+	triggerBindings := tbs.Items
+
+	for idx := range triggerBindings {
 		if allNamespaces {
 			fmt.Fprintf(w, "%s\t%s\t%s\n",
-				tb.Namespace,
-				tb.Name,
-				formatted.Age(&tb.CreationTimestamp, p.Time()),
+				triggerBindings[idx].Namespace,
+				triggerBindings[idx].Name,
+				formatted.Age(&triggerBindings[idx].CreationTimestamp, p.Time()),
 			)
 		} else {
 			fmt.Fprintf(w, "%s\t%s\n",
-				tb.Name,
-				formatted.Age(&tb.CreationTimestamp, p.Time()),
+				triggerBindings[idx].Name,
+				formatted.Age(&triggerBindings[idx].CreationTimestamp, p.Time()),
 			)
 		}
 	}

--- a/pkg/cmd/triggertemplate/list.go
+++ b/pkg/cmd/triggertemplate/list.go
@@ -120,17 +120,20 @@ func printFormatted(s *cli.Stream, tts *v1beta1.TriggerTemplateList, p cli.Param
 	if !noHeaders {
 		fmt.Fprintln(w, headers)
 	}
-	for _, tt := range tts.Items {
+
+	triggerTemplates := tts.Items
+
+	for idx := range triggerTemplates {
 		if allNamespaces {
 			fmt.Fprintf(w, "%s\t%s\t%s\n",
-				tt.Namespace,
-				tt.Name,
-				formatted.Age(&tt.CreationTimestamp, p.Time()),
+				triggerTemplates[idx].Namespace,
+				triggerTemplates[idx].Name,
+				formatted.Age(&triggerTemplates[idx].CreationTimestamp, p.Time()),
 			)
 		} else {
 			fmt.Fprintf(w, "%s\t%s\n",
-				tt.Name,
-				formatted.Age(&tt.CreationTimestamp, p.Time()),
+				triggerTemplates[idx].Name,
+				formatted.Age(&triggerTemplates[idx].CreationTimestamp, p.Time()),
 			)
 		}
 	}

--- a/pkg/pipelinerun/tracker_test.go
+++ b/pkg/pipelinerun/tracker_test.go
@@ -46,11 +46,11 @@ func TestTracker_pipelinerun_complete(t *testing.T) {
 
 		task1Name = "output-task-1"
 		tr1Name   = "output-task-1"
-		tr1Pod    = "output-task-1-pod-123456"
+		tr1Pods   = "output-task-1-pods-123456"
 
 		task2Name = "output-task-2"
 		tr2Name   = "output-task-2"
-		tr2Pod    = "output-task-2-pod-123456"
+		tr2Pods   = "output-task-2-pods-123456"
 
 		allTasks  = []string{task1Name, task2Name}
 		onlyTask1 = []string{task1Name}
@@ -99,7 +99,7 @@ func TestTracker_pipelinerun_complete(t *testing.T) {
 				},
 				Status: v1.TaskRunStatus{
 					TaskRunStatusFields: v1.TaskRunStatusFields{
-						PodName: tr1Pod,
+						PodName: tr1Pods,
 					},
 				},
 			},
@@ -115,7 +115,7 @@ func TestTracker_pipelinerun_complete(t *testing.T) {
 				},
 				Status: v1.TaskRunStatus{
 					TaskRunStatusFields: v1.TaskRunStatusFields{
-						PodName: tr2Pod,
+						PodName: tr2Pods,
 					},
 				},
 			},

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -54,7 +54,7 @@ spec:
         - name: flags
           value: "-v --timeout 20m"
         - name: version
-          value: v1.53.3
+          value: v1.54.2
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/test/builder/builder.go
+++ b/test/builder/builder.go
@@ -294,11 +294,13 @@ func ListAllTasksOutput(t *testing.T, cs *framework.Clients, td map[int]interfac
 	}
 	fmt.Fprintln(w, header)
 
-	for _, task := range task.Items {
+	tasks := task.Items
+
+	for idx := range tasks {
 		fmt.Fprintf(w, body,
-			task.Name,
-			formatted.FormatDesc(task.Spec.Description),
-			formatted.Age(&task.CreationTimestamp, clock),
+			tasks[idx].Name,
+			formatted.FormatDesc(tasks[idx].Spec.Description),
+			formatted.Age(&tasks[idx].CreationTimestamp, clock),
 		)
 	}
 	w.Flush()
@@ -327,11 +329,13 @@ func ListAllClusterTasksOutput(t *testing.T, cs *framework.Clients, td map[int]i
 	}
 	fmt.Fprintln(w, header)
 
-	for _, clustertask := range clustertask.Items {
+	clusterTasks := clustertask.Items
+
+	for idx := range clusterTasks {
 		fmt.Fprintf(w, body,
-			clustertask.Name,
-			formatted.FormatDesc(clustertask.Spec.Description),
-			formatted.Age(&clustertask.CreationTimestamp, clock),
+			clusterTasks[idx].Name,
+			formatted.FormatDesc(clusterTasks[idx].Spec.Description),
+			formatted.Age(&clusterTasks[idx].CreationTimestamp, clock),
 		)
 	}
 	w.Flush()


### PR DESCRIPTION
# Changes

Fixes couple of lint issues:
- G101: Potential hardcoded credentials
- G601: Implicit memory aliasing in for loop.

Temporarily disabling:
- G602: Potentially accessing slice out of bounds as this is a known
  false positive and can be tracked at https://github.com/securego/gosec/issues/1005

Also bump golangci-lint version in release pipeline

Signed-off-by: vinamra28 <jvinamra776@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Run the code checkers with `make check`
- [X] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```