### PR TITLE
Fix triggertemplate describe command breaks backward compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/tektoncd/hub v1.16.0
 	github.com/tektoncd/pipeline v0.56.0
 	github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1
-	github.com/tektoncd/triggers v0.26.0
+	github.com/tektoncd/triggers v0.26.1
 	github.com/theupdateframework/go-tuf v0.7.0
 	go.opencensus.io v0.24.0
 	go.uber.org/multierr v1.11.0
@@ -331,7 +331,7 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	knative.dev/eventing v0.30.1-0.20220407170245-58865afba92c // indirect
 	knative.dev/networking v0.0.0-20231017124814-2a7676e912b7 // indirect
-	knative.dev/serving v0.39.0 // indirect
+	knative.dev/serving v0.38.6 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1818,8 +1818,8 @@ github.com/tektoncd/pipeline v0.56.0 h1:Gyti3F5u1ADjI08hG3mGtWgpaaiOfeaxnznL/U/N
 github.com/tektoncd/pipeline v0.56.0/go.mod h1:npl5qTu+yU74zqKIkTVnFfu/1pMhJFZjvnCrH6DlfLM=
 github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1 h1:9paprRIBXQgcvdhGq3wKiSspXP0JIFSY52ru3sIMjKM=
 github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1/go.mod h1:7eWs1XNkmReggow7ggRbRyRuHi7646B8b2XipCZ3VOw=
-github.com/tektoncd/triggers v0.26.0 h1:/EXdGbU2LdFoUTzJjZFXIoFuS1A1ZkW3+zWnmBdteQk=
-github.com/tektoncd/triggers v0.26.0/go.mod h1:X573RMcATfY++Cu0JWqHHV/lPJfT3tdSDaGSAR8krTU=
+github.com/tektoncd/triggers v0.26.1 h1:zP49d0FX5Yfvu7ExD48WEB00S3KNMMVXMMNYh96csj4=
+github.com/tektoncd/triggers v0.26.1/go.mod h1:yYx6AkLl7n4SjyRf9eOyN38frAfRHbjZ3jWHDyRoc64=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
@@ -2853,8 +2853,8 @@ knative.dev/pkg v0.0.0-20220325200448-1f7514acd0c2/go.mod h1:5xt0nzCwxvQ2N4w71sm
 knative.dev/pkg v0.0.0-20231103161548-f5b42e8dea44 h1:2gjHbqg8K9k1KJtLgxsTvzxovXOhozcrk3AzzJmjsA0=
 knative.dev/pkg v0.0.0-20231103161548-f5b42e8dea44/go.mod h1:g+UCgSKQ2f15kHYu/V3CPtoKo5F1x/2Y1ot0NSK7gA0=
 knative.dev/reconciler-test v0.0.0-20220328072550-7d32310c9b3a/go.mod h1:wlz1lGyn5fjJYL5PTSL/SOI4xgVpU+q6D4eaa19NsDA=
-knative.dev/serving v0.39.0 h1:NVt8WthHmFFMWZ3qpBblXt47del8qqrbCegqwGBVSwk=
-knative.dev/serving v0.39.0/go.mod h1:0QIp5mvgWa1oUC2MxMf+Q/JWgG8JhAsSdJKc6iTRlvE=
+knative.dev/serving v0.38.6 h1:G4N2dYuMggJf4Cc4ycen/dYjEF1IlyX3zoRpkou/7zI=
+knative.dev/serving v0.38.6/go.mod h1:5JIK94q75k2Y09CKpFRMe6Rs12bgCGv25wInPor/XCk=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.36.0/go.mod h1:NFUHyPn4ekoC/JHeZFfZurN6ixxawE1BnVonP/oahEI=

--- a/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithOutputYaml.golden
+++ b/pkg/cmd/triggertemplate/testdata/TestTriggerTemplateDescribe_WithOutputYaml.golden
@@ -9,7 +9,7 @@ spec:
   - default: value
     description: test with one param
     name: key
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -31,7 +31,7 @@ type TriggerTemplateSpec struct {
 	// +listType=atomic
 	Params []ParamSpec `json:"params,omitempty"`
 	// +listType=atomic
-	ResourceTemplates []TriggerResourceTemplate `json:"resourceTemplates,omitempty"`
+	ResourceTemplates []TriggerResourceTemplate `json:"resourcetemplates,omitempty"`
 }
 
 // TriggerResourceTemplate describes a resource to create

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -51,10 +51,10 @@ func (s *TriggerTemplateSpec) validate(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField(apis.CurrentField))
 	}
 	if len(s.ResourceTemplates) == 0 {
-		errs = errs.Also(apis.ErrMissingField("resourceTemplates"))
+		errs = errs.Also(apis.ErrMissingField("resourcetemplates"))
 	}
