### PR TITLE
Fix ubuntu launchpad build

### DIFF
--- a/tekton/debbuild/control/control
+++ b/tekton/debbuild/control/control
@@ -3,9 +3,11 @@ Maintainer: Chmouel Boudjnah <chmouel@redhat.com>
 Section: misc
 Priority: optional
 Standards-Version: 4.3.0
-Build-Depends: debhelper (>= 11),
-               dh-golang (>= 1.34~),
-               golang-any (>= 2:1.12~)
+Build-Depends: debhelper (>= 13),
+               dh-sequence-golang,
+               golang-any,
+               curl,
+               python3
 Vcs-Git: https://github.com/tektoncd/cli.git
 
 Package: tektoncd-cli

--- a/tekton/debbuild/control/rules
+++ b/tekton/debbuild/control/rules
@@ -14,7 +14,7 @@ BUILD_DATE := $(BUILD_DATE:+0000=Z)
 	dh $@ --builddirectory=_build --buildsystem=golang
 
 override_dh_auto_build:
-	@set -x ; export XDG_CACHE_HOME=/tmp/cache ; \
+	@set -x ; export HOME="$(CURDIR)" ; export XDG_CACHE_HOME=/tmp/cache ; \
 	RELEASED_VERSION=`curl -s  https://api.github.com/repos/tektoncd/cli/releases/latest|python3 -c "import sys, json;x=json.load(sys.stdin);print(x['tag_name'])"|sed 's/^v//'` ; test -n "$$RELEASED_VERSION" || RELEASED_VERSION=$(BUILD_DATE) ; \
 	test -e ./debian/VERSION && VERSION=`cat debian/VERSION` || VERSION=$$RELEASED_VERSION ; \
 		CGO_ENABLED=0 go build -mod=vendor -v -o ${TKN} -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$$VERSION" ./cmd/tkn


### PR DESCRIPTION
This will fix the issue of build failing on launchpad we are now just waiting for go 1.22.5 to be available to so the builds

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix ubuntu launchpad build
```