### PR TITLE
Support for `SOURCE_DATE_EPOCH` in `tkn bundle push`

### DIFF
--- a/docs/cmd/tkn_bundle_push.md
+++ b/docs/cmd/tkn_bundle_push.md
@@ -25,6 +25,9 @@ Authentication:
 Input:
 	Valid input in any form is valid Tekton YAML or JSON with a fully-specified "apiVersion" and "kind". To pass multiple objects in a single input, use "---" separators in YAML or a top-level "[]" in JSON.
 
+Created time:
+	Setting created time of the OCI Image Configuration layer can be done by either providing it via --ctime parameter or setting the SOURCE_DATE_EPOCH environment variable.
+
 
 ### Options
 

--- a/docs/man/man1/tkn-bundle-push.1
+++ b/docs/man/man1/tkn-bundle-push.1
@@ -39,6 +39,10 @@ Authentication:
 Input:
     Valid input in any form is valid Tekton YAML or JSON with a fully\-specified "apiVersion" and "kind". To pass multiple objects in a single input, use "\-\-\-" separators in YAML or a top\-level "[]" in JSON.
 
+.PP
+Created time:
+    Setting created time of the OCI Image Configuration layer can be done by either providing it via \-\-ctime parameter or setting the SOURCE\_DATE\_EPOCH environment variable.
+
 
 .SH OPTIONS
 .PP


### PR DESCRIPTION
# Changes

First commit is a refactoring commit to move the code from `PreRunE` to `parseArgsAndFlags`, this is something that in full honesty should have been done on #2133. This way is easier to test the implementation.

Second commit introduces support for `SOURCE_TIME_EPOCH` environment variable in `tkn bundle push`.

Fixes #2136 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Created time in OCI Image Configuration in `tkn bundle push` can be provided using the SOURCE_TIME_EPOCH environment variable
```