-	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourceTemplates"))
-	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourceTemplates"))
+	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourcetemplates"))
+	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourcetemplates"))
 	return errs
 }
 

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/openapi_generated.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/openapi_generated.go
@@ -1634,7 +1634,7 @@ func schema_pkg_apis_triggers_v1beta1_TriggerTemplateSpec(ref common.ReferenceCa
 							},
 						},
 					},
-					"resourceTemplates": {
+					"resourcetemplates": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-type": "atomic",

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/trigger_template_types.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/trigger_template_types.go
@@ -31,7 +31,7 @@ type TriggerTemplateSpec struct {
 	// +listType=atomic
 	Params []ParamSpec `json:"params,omitempty"`
 	// +listType=atomic
-	ResourceTemplates []TriggerResourceTemplate `json:"resourceTemplates,omitempty"`
+	ResourceTemplates []TriggerResourceTemplate `json:"resourcetemplates,omitempty"`
 }
 
 // TriggerResourceTemplate describes a resource to create

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/trigger_template_validation.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/trigger_template_validation.go
@@ -56,10 +56,10 @@ func (s *TriggerTemplateSpec) validate(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField(apis.CurrentField))
 	}
 	if len(s.ResourceTemplates) == 0 {
-		errs = errs.Also(apis.ErrMissingField("resourceTemplates"))
+		errs = errs.Also(apis.ErrMissingField("resourcetemplates"))
 	}
-	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourceTemplates"))
-	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourceTemplates"))
+	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourcetemplates"))
+	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourcetemplates"))
 	return errs
 }
 

--- a/vendor/knative.dev/serving/AUTHORS
+++ b/vendor/knative.dev/serving/AUTHORS
@@ -1,0 +1,11 @@
+# This is the list of Knative authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google LLC
+Pivotal Software, Inc.
+IBM Corp
+Red Hat, Inc.
+Cisco Systems, Inc.
+VMware, Inc.

--- a/vendor/knative.dev/serving/pkg/apis/config/features.go
+++ b/vendor/knative.dev/serving/pkg/apis/config/features.go
@@ -59,7 +59,6 @@ func defaultFeaturesConfig() *Features {
 		PodSpecNodeSelector:              Disabled,
 		PodSpecRuntimeClassName:          Disabled,
 		PodSpecSecurityContext:           Disabled,
-		PodSpecShareProcessNamespace:     Disabled,
 		PodSpecPriorityClassName:         Disabled,
 		PodSpecSchedulerName:             Disabled,
 		ContainerSpecAddCapabilities:     Disabled,
@@ -92,7 +91,6 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-nodeselector", &nc.PodSpecNodeSelector),
 		asFlag("kubernetes.podspec-runtimeclassname", &nc.PodSpecRuntimeClassName),
 		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
-		asFlag("kubernetes.podspec-shareprocessnamespace", &nc.PodSpecShareProcessNamespace),
 		asFlag("kubernetes.podspec-priorityclassname", &nc.PodSpecPriorityClassName),
 		asFlag("kubernetes.podspec-schedulername", &nc.PodSpecSchedulerName),
 		asFlag("kubernetes.containerspec-addcapabilities", &nc.ContainerSpecAddCapabilities),
@@ -129,7 +127,6 @@ type Features struct {
 	PodSpecNodeSelector              Flag
 	PodSpecRuntimeClassName          Flag
 	PodSpecSecurityContext           Flag
-	PodSpecShareProcessNamespace     Flag
 	PodSpecPriorityClassName         Flag
 	PodSpecSchedulerName             Flag
 	ContainerSpecAddCapabilities     Flag

--- a/vendor/knative.dev/serving/pkg/apis/serving/fieldmask.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/fieldmask.go
@@ -245,9 +245,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 		// This is further validated in ValidatePodSecurityContext.
 		out.SecurityContext = in.SecurityContext
 	}
-	if cfg.Features.PodSpecShareProcessNamespace != config.Disabled {
-		out.ShareProcessNamespace = in.ShareProcessNamespace
-	}
 	if cfg.Features.PodSpecPriorityClassName != config.Disabled {
 		out.PriorityClassName = in.PriorityClassName
 	}
@@ -273,6 +270,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.HostNetwork = false
 	out.HostPID = false
 	out.HostIPC = false
+	out.ShareProcessNamespace = nil
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.Priority = nil
@@ -376,7 +374,6 @@ func HandlerMask(in *corev1.ProbeHandler) *corev1.ProbeHandler {
 	out.Exec = in.Exec
 	out.HTTPGet = in.HTTPGet
 	out.TCPSocket = in.TCPSocket
-	out.GRPC = in.GRPC
 
 	return out
 
@@ -428,22 +425,6 @@ func TCPSocketActionMask(in *corev1.TCPSocketAction) *corev1.TCPSocketAction {
 	// Allowed fields
 	out.Host = in.Host
 	out.Port = in.Port
-
-	return out
-}
-
-// GRPCActionMask performs a _shallow_ copy of the Kubernetes GRPCAction object to a new
-// Kubernetes GRPCAction object bringing over only the fields allowed in the Knative API. This
-// does not validate the contents or the bounds of the provided fields.
-func GRPCActionMask(in *corev1.GRPCAction) *corev1.GRPCAction {
-	if in == nil {
-		return nil
-	}
-	out := new(corev1.GRPCAction)
-
-	// Allowed fields
-	out.Port = in.Port
-	out.Service = in.Service
 
 	return out
 }
@@ -727,14 +708,8 @@ func CapabilitiesMask(ctx context.Context, in *corev1.Capabilities) *corev1.Capa
 	// Allowed fields
 	out.Drop = in.Drop
 
-	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities == config.Enabled {
+	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled {
 		out.Add = in.Add
-	} else if config.FromContextOrDefaults(ctx).Features.SecurePodDefaults == config.Enabled {
-		if len(in.Add) == 1 && in.Add[0] == "NET_BIND_SERVICE" {
-			out.Add = in.Add
-		} else {
-			out.Add = nil
-		}
 	}
 
 	return out

--- a/vendor/knative.dev/serving/pkg/apis/serving/k8s_validation.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/k8s_validation.go
@@ -832,13 +832,9 @@ func validateProbe(p *corev1.Probe, port corev1.ContainerPort) *apis.FieldError 
 		handlers = append(handlers, "exec")
 		errs = errs.Also(apis.CheckDisallowedFields(*h.Exec, *ExecActionMask(h.Exec))).ViaField("exec")
 	}
-	if h.GRPC != nil {
-		handlers = append(handlers, "gRPC")
-		errs = errs.Also(apis.CheckDisallowedFields(*h.GRPC, *GRPCActionMask(h.GRPC))).ViaField("grpc")
-	}
 
 	if len(handlers) == 0 {
-		errs = errs.Also(apis.ErrMissingOneOf("httpGet", "tcpSocket", "exec", "grpc"))
+		errs = errs.Also(apis.ErrMissingOneOf("httpGet", "tcpSocket", "exec"))
 	} else if len(handlers) > 1 {
 		errs = errs.Also(apis.ErrMultipleOneOf(handlers...))
 	}

--- a/vendor/knative.dev/serving/pkg/apis/serving/v1/revision_defaults.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/v1/revision_defaults.go
@@ -143,13 +143,8 @@ func (*RevisionSpec) applyProbes(container *corev1.Container) {
 	}
 	if container.ReadinessProbe.TCPSocket == nil &&
 		container.ReadinessProbe.HTTPGet == nil &&
-		container.ReadinessProbe.Exec == nil &&
-		container.ReadinessProbe.GRPC == nil {
+		container.ReadinessProbe.Exec == nil {
 		container.ReadinessProbe.TCPSocket = &corev1.TCPSocketAction{}
-	}
-
-	if container.ReadinessProbe.GRPC != nil && container.ReadinessProbe.GRPC.Service == nil {
-		container.ReadinessProbe.GRPC.Service = ptr.String("")
 	}
 
 	if container.ReadinessProbe.SuccessThreshold == 0 {

--- a/vendor/knative.dev/serving/pkg/apis/serving/v1/revision_helpers.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/v1/revision_helpers.go
@@ -128,6 +128,11 @@ func (r *Revision) GetRoutingStateModified() time.Time {
 	return parsed
 }
 
+// IsReachable returns whether or not the revision can be reached by a route.
+func (r *Revision) IsReachable() bool {
+	return RoutingState(r.Labels[serving.RoutingStateLabelKey]) == RoutingStateActive
+}
+
 // GetProtocol returns the app level network protocol.
 func (r *Revision) GetProtocol() net.ProtocolType {
 	ports := r.Spec.GetContainer().Ports

--- a/vendor/knative.dev/serving/pkg/apis/serving/v1/route_lifecycle.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/v1/route_lifecycle.go
@@ -174,11 +174,10 @@ func (rs *RouteStatus) MarkCertificateReady(name string) {
 
 // MarkCertificateNotReady marks the RouteConditionCertificateProvisioned
 // condition to indicate that the Certificate is not ready.
-func (rs *RouteStatus) MarkCertificateNotReady(c *v1alpha1.Certificate) {
-	certificateCondition := c.Status.GetCondition("Ready")
+func (rs *RouteStatus) MarkCertificateNotReady(name string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionCertificateProvisioned,
 		"CertificateNotReady",
-		"Certificate %s is not ready: %s", c.Name, certificateCondition.GetReason())
+		"Certificate %s is not ready.", name)
 }
 
 // MarkCertificateNotOwned changes the RouteConditionCertificateProvisioned
@@ -191,10 +190,10 @@ func (rs *RouteStatus) MarkCertificateNotOwned(name string) {
 }
 
 const (
-	// ExternalDomainTLSNotEnabledMessage is the message which is set on the
+	// AutoTLSNotEnabledMessage is the message which is set on the
 	// RouteConditionCertificateProvisioned condition when it is set to True
-	// because external-domain-tls was not enabled.
-	ExternalDomainTLSNotEnabledMessage = "external-domain-tls is not enabled"
+	// because AutoTLS was not enabled.
+	AutoTLSNotEnabledMessage = "autoTLS is not enabled"
 
 	// TLSNotEnabledForClusterLocalMessage is the message which is set on the
 	// RouteConditionCertificateProvisioned condition when it is set to True
@@ -203,7 +202,7 @@ const (
 )
 
 // MarkTLSNotEnabled sets RouteConditionCertificateProvisioned to true when
-// certificate config such as external-domain-tls is not enabled or private cluster-local service.
+// certificate config such as autoTLS is not enabled or private cluster-local service.
 func (rs *RouteStatus) MarkTLSNotEnabled(msg string) {
 	routeCondSet.Manage(rs).MarkTrueWithReason(RouteConditionCertificateProvisioned,
 		"TLSNotEnabled", msg)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1478,7 +1478,7 @@ github.com/tektoncd/pipeline/test/diff
 # github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1
 ## explicit; go 1.19
 github.com/tektoncd/plumbing/scripts
-# github.com/tektoncd/triggers v0.26.0
+# github.com/tektoncd/triggers v0.26.1
 ## explicit; go 1.19
 github.com/tektoncd/triggers/pkg/apis/config
 github.com/tektoncd/triggers/pkg/apis/triggers
@@ -2630,7 +2630,7 @@ knative.dev/pkg/tracing/propagation
 knative.dev/pkg/tracing/propagation/tracecontextb3
 knative.dev/pkg/tracker
 knative.dev/pkg/webhook/resourcesemantics
-# knative.dev/serving v0.39.0
+# knative.dev/serving v0.38.6
 ## explicit; go 1.18
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1


### PR DESCRIPTION
Thisis to fix triggertemplate describe command, which broke the backward compatibility as the field has been changed to camel case in triggers 0.26.0 release, which has been reverted in 0.26.1 change to make the same and fix backward compatibility.

Here we are also bumping to 0.26.1 triggers to fix the backward compatibility

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix triggertemplate describe command breaks backward compatibility
```
