### PR TITLE
Reproducible/deterministic bundles

### DIFF
--- a/docs/cmd/tkn_bundle_push.md
+++ b/docs/cmd/tkn_bundle_push.md
@@ -30,6 +30,7 @@ Input:
 
 ```
       --annotate strings         OCI Manifest annotation in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple annotations.
+      --ctime string             YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS or RFC3339 formatted created time to set, defaults to current time. In non RFC3339 syntax dates are in UTC timezone.
   -f, --filenames strings        List of fully-qualified file paths containing YAML or JSON defined Tekton objects to include in this bundle
   -h, --help                     help for push
       --remote-bearer string     A Bearer token to authenticate against the repository

--- a/docs/man/man1/tkn-bundle-push.1
+++ b/docs/man/man1/tkn-bundle-push.1
@@ -46,6 +46,10 @@ Input:
     OCI Manifest annotation in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple annotations.
 
 .PP
+\fB\-\-ctime\fP=""
+    YYYY\-MM\-DD, YYYY\-MM\-DDTHH:MM:SS or RFC3339 formatted created time to set, defaults to current time. In non RFC3339 syntax dates are in UTC timezone.
+
+.PP
 \fB\-f\fP, \fB\-\-filenames\fP=[]
     List of fully\-qualified file paths containing YAML or JSON defined Tekton objects to include in this bundle
 

--- a/pkg/bundle/builder.go
+++ b/pkg/bundle/builder.go
@@ -23,7 +23,7 @@ import (
 
 // BuildTektonBundle will return a complete OCI Image usable as a Tekton Bundle built by parsing, decoding, and
 // compressing the provided contents as Tekton objects.
-func BuildTektonBundle(contents []string, annotations map[string]string, log io.Writer) (v1.Image, error) {
+func BuildTektonBundle(contents []string, annotations map[string]string, ctime time.Time, log io.Writer) (v1.Image, error) {
 	img := mutate.Annotations(empty.Image, annotations).(v1.Image)
 
 	if len(contents) > tkremote.MaximumBundleObjects {
@@ -32,7 +32,7 @@ func BuildTektonBundle(contents []string, annotations map[string]string, log io.
 
 	fmt.Fprint(log, "Creating Tekton Bundle:\n")
 
-	// sort the contens based on the digest of the content, this keeps the layer
+	// sort the contents based on the digest of the content, this keeps the layer
 	// order in the image manifest deterministic
 	sort.Slice(contents, func(i, j int) bool {
 		iDigest := sha256.Sum256([]byte(contents[i]))
@@ -96,7 +96,7 @@ func BuildTektonBundle(contents []string, annotations map[string]string, log io.
 	}
 
 	// Set created time for bundle image
-	img, err := mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	img, err := mutate.CreatedAt(img, v1.Time{Time: ctime})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add created time to image: %w", err)
 	}

--- a/pkg/cmd/bundle/list_test.go
+++ b/pkg/cmd/bundle/list_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -104,7 +105,7 @@ func TestListCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			img, err := bundle.BuildTektonBundle([]string{examplePullTask, examplePullPipeline}, nil, &bytes.Buffer{})
+			img, err := bundle.BuildTektonBundle([]string{examplePullTask, examplePullPipeline}, nil, time.Now(), &bytes.Buffer{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/bundle/list_test.go
+++ b/pkg/cmd/bundle/list_test.go
@@ -47,15 +47,15 @@ func TestListCommand(t *testing.T) {
 		{
 			name:           "no-format",
 			format:         "",
-			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\npipeline.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\npipeline.tekton.dev/foobar\ntask.tekton.dev/foobar\n",
 		}, {
 			name:           "name-format",
 			format:         "name",
-			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\ntask.tekton.dev/foobar\npipeline.tekton.dev/foobar\n",
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\npipeline.tekton.dev/foobar\ntask.tekton.dev/foobar\n",
 		}, {
 			name:           "yaml-format",
 			format:         "yaml",
-			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\n" + examplePullTask + examplePullPipeline,
+			expectedStdout: "*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)\n" + examplePullPipeline + examplePullTask,
 		}, {
 			name:           "specify-kind-task",
 			format:         "name",


### PR DESCRIPTION
# Changes

Sorts the bundle image layers according to the digest of the layer's content and adds the `--ctime` parameter to `tkn bundle push` to allow setting the created time in the bundle image config.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Tekton bundle images are reproducible with --ctime provided to tkn bundle push
```

Fixes #2132 