### PR TITLE
Bump goreleaser version and optimize get-version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,14 +17,14 @@ builds:
   ldflags:
   - -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}
 archives:
-- name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-    arm64: aarch64
+- name_template: >-
+    {{- .Binary }}_
+    {{- .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else if eq .Arch "arm64" }}aarch64
+    {{- else }}{{ .Arch }}{{ end }}
   format_overrides:
     - goos: windows
       format: zip
@@ -41,11 +41,10 @@ changelog:
     - Merge pull request
     - Merge branch
 release:
-  prerelease: true
+  prerelease: "true"
 brews:
-  -
-    name: tektoncd-cli
-    tap:
+  - name: tektoncd-cli
+    repository:
       owner: tektoncd
       name: homebrew-tools
     folder: Formula
@@ -62,7 +61,15 @@ brews:
       (zsh_completion/"_tkn").write output
       prefix.install_metafiles
 nfpms:
-  - file_name_template: "tektoncd-cli-{{.Version}}_{{.Os}}-{{.Arch}}"
+  - file_name_template: >-
+      tektoncd-cli-
+      {{- .Version }}_
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}64bit
+      {{- else if eq .Arch "386" }}32bit
+      {{- else if eq .Arch "arm" }}ARM
+      {{- else if eq .Arch "arm64" }}ARM64
+      {{- else }}{{ .Arch }}{{ end }}
     homepage: https://github.com/tektoncd/cli/
     description: A command line interface for interacting with Tekton
     maintainer: Tekton Developers <tekton@tekton.dev>
@@ -72,15 +79,6 @@ nfpms:
     - deb
     - rpm
     bindir: /usr/bin
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-
 universal_binaries:
 - replace: true
   name_template: 'tkn'

--- a/tekton/get-version.yaml
+++ b/tekton/get-version.yaml
@@ -10,19 +10,15 @@ spec:
     - name: package
       description: base package where the source code lies
   steps:
-    - name: pull
-      image: goreleaser/goreleaser
+    - name: pull-get-versions
+      image: alpine/git:v2.40.1
       workingDir: $(workspaces.source.path)
       script: |
+        git config --global --add safe.directory $(workspaces.source.path)
         git status && git fetch -p --all
-    - name: get-versions
-      # because it has git
-      image: goreleaser/goreleaser
-      workingDir: $(workspaces.source.path)
-      script: |
-        echo -n $(git tag --points-at HEAD) > /tekton/results/version
-        echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\1/') > /tekton/results/major
-        echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\2/') > /tekton/results/minor
+        echo -n $(git tag --points-at HEAD) > $(results.version.path)
+        echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\1/') > $(results.major.path)
+        echo -n $(git tag --points-at HEAD | sed 's/^v\([^\.]*\)\.\([^\.]*\).*/\2/') > $(results.minor.path)
   results:
     - name: version
     - name: major

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -100,7 +100,7 @@ spec:
         - name: github-token-secret-key
           value: $(params.github-token-secret-key)
         - name: image
-          value: goreleaser/goreleaser:v1.11.5
+          value: goreleaser/goreleaser:v1.20.0
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -115,14 +115,15 @@ kubectl create namespace ${TARGET_NAMESPACE} 2>/dev/null || true
 
 for task in ${CATALOG_TASKS};do
   if [ ${task} == "lint" ]; then
-    kubectl -n ${TARGET_NAMESPACE} apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golangci-${task}/0.2/golangci-${task}.yaml
+    tkn -n ${TARGET_NAMESPACE} hub install task golangci-lint
   else
-    kubectl -n ${TARGET_NAMESPACE} apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-${task}/0.2/golang-${task}.yaml
+    tkn -n ${TARGET_NAMESPACE} hub install task golang-${task}
   fi
 done
 
-kubectl -n ${TARGET_NAMESPACE} apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.6/git-clone.yaml
-kubectl -n ${TARGET_NAMESPACE} apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/goreleaser/0.2/goreleaser.yaml
+tkn -n ${TARGET_NAMESPACE} install task git-clone
+tkn -n ${TARGET_NAMESPACE} install task goreleaser
+
 kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/get-version.yaml
 kubectl -n ${TARGET_NAMESPACE} apply -f ./tekton/publish.yaml
 


### PR DESCRIPTION
# Changes

With go version v1.20.7, goreleaser version also need to be upgraded to v1.15.2.

Also in get-version task we were running two steps and both the steps were using same image, hence merged both into a single step. Also the task was using goreleaser image which is more than 300M in size, instead using alpine/git which is ~21M

Also use tkn hub install to install tasks from catalog so that we always use the latest one available

----

With goreleaser version v1.14.0, archives.replacements and
nfpms.replacements have been deprecated and we can leverage their
respective name_template and file_name_template. Also the `replacements`
property has been removed in v1.19.0.

Updating goreleaser.yaml as per the suggested approach specified at
https://goreleaser.com/deprecations/#archivesreplacements

Signed-off-by: vinamra28 <jvinamra776@gmail.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [NA] Run the code checkers with `make check`
- [NA] Regenerate the manpages, docs and go formatting with `make generated`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```