### PR TITLE
Bump golangci-lint to v0.58.0

### DIFF
--- a/.errcheck.txt
+++ b/.errcheck.txt
@@ -1,8 +1,0 @@
-(*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
-flag.Set
-os.Setenv
-logger.Sync
-fmt.Fprintf
-fmt.Fprintln
-(io.Closer).Close
-updateConfigMap

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,15 +5,23 @@ issues:
     - path: _test\.go
       linters:
         - gosec
+  exclude-dirs:
+    - vendor
 run:
   issues-exit-code: 1
   build-tags:
     - e2e
-  skip-dirs:
-    - vendor
 linters-settings:
   errcheck:
-    exclude: .errcheck.txt
+    exclude-functions:
+      - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+      - flag.Set
+      - os.Setenv
+      - logger.Sync
+      - fmt.Fprintf
+      - fmt.Fprintln
+      - (io.Closer).Close
+      - updateConfigMap
   staticcheck:
     checks:
       - '-SA1019' # ignore ClusterTask warning

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO   = go
-PKGS = $(or $(PKG),$(shell env GO111MODULE=on $(GO) list ./... | grep -v 'github\.com\/tektoncd\/cli\/third_party\/'))
+PKGS = $(or $(PKG),$(shell env GO111MODULE=on $(GO) list ./... | grep -v 'github.com/tektoncd/cli/third_party/'))
 BIN  = $(CURDIR)/.bin
 
 export GO111MODULE=on
@@ -11,7 +11,7 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
 
-GOLANGCI_VERSION = v1.56.2
+GOLANGCI_VERSION = v1.58.0
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -54,7 +54,7 @@ spec:
         - name: flags
           value: "-v --timeout 20m"
         - name: version
-          value: v1.56.2
+          value: v1.58.0
       workspaces:
         - name: source
           workspace: shared-workspace


### PR DESCRIPTION
This will bump golangci-lint to v0.58.0 and does
the changes in config file to fix the warnings

Also fix gofmt warnings

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Bump golangci-lint to v0.58.0
```
