### PR TITLE
Fix logs command not showing logs

### DIFF
--- a/pkg/cmd/taskrun/logs_test.go
+++ b/pkg/cmd/taskrun/logs_test.go
@@ -2844,7 +2844,7 @@ func TestLog_taskrun_follow_mode_update_timeout_v1beta1(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	expectedOut := "task output-task create has not started yet or pod for task not yet available\n"
+	expectedOut := "task output-task has not started yet or pod for task not yet available\n"
 	test.AssertOutput(t, expectedOut, output)
 }
 
@@ -2992,7 +2992,7 @@ func TestLog_taskrun_follow_mode_update_timeout(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	expectedOut := "task output-task create has not started yet or pod for task not yet available\n"
+	expectedOut := "task output-task has not started yet or pod for task not yet available\n"
 	test.AssertOutput(t, expectedOut, output)
 }
 

--- a/test/e2e/pipeline/start_test.go
+++ b/test/e2e/pipeline/start_test.go
@@ -77,6 +77,12 @@ func TestPipelineInteractiveStartE2E(t *testing.T) {
 		})
 	})
 
+	t.Run("Validate pipeline logs, with  follow mode (-f) and --last ", func(t *testing.T) {
+		res := tkn.Run(t, "pipeline", "logs", "--last", "-f")
+		expected := "\n\ntest-e2e\n\n"
+		helper.AssertOutput(t, expected, res.Stdout())
+	})
+
 	t.Run("Start PipelineRun using pipeline start interactively using --use-param-defaults and some of the params not having default ", func(t *testing.T) {
 		tkn.RunInteractiveTests(t, &cli.Prompt{
 			CmdArgs: []string{

--- a/test/resources/pipeline.yaml
+++ b/test/resources/pipeline.yaml
@@ -25,7 +25,7 @@ spec:
   steps:
   - name: create-new-file
     image: ubuntu
-    script: touch $(workspaces.shared-data.path)/$(params.filename)
+    script: sleep 30s;touch $(workspaces.shared-data.path)/$(params.filename)
   - name: write-new-stuff
     image: ubuntu
     script: echo $(params.message) > $(workspaces.shared-data.path)/$(params.filename)


### PR DESCRIPTION
This will fix the logs command not showing logs
if there are retries and task has completed in first go

Failure and Completion of taskrun should not
depend on no. of retries. Also retries will
not scheduled be if task is done so add a check
for that.

Add e2e test for this scenarioi

Fix https://github.com/tektoncd/cli/issues/2208

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix logs command not showing logs
```