### PR TITLE
reflect state of started pipeline/task when using --showlog

### DIFF
--- a/pkg/cmd/clustertask/start.go
+++ b/pkg/cmd/clustertask/start.go
@@ -345,7 +345,36 @@ func startClusterTask(opt startOptions, args []string) error {
 		Params:      opt.cliparams,
 		AllSteps:    false,
 	}
-	return taskrun.Run(runLogOpts)
+
+	if err := taskrun.Run(runLogOpts); err != nil {
+		return err
+	}
+
+	start := time.Now()
+	timeout := 10 * time.Second
+
+	for {
+		trCreated, err = tractions.GetTaskRunV1beta1(taskrunGroupResource, cs, trCreated.Name, trCreated.Namespace)
+		if err != nil {
+			return err
+		}
+
+		if trCreated.IsDone() {
+			break
+		}
+
+		if time.Since(start) > timeout {
+			return errors.New("timeout waiting for TaskRun to be done")
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	// check if the created clustertaskrun succeed or not
+	if !trCreated.IsSuccessful() {
+		return errors.New(trCreated.Name + " has failed.")
+	}
+	return nil
 }
 
 func printTaskRun(output string, s *cli.Stream, tr interface{}) error {


### PR DESCRIPTION
- this change fixes an issue where using --showlog with tkn start pipeline/task does not return a non-zero value when  created taskrun/pipelinerun fails.
- refer #1820

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

task, clustertask and pipeline start command now returns each run status when completed if user specify `--show-log`. It provides better usability for tkn CLI to be used in Task or CI.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
task, clustertask and pipeline start command now returns each run status when completed if user specify `--show-log`. It provides better usability for tkn CLI to be used in Task or CI.
```