### PR TITLE
Fix links in doc to fix pre-commit

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -6,7 +6,7 @@
 
 - You need to have your own Kubernetes cluster (e.g. `minikube`, `gcp`, or other means) with Tekton installed.
 
-- You need to have [these tools](https://github.com/tektoncd/cli/blob/main/tekton/release.sh#L13y) installed locally.
+- You need to have [these tools](./tekton/release.sh#L13) installed locally.
 
 - You will need to have a [GPG key set up](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) with your git account to push the release branch.
 
@@ -53,19 +53,10 @@ dnf makecache
 dnf upgrade tektoncd-cli
 ```
 
-- Make an update on [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/tektoncd-cli.rb) for tektoncd-cli formula.
+- Make an update on [homebrew-core](https://github.com/Homebrew/homebrew-core) for tektoncd-cli formula.
 
-  * Make sure you get the proper `sha256sum`. You need to download the `Source Code (tar.gz)` from this [link](https://github.com/Homebrew/homebrew-core/blob/master/Formula/tektoncd-cli.rb#L4), but replace the version number with the version number you have released. After downloading, run the command below on the downloaded file (once again you will need to replace the version shown below with the released version):
-
-    ```shell script
-    sha256sum cli-0.7.1.tar.gz
-    ```
-
-    You will get similar output to what is shown below:
-
-    `72df3075303d2b0393bae9a0f9e9b8441060b8a4db57e613ba8f1bfda03809b5  cli-0.7.1.tar.gz`
-
-  * Raise a PR to update like [this](https://github.com/Homebrew/homebrew-core/pull/46492) to Homebrew Core
+  * Homebrew Core have a GitHub action to bump the CLI version in Formula for new releases which runs every 3 hours.
+  Make sure a PR like [this](https://github.com/Homebrew/homebrew-core/pull/171551) is created and merged for new release.
 
 - Make a version update to the test-runner and `tkn` image in the [plumbing](https://github.com/tektoncd/plumbing/) repo. The test-runner image is used to run the CI on the pipeline project, which uses `tkn`. For both Dockerfiles listed below, search for `ARG TKN_VERSION` in the Dockerfile for where to update the release version. Update the version arg to match the version of `tkn` released (i.e. `ARG TKN_VERSION=<RELEASED_VERSION>`).
 
@@ -74,7 +65,7 @@ dnf upgrade tektoncd-cli
   * [tkn image](https://github.com/tektoncd/plumbing/blob/main/tekton/images/tkn/Dockerfile)
 
 
-- Go to https://archlinux.org/packages/community/x86_64/tekton-cli/flag/ and let the packagers know the package is out of date by leaving a message to the release url and your email address so they can update it.
+- Go to https://archlinux.org/packages/extra/x86_64/tekton-cli/flag/ and let the packagers know the package is out of date by leaving a message to the release url and your email address so they can update it.
 
 - Update the version numbers in the main [README.md](README.md) to the version you are releasing by opening a pull request to the main branch of this repository. Do not worry about updating the README for the release branch.
 

--- a/choco/README.md
+++ b/choco/README.md
@@ -30,8 +30,8 @@ Run `choco uninstall tektoncd-cli` to uninstall `tkn`.
 
 To update this package to a newer version of `tkn`, the following updates should be made:
 
-* Edit the version property in [`tektoncd-cli.nuspec`](https://github.com/tektoncd/cli/blob/main/choco/tektoncd-cli.nuspec#L5) to the latest available version of `tkn`. 
-* Change the [version in the download url for the Windows `tkn` zip](https://github.com/tektoncd/cli/blob/main/choco/tools/chocolateyinstall.ps1#L4) to the latest available version of `tkn`. 
-* Update the [checksum for the package](https://github.com/tektoncd/cli/blob/main/choco/tools/chocolateyinstall.ps1#L11) by getting the sha256 of the zip file. Example: `Get-FileHash '.\tkn_0.37.0_Windows_x86_64.zip'`. The zip can be downloaded using the release download url from GitHub; just remember to change the version numbers in the url: https://github.com/tektoncd/cli/releases/download/v0.37.0/tkn_0.37.0_Windows_x86_64.zip.
+* Edit the version property in [tektoncd-cli.nuspec](./tektoncd-cli.nuspec#L5) to the latest available version of `tkn`. 
+* Change the [version in the download url for the Windows `tkn` zip](./tools/chocolateyinstall.ps1#L4) to the latest available version of `tkn`. 
+* Update the [checksum for the package](./tools/chocolateyinstall.ps1#L11) by getting the sha256 of the zip file. Example: `Get-FileHash '.\tkn_0.37.0_Windows_x86_64.zip'`. The zip can be downloaded using the release download url from GitHub; just remember to change the version numbers in the url: https://github.com/tektoncd/cli/releases/download/v0.37.0/tkn_0.37.0_Windows_x86_64.zip.
 * Run `choco pack` in the `choco` directory to build the package
 * Run `choco push` to push the built package and make it available for download (NOTE: You will need permissions to push the package/to be authenticated. Reach out to [@danielhelfand](https://github.com/danielhelfand) for more details.)

--- a/releases.md
+++ b/releases.md
@@ -36,7 +36,7 @@ Further documentation available:
 
 ## Releases
 
-### v0.37
+### v0.37 (LTS)
 
 - **Latest Release**: [v0.37.0][v0-37-0] (2024-05-13) ([docs][v0-37-0-docs])
 - **Initial Release**: [v0.37.0][v0-37-0] (2024-05-13) ([docs][v0-37-0-docs])


### PR DESCRIPTION
This will update links in doc to relative path
instead of URL to fix pre-commit error. Also
update the homebrew steps.

Fix #2303

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix links in doc to fix pre-commit
```