### PR TITLE
Adds hub version in output of `tkn version` command

### DIFF
--- a/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline,_chains,_triggers,_dashboard,_hub_and_operator_installed.golden
+++ b/pkg/cmd/version/testdata/TestGetVersions-deployment_with_pipeline,_chains,_triggers,_dashboard,_hub_and_operator_installed.golden
@@ -1,0 +1,7 @@
+Client version: dev
+Chains version: v0.8.0
+Pipeline version: v0.10.0
+Triggers version: v0.5.0
+Dashboard version: v0.7.0
+Operator version: v0.54.0
+Hub version: v1.14.0

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -98,6 +98,10 @@ func Command(p cli.Params) *cobra.Command {
 					if operatorVersion != "" {
 						fmt.Fprintf(cmd.OutOrStdout(), "Operator version: %s\n", operatorVersion)
 					}
+					hubVersion, _ := version.GetHubVersion(cs, namespace)
+					if hubVersion != "" {
+						fmt.Fprintf(cmd.OutOrStdout(), "Hub version: %s\n", hubVersion)
+					}
 				case "client":
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", clientVersion)
 				case "chains":
@@ -130,6 +134,12 @@ func Command(p cli.Params) *cobra.Command {
 						operatorVersion = "unknown"
 					}
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", operatorVersion)
+				case "hub":
+					hubVersion, _ := version.GetHubVersion(cs, namespace)
+					if hubVersion == "" {
+						hubVersion = "unknown"
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", hubVersion)
 				default:
 					fmt.Fprintf(cmd.OutOrStdout(), "Invalid component value\n")
 				}

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -260,6 +260,7 @@ func TestGetVersions(t *testing.T) {
 	triggersConfigMap := getConfigMapData("triggers-info", "v0.5.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
 	dashboardConfigMap := getConfigMapData("dashboard-info", "v0.7.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
 	operatorConfigMap := getConfigMapData("tekton-operator-info", "v0.54.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
+	hubConfigMap := getConfigMapData("hub-info", "v1.14.0", map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"})
 
 	testParams := []struct {
 		name                  string
@@ -305,11 +306,11 @@ func TestGetVersions(t *testing.T) {
 		configMap:             []*corev1.ConfigMap{pipelineConfigMap, triggersConfigMap, dashboardConfigMap, operatorConfigMap},
 		goldenFile:            true,
 	}, {
-		name:                  "deployment with pipeline, chains, triggers, dashboard and operator installed",
+		name:                  "deployment with pipeline, chains, triggers, dashboard, hub and operator installed",
 		namespace:             "test",
 		userProvidedNamespace: "test",
 		deployment:            []*v1.Deployment{},
-		configMap:             []*corev1.ConfigMap{pipelineConfigMap, chainsConfigMap, triggersConfigMap, dashboardConfigMap, operatorConfigMap},
+		configMap:             []*corev1.ConfigMap{pipelineConfigMap, chainsConfigMap, triggersConfigMap, dashboardConfigMap, operatorConfigMap, hubConfigMap},
 		goldenFile:            true,
 	}}
 	for _, tp := range testParams {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,6 +38,7 @@ const (
 	triggersInfo                   string = "triggers-info"
 	dashboardInfo                  string = "dashboard-info"
 	operatorInfo                   string = "tekton-operator-info"
+	hubInfo                        string = "hub-info"
 )
 
 var defaultNamespaces = []string{"tekton-pipelines", "openshift-pipelines", "tekton-chains", "tekton-operator", "openshift-operators"}
@@ -287,6 +288,15 @@ func findDashboardVersion(deployments []v1.Deployment) string {
 // GetOperatorVersion Get operator version
 func GetOperatorVersion(c *cli.Clients, ns string) (string, error) {
 	configMap, err := getConfigMap(c, operatorInfo, ns)
+	if err != nil {
+		return "", err
+	}
+	version := configMap.Data["version"]
+	return version, nil
+}
+
+func GetHubVersion(c *cli.Clients, ns string) (string, error) {
+	configMap, err := getConfigMap(c, hubInfo, ns)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Adds hub version in output of `tkn version` command

UI Example 

```bash
$ tkn version
Client version: 0.21.0
Pipeline version: v0.28.2
Triggers version: v0.16.1
Operator version: v0.53.0
Hub version: v1.14.0
```

Signed-off-by: Puneet Punamiya [ppunamiy@redhat.com](mailto:ppunamiy@redhat.com)

# Release Notes

```release-note
Adds hub version in output of tkn version command
```