### PR TITLE
Prepare setup for moving e2e to kind

### DIFF
--- a/test/e2e-tests-kind-prow.env
+++ b/test/e2e-tests-kind-prow.env
@@ -1,0 +1,3 @@
+E2E_SKIP_CLUSTER_CREATION=true
+KO_DOCKER_REPO=registry.local:5000
+ARTIFACTS=/workspace/source/artifacts

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -24,9 +24,13 @@ source $(dirname $0)/e2e-common.sh
 
 cd $(dirname $(readlink -f $0))/../
 
+E2E_SKIP_CLUSTER_CREATION=${E2E_SKIP_CLUSTER_CREATION:="false"}
+
 ci_run && {
-  header "Setting up environment"
-  initialize $@
+    header "Setting up environment"
+    if [ "${E2E_SKIP_CLUSTER_CREATION}" != "true" ]; then
+        initialize "$@"
+    fi
 }
 
 tkn() {
@@ -155,9 +159,9 @@ for res in eventlistener triggertemplate triggerbinding clustertriggerbinding; d
   kubectl delete --ignore-not-found=true ${res}.triggers.tekton.dev --all
 done
 
-# Run the e2e tests
-export SYSTEM_NAMESPACE=${SYSTEM_NAMESPACE:-"tekton-pipelines"}
+# Run go e2e tests
 header "Running Go e2e tests"
+export SYSTEM_NAMESPACE=${SYSTEM_NAMESPACE:-"tekton-pipelines"}
 failed=0
 if [[ -e ./bin/tkn ]];then
     export TEST_CLIENT_BINARY="${PWD}/bin/tkn"
@@ -166,6 +170,7 @@ else
     echo "Go Build successfull"
     export TEST_CLIENT_BINARY="${PWD}/tkn"
 fi
+
 go_test_e2e ./test/e2e/... || failed=1
 (( failed )) && fail_test
 


### PR DESCRIPTION
This will prepare the setup for moving e2e tests to run on kind instead of gcp

Fix #1774

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Prepare setup for moving e2e to kind
```