### PR TITLE
Bump to golangci-lint v1.60.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
 
-GOLANGCI_VERSION = v1.58.0
+GOLANGCI_VERSION = v1.60.1
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 

--- a/pkg/formatted/color.go
+++ b/pkg/formatted/color.go
@@ -83,7 +83,7 @@ func DecorateAttr(attrString, message string) string {
 	case "underline":
 		attr = color.Underline
 	case "underline bold":
-		return color.New(color.Underline).Add(color.Bold).Sprintf(message)
+		return color.New(color.Underline).Add(color.Bold).Sprintf("%s", message)
 	case "bold":
 		attr = color.Bold
 	case "yellow":
@@ -104,7 +104,7 @@ func DecorateAttr(attrString, message string) string {
 		attr = color.FgHiWhite
 	}
 
-	return color.New(attr).Sprintf(message)
+	return color.New(attr).Sprintf("%s", message)
 }
 
 type atomicCounter struct {

--- a/pkg/log/pipeline_reader.go
+++ b/pkg/log/pipeline_reader.go
@@ -77,7 +77,7 @@ func (r *Reader) readLivePipelineLogs(pr *v1.PipelineRun) (<-chan Log, <-chan er
 		wg.Wait()
 
 		if !empty(pr.Status) && pr.Status.Conditions[0].Status == corev1.ConditionFalse {
-			errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
+			errC <- fmt.Errorf("%s", pr.Status.Conditions[0].Message)
 		}
 	}()
 
@@ -118,7 +118,7 @@ func (r *Reader) readAvailablePipelineLogs(pr *v1.PipelineRun) (<-chan Log, <-ch
 		}
 
 		if !empty(pr.Status) && pr.Status.Conditions[0].Status == corev1.ConditionFalse {
-			errC <- fmt.Errorf(pr.Status.Conditions[0].Message)
+			errC <- fmt.Errorf("%s", pr.Status.Conditions[0].Message)
 		}
 	}()
 

--- a/pkg/params/validation.go
+++ b/pkg/params/validation.go
@@ -36,7 +36,7 @@ func ValidateParamType(params []v1beta1.ParamSpec) error {
 		for _, param := range paramsWithInvalidType {
 			errString += fmt.Sprintf(" '%s'", param.Name)
 		}
-		return fmt.Errorf(errString)
+		return fmt.Errorf("%s", errString)
 	}
 
 	return nil

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -174,7 +174,7 @@ func checkPodStatus(obj interface{}) (*corev1.Pod, error) {
 	for _, c := range pod.Status.Conditions {
 		if c.Type == corev1.PodInitialized || c.Type == corev1.ContainersReady {
 			if c.Status == corev1.ConditionUnknown {
-				return pod, fmt.Errorf(c.Message)
+				return pod, fmt.Errorf("%s", c.Message)
 			}
 		}
 	}

--- a/pkg/workspaces/workspaces_test.go
+++ b/pkg/workspaces/workspaces_test.go
@@ -47,7 +47,7 @@ func TestMerge(t *testing.T) {
 	optWS := []string{}
 	outWS, err := Merge(ws, optWS, httpClient)
 	if err != nil {
-		t.Errorf("Not expected error: " + err.Error())
+		t.Errorf("Not expected error: %s", err.Error())
 	}
 	test.AssertOutput(t, ws, outWS)
 
@@ -110,14 +110,14 @@ func TestMerge(t *testing.T) {
 	}
 	outWS, err = Merge(ws, optWS, httpClient)
 	if err != nil {
-		t.Errorf("Not expected error: " + err.Error())
+		t.Errorf("Not expected error: %s", err.Error())
 	}
 	test.AssertOutput(t, 7, len(outWS))
 
 	optWS = []string{"name=volumeclaimtemplatews,volumeClaimTemplateFile=./testdata/pvc.yaml"}
 	_, err = Merge(ws, optWS, httpClient)
 	if err != nil {
-		t.Errorf("Not expected error: " + err.Error())
+		t.Errorf("Not expected error: %s", err.Error())
 	}
 
 	optWS = []string{"name=volumeclaimtemplatews,volumeClaimTemplateFile=./testdata/pvc-typo.yaml"}
@@ -130,7 +130,7 @@ func TestMerge(t *testing.T) {
 	optWS = []string{"name=csiws,csiFile=./testdata/csi.yaml"}
 	outWS, err = Merge(ws, optWS, httpClient)
 	if err != nil {
-		t.Errorf("Not expected error: " + err.Error())
+		t.Errorf("Not expected error: %s", err.Error())
 	}
 
 	optWS = []string{"name=csiws,csiFile=./testdata/csi-typo.yaml"}

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -54,7 +54,7 @@ spec:
         - name: flags
           value: "-v --timeout 20m"
         - name: version
-          value: v1.58.0
+          value: v1.60.1
       workspaces:
         - name: source
           workspace: shared-workspace
@@ -68,7 +68,7 @@ spec:
         - name: packages
           value: ./pkg/... ./cmd/...
         - name: version
-          value: "1.22"
+          value: "1.22.5"
         - name: flags
           value: -v -mod=vendor
       workspaces:
@@ -82,7 +82,7 @@ spec:
         - name: package
           value: $(params.package)
         - name: version
-          value: "1.22"
+          value: "1.22.5"
         - name: flags
           value: -v -mod=vendor
       workspaces:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/tektoncd/cli/tools
 
-go 1.22.0
+go 1.22.1
+
 toolchain go1.22.5
 
 require github.com/golangci/golangci-lint v1.60.1


### PR DESCRIPTION
This will bump to golangci-lint v1.60.1 and also
update release pipeline to correct go and golangci-lint version

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Bump to golangci-lint v1.60.1
```