### PR TITLE
Build deterministic bundles by default

### DIFF
--- a/docs/cmd/tkn_bundle_push.md
+++ b/docs/cmd/tkn_bundle_push.md
@@ -26,7 +26,7 @@ Input:
 	Valid input in any form is valid Tekton YAML or JSON with a fully-specified "apiVersion" and "kind". To pass multiple objects in a single input, use "---" separators in YAML or a top-level "[]" in JSON.
 
 Created time:
-	Setting created time of the OCI Image Configuration layer can be done by either providing it via --ctime parameter or setting the SOURCE_DATE_EPOCH environment variable.
+	The default created time of the OCI Image Configuration layer is set to 1970-01-01T00:00:00Z. Changing it can be done by either providing it via --ctime parameter or setting the SOURCE_DATE_EPOCH environment variable.
 
 
 ### Options

--- a/docs/man/man1/tkn-bundle-push.1
+++ b/docs/man/man1/tkn-bundle-push.1
@@ -41,7 +41,7 @@ Input:
 
 .PP
 Created time:
-    Setting created time of the OCI Image Configuration layer can be done by either providing it via \-\-ctime parameter or setting the SOURCE\_DATE\_EPOCH environment variable.
+    The default created time of the OCI Image Configuration layer is set to 1970\-01\-01T00:00:00Z. Changing it can be done by either providing it via \-\-ctime parameter or setting the SOURCE\_DATE\_EPOCH environment variable.
 
 
 .SH OPTIONS

--- a/pkg/cmd/bundle/push_test.go
+++ b/pkg/cmd/bundle/push_test.go
@@ -3,7 +3,6 @@ package bundle
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -17,7 +16,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/jonboulle/clockwork"
 	"github.com/tektoncd/cli/pkg/bundle"
 	"github.com/tektoncd/cli/pkg/cli"
 	tkremote "github.com/tektoncd/pipeline/pkg/remote/oci"
@@ -71,7 +69,7 @@ func TestPushCommand(t *testing.T) {
 				"simple.yaml": exampleTask,
 			},
 			expectedContents: map[string]expected{exampleTaskExpected.name: exampleTaskExpected},
-			expectedCTime:    fixedTime,
+			expectedCTime:    time.Unix(defaultTimestamp, 0),
 		},
 		{
 			name: "stdin-input",
@@ -80,7 +78,7 @@ func TestPushCommand(t *testing.T) {
 			},
 			stdin:            exampleTask,
 			expectedContents: map[string]expected{exampleTaskExpected.name: exampleTaskExpected},
-			expectedCTime:    fixedTime,
+			expectedCTime:    time.Unix(defaultTimestamp, 0),
 		},
 		{
 			name: "with-annotations",
@@ -93,7 +91,7 @@ func TestPushCommand(t *testing.T) {
 				"org.opencontainers.image.license": "Apache-2.0",
 				"org.opencontainers.image.url":     "https://example.org",
 			},
-			expectedCTime: fixedTime,
+			expectedCTime: time.Unix(defaultTimestamp, 0),
 		},
 		{
 			name: "with-ctime",
@@ -153,10 +151,7 @@ func TestPushCommand(t *testing.T) {
 				ctimeParam:         tc.ctime,
 			}
 
-			ctx := context.Background()
-			ctx = clockwork.AddToContext(ctx, clockwork.NewFakeClockAt(fixedTime))
-
-			if err := opts.Run(ctx, []string{ref}); err != nil {
+			if err := opts.Run([]string{ref}); err != nil {
 				t.Errorf("Unexpected failure calling run: %v", err)
 			}
 
@@ -254,7 +249,7 @@ func TestParseTime(t *testing.T) {
 		err      string
 		expected time.Time
 	}{
-		{name: "now", expected: fixedTime},
+		{name: "now", expected: time.Unix(defaultTimestamp, 0)},
 		{name: "date", given: "2023-09-22", expected: time.Date(2023, 9, 22, 0, 0, 0, 0, time.UTC)},
 		{name: "date and time", given: "2023-09-22T01:02:03", expected: time.Date(2023, 9, 22, 1, 2, 3, 0, time.UTC)},
 		{name: "utc with fraction", given: "2023-09-22T01:02:03.45Z", expected: time.Date(2023, 9, 22, 1, 2, 3, 45, time.UTC)},
@@ -266,7 +261,7 @@ func TestParseTime(t *testing.T) {
 			// remove SOURCE_DATE_EPOCH if set externally
 			t.Setenv("SOURCE_DATE_EPOCH", "")
 
-			got, err := determineCTime(c.given, clockwork.NewFakeClockAt(fixedTime))
+			got, err := determineCTime(c.given)
 
 			if err != nil {
 				if err.Error() != c.err {
@@ -342,7 +337,7 @@ func TestParseArgsAndFlags(t *testing.T) {
 			annotationsParams:   []string{"a=b", "c=d"},
 			expectedRef:         "registry.io/repository:tag",
 			expectedAnnotations: map[string]string{"a": "b", "c": "d"},
-			expectedCTime:       fixedTime,
+			expectedCTime:       time.Unix(defaultTimestamp, 0),
 		},
 		{
 			name:          "ctime param",
@@ -405,10 +400,7 @@ func TestParseArgsAndFlags(t *testing.T) {
 				expectedContent = append(expectedContent, c)
 			}
 
-			ctx := context.Background()
-			ctx = clockwork.AddToContext(ctx, clockwork.NewFakeClockAt(fixedTime))
-
-			if err := opts.parseArgsAndFlags(ctx, []string{c.refArg}); err != nil {
+			if err := opts.parseArgsAndFlags([]string{c.refArg}); err != nil {
 				if err.Error() != c.err {
 					t.Errorf("unexpected error, expecting %q, got: %q", c.err, err)
 				}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Sets the default created time to 1970-01-01T00:00:00Z (Unix epoch) instead of the current time.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Default created time of Tekton OCI bundles is set to Unix epoch (1970-01-01T00:00:00Z)
```

Fixes #2135
