### PR TITLE
Add -E flag to exit with the pr sate on unix shell

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -63,6 +63,7 @@ my-csi-template and my-volume-claim-template)
 
 ```
       --dry-run                       preview PipelineRun without running it
+  -E, --exit-with-pipelinerun-error   when using --showlog, exit with pipelinerun to the unix shell, 0 if success, 1 if error, 2 on unknown status
   -f, --filename string               local or remote file name containing a Pipeline definition to start a PipelineRun
       --finally-timeout string        timeout for Finally TaskRuns
   -h, --help                          help for start

--- a/docs/cmd/tkn_pipelinerun_logs.md
+++ b/docs/cmd/tkn_pipelinerun_logs.md
@@ -30,15 +30,16 @@ Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (inc
 ### Options
 
 ```
-  -a, --all            show all logs including init steps injected by tekton
-  -f, --follow         stream live logs
-  -F, --fzf            use fzf to select a PipelineRun
-  -h, --help           help for logs
-  -L, --last           show logs for last PipelineRun
-      --limit int      lists number of PipelineRuns (default 5)
-      --prefix         prefix each log line with the log source (task name and step name) (default true)
-  -t, --task strings   show logs for mentioned Tasks only
-      --timestamps     show logs with timestamp
+  -a, --all                           show all logs including init steps injected by tekton
+  -E, --exit-with-pipelinerun-error   exit with pipelinerun to the unix shell, 0 if success, 1 if error, 2 on unknown status
+  -f, --follow                        stream live logs
+  -F, --fzf                           use fzf to select a PipelineRun
+  -h, --help                          help for logs
+  -L, --last                          show logs for last PipelineRun
+      --limit int                     lists number of PipelineRuns (default 5)
+      --prefix                        prefix each log line with the log source (task name and step name) (default true)
+  -t, --task strings                  show logs for mentioned Tasks only
+      --timestamps                    show logs with timestamp
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -32,6 +32,10 @@ Parameters, at least those that have no default value
     preview PipelineRun without running it
 
 .PP
+\fB\-E\fP, \fB\-\-exit\-with\-pipelinerun\-error\fP[=false]
+    when using \-\-showlog, exit with pipelinerun to the unix shell, 0 if success, 1 if error, 2 on unknown status
+
+.PP
 \fB\-f\fP, \fB\-\-filename\fP=""
     local or remote file name containing a Pipeline definition to start a PipelineRun
 

--- a/docs/man/man1/tkn-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-pipelinerun-logs.1
@@ -24,6 +24,10 @@ Show the logs of a PipelineRun
     show all logs including init steps injected by tekton
 
 .PP
+\fB\-E\fP, \fB\-\-exit\-with\-pipelinerun\-error\fP[=false]
+    exit with pipelinerun to the unix shell, 0 if success, 1 if error, 2 on unknown status
+
+.PP
 \fB\-f\fP, \fB\-\-follow\fP[=false]
     stream live logs
 

--- a/pkg/cmd/pipeline/start.go
+++ b/pkg/cmd/pipeline/start.go
@@ -68,6 +68,7 @@ type startOptions struct {
 	Labels                []string
 	ShowLog               bool
 	DryRun                bool
+	ExitWithPrError       bool
 	Output                string
 	PrefixName            string
 	TimeOut               string
@@ -195,6 +196,7 @@ For passing the workspaces via flags:
 	c.Flags().BoolVarP(&opt.UseParamDefaults, "use-param-defaults", "", false, "use default parameter values without prompting for input")
 	c.Flags().StringVar(&opt.PodTemplate, "pod-template", "", "local or remote file containing a PodTemplate definition")
 	c.Flags().BoolVarP(&opt.SkipOptionalWorkspace, "skip-optional-workspace", "", false, "skips the prompt for optional workspaces")
+	c.Flags().BoolVarP(&opt.ExitWithPrError, "exit-with-pipelinerun-error", "E", false, "when using --showlog, exit with pipelinerun to the unix shell, 0 if success, 1 if error, 2 on unknown status")
 
 	c.Flags().StringVarP(&opt.ServiceAccountName, "serviceaccount", "s", "", "pass the serviceaccount name")
 	_ = c.RegisterFlagCompletionFunc("serviceaccount",
@@ -413,6 +415,7 @@ func (opt *startOptions) startPipeline(pipelineStart *v1beta1.Pipeline) error {
 		Prefixing:       true,
 		Params:          opt.cliparams,
 		AllSteps:        false,
+		ExitWithPrError: opt.ExitWithPrError,
 	}
 	return prcmd.Run(runLogOpts)
 }

--- a/pkg/cmd/pipelinerun/logs_test.go
+++ b/pkg/cmd/pipelinerun/logs_test.go
@@ -182,6 +182,65 @@ func TestLog_no_pipelinerun_argument(t *testing.T) {
 	}
 }
 
+func TestLog_PrStatusToUnixStatus(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pr       *v1.PipelineRun
+		expected int
+	}{
+		{
+			name: "No conditions",
+			pr: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{},
+					},
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "Condition status is false",
+			pr: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "Condition status true",
+			pr: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := prStatusToUnixStatus(tc.pr)
+			if result != tc.expected {
+				t.Errorf("Expected %d, got %d", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestLog_run_found_v1beta1(t *testing.T) {
 	clock := test.FakeClock()
 	pdata := []*v1beta1.Pipeline{
@@ -1673,7 +1732,6 @@ func TestPipelinerunLog_follow_mode_v1beta1(t *testing.T) {
 		cb.UnstructuredV1beta1PR(prs[0], versionv1beta1),
 		cb.UnstructuredV1beta1P(pps[0], versionv1beta1),
 	)
-
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
@@ -1862,7 +1920,6 @@ func TestPipelinerunLog_follow_mode(t *testing.T) {
 		cb.UnstructuredPR(prs[0], version),
 		cb.UnstructuredP(pps[0], version),
 	)
-
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
@@ -2517,7 +2574,6 @@ func TestLog_pipelinerun_still_running_v1beta1(t *testing.T) {
 	updatePRv1beta1(finalPRs, watcher)
 
 	output, err := fetchLogs(prlo)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -2648,7 +2704,6 @@ func TestLog_pipelinerun_still_running(t *testing.T) {
 	updatePR(finalPRs, watcher)
 
 	output, err := fetchLogs(prlo)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -3502,7 +3557,6 @@ func TestPipelinerunLog_finally_v1beta1(t *testing.T) {
 		cb.UnstructuredV1beta1PR(prs[0], versionv1beta1),
 		cb.UnstructuredV1beta1P(pps[0], versionv1beta1),
 	)
-
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}
@@ -3752,7 +3806,6 @@ func TestPipelinerunLog_finally(t *testing.T) {
 		cb.UnstructuredPR(prs[0], version),
 		cb.UnstructuredP(pps[0], version),
 	)
-
 	if err != nil {
 		t.Errorf("unable to create dynamic client: %v", err)
 	}

--- a/pkg/options/logs.go
+++ b/pkg/options/logs.go
@@ -51,6 +51,7 @@ type LogOptions struct {
 	Tail            int64
 	Timestamps      bool
 	Prefixing       bool
+	ExitWithPrError bool
 	// ActivityTimeout is the amount of time to wait for some activity
 	// (e.g. Pod ready) before giving up.
 	ActivityTimeout time.Duration


### PR DESCRIPTION
Add the -E or --exit-with-pipelinerun-error flag to tkn pr logs to exit with the pipelinerun error after showing the logs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
