### PR TITLE
Add labeling support to `tkn bundle push`

### DIFF
--- a/docs/cmd/tkn_bundle_push.md
+++ b/docs/cmd/tkn_bundle_push.md
@@ -36,6 +36,7 @@ Created time:
       --ctime string             YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS or RFC3339 formatted created time to set, defaults to current time. In non RFC3339 syntax dates are in UTC timezone.
   -f, --filenames strings        List of fully-qualified file paths containing YAML or JSON defined Tekton objects to include in this bundle
   -h, --help                     help for push
+      --label strings            OCI Config labels in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple labels.
       --remote-bearer string     A Bearer token to authenticate against the repository
       --remote-password string   A password to pass to the registry for basic auth. Must be used with --remote-username
       --remote-skip-tls          If set to true, skips TLS check when connecting to the registry

--- a/docs/man/man1/tkn-bundle-push.1
+++ b/docs/man/man1/tkn-bundle-push.1
@@ -62,6 +62,10 @@ Created time:
     help for push
 
 .PP
+\fB\-\-label\fP=[]
+    OCI Config labels in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple labels.
+
+.PP
 \fB\-\-remote\-bearer\fP=""
     A Bearer token to authenticate against the repository
 

--- a/pkg/cmd/bundle/list_test.go
+++ b/pkg/cmd/bundle/list_test.go
@@ -105,7 +105,7 @@ func TestListCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			img, err := bundle.BuildTektonBundle([]string{examplePullTask, examplePullPipeline}, nil, time.Now(), &bytes.Buffer{})
+			img, err := bundle.BuildTektonBundle([]string{examplePullTask, examplePullPipeline}, nil, nil, time.Now(), &bytes.Buffer{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/bundle/push.go
+++ b/pkg/cmd/bundle/push.go
@@ -42,6 +42,8 @@ type pushOptions struct {
 	remoteOptions      bundle.RemoteOptions
 	annotationParams   []string
 	annotations        map[string]string
+	labelParams        []string
+	labels             map[string]string
 	ctimeParam         string
 	ctime              time.Time
 }
@@ -101,6 +103,7 @@ Created time:
 	c.Flags().StringSliceVarP(&opts.bundleContentPaths, "filenames", "f", []string{}, "List of fully-qualified file paths containing YAML or JSON defined Tekton objects to include in this bundle")
 	c.Flags().StringSliceVarP(&opts.annotationParams, "annotate", "", []string{}, "OCI Manifest annotation in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple annotations.")
 	c.Flags().StringVar(&opts.ctimeParam, "ctime", "", "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS or RFC3339 formatted created time to set, defaults to current time. In non RFC3339 syntax dates are in UTC timezone.")
+	c.Flags().StringSliceVarP(&opts.labelParams, "label", "", []string{}, "OCI Config labels in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple labels.")
 	bundle.AddRemoteFlags(c.Flags(), &opts.remoteOptions)
 
 	return c
@@ -137,6 +140,10 @@ func (p *pushOptions) parseArgsAndFlags(args []string) (err error) {
 		return err
 	}
 
+	if p.labels, err = params.ParseParams(p.labelParams); err != nil {
+		return err
+	}
+
 	if p.ctime, err = determineCTime(p.ctimeParam); err != nil {
 		return err
 	}
@@ -150,7 +157,7 @@ func (p *pushOptions) Run(args []string) error {
 		return err
 	}
 
-	img, err := bundle.BuildTektonBundle(p.bundleContents, p.annotations, p.ctime, p.stream.Out)
+	img, err := bundle.BuildTektonBundle(p.bundleContents, p.annotations, p.labels, p.ctime, p.stream.Out)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When pushing the bundle `-l` or `--label` can be provided to set labels in the config JSON of the image.

Fixes #2256

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Added support for setting bundle image labels
```
