### PR TITLE
Move to goreleaser v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 builds:
 - env:
   - CGO_ENABLED=0

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -100,7 +100,7 @@ spec:
         - name: github-token-secret-key
           value: $(params.github-token-secret-key)
         - name: image
-          value: goreleaser/goreleaser:v1.25.1
+          value: goreleaser/goreleaser:v2.1.0
         - name: flags
           value: --timeout=60m
       workspaces:


### PR DESCRIPTION
This will make sure to use goreleaser v2 in release job and fix the goreleaser warning for that

it is required as we have moved to 1.22.5 and v2.1.0 go releaser is the minimum where go 1.22.5 is available

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Move to goreleaser v2
```
