### PR TITLE
Remove hardcoded golangci-lint and go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
 
-GOLANGCI_VERSION = v1.60.1
+# Get golangci_version from tools/go.mod to eliminate the manual bump
+GOLANGCI_VERSION = $(shell cat tools/go.mod | grep golangci-lint | awk '{ print $$3 }')
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -20,6 +20,10 @@ spec:
     - name: github-token-secret-key
       description: name of the key for the secret holding the github-token
       default: bot-token
+    - name: golangci-lint-version
+      description: version of the golangci-lint tool
+    - name: go-version
+      description: version of the go language
   tasks:
     - name: fetch-repository
       taskRef:
@@ -54,7 +58,7 @@ spec:
         - name: flags
           value: "-v --timeout 20m"
         - name: version
-          value: v1.60.1
+          value: $(params.golangci-lint-version)
       workspaces:
         - name: source
           workspace: shared-workspace
@@ -68,7 +72,7 @@ spec:
         - name: packages
           value: ./pkg/... ./cmd/...
         - name: version
-          value: "1.22.5"
+          value: $(params.go-version)
         - name: flags
           value: -v -mod=vendor
       workspaces:
@@ -82,7 +86,7 @@ spec:
         - name: package
           value: $(params.package)
         - name: version
-          value: "1.22.5"
+          value: $(params.go-version)
         - name: flags
           value: -v -mod=vendor
       workspaces:

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -12,6 +12,9 @@ CATALOG_TASKS="lint build test"
 
 BINARIES="kubectl jq tkn git"
 
+GOLANGCI_VERSION="$(cat tools/go.mod | grep golangci-lint | awk '{ print $3 }')"
+GO_VERSION="$(cat go.mod | grep "go" | awk 'NR==1{ print $2 }')"
+
 set -e
 
 for b in ${BINARIES};do
@@ -147,6 +150,8 @@ URL=$(git remote get-url "${PUSH_REMOTE}" | sed 's,git@github.com:,https://githu
 tkn -n ${TARGET_NAMESPACE} pipeline start cli-release-pipeline \
   -p revision="${RELEASE_VERSION}" \
   -p url="${URL}" \
+  -p golangci-lint-version="${GOLANGCI_VERSION}" \
+  -p go-version="${GO_VERSION}" \
   -w name=shared-workspace,volumeClaimTemplateFile=./tekton/volume-claim-template.yml
 
 tkn -n ${TARGET_NAMESPACE} pipeline logs cli-release-pipeline -f --last


### PR DESCRIPTION
This will remove hardcoded versions of golangci-lint and go in Makefile and release pipeline, instead detect them from go.mod files

This will eliminate the need to update them during release and also CI will run the latest golangci-lint version

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Remove hardcoded golangci-lint and go version
```