### PR TITLE
Bump tektoncd/pipeline to v0.62.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/chains v0.22.0
 	github.com/tektoncd/hub v1.18.0
-	github.com/tektoncd/pipeline v0.62.2
+	github.com/tektoncd/pipeline v0.62.3
 	github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1
 	github.com/tektoncd/triggers v0.29.0
 	github.com/theupdateframework/go-tuf v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1286,8 +1286,8 @@ github.com/tektoncd/chains v0.22.0 h1:9rgm+skfKpmIAh0CpHSPT6i2R2kmH815YF5iVnvNEM
 github.com/tektoncd/chains v0.22.0/go.mod h1:5FsO4gIKUIlJ4ohmmMXep0GPMWN1oEwRLXiETmU7XhY=
 github.com/tektoncd/hub v1.18.0 h1:q9EN0gBKYyHsa9SnyT0LbFP47IG8nH7g1oqzKlObAww=
 github.com/tektoncd/hub v1.18.0/go.mod h1:pPiMmCE7ORjL+S+ZYkqRGgaaUpRIkdzSFvv/numhO54=
-github.com/tektoncd/pipeline v0.62.2 h1:TnTPSbx19wMsqx5N/xWJ3TEpxNj2SoeFmz7Mb6POj4Q=
-github.com/tektoncd/pipeline v0.62.2/go.mod h1:cYPH4n3X8t39arNMhgyU7swyv3hVeWToz1yYDRzTLT8=
+github.com/tektoncd/pipeline v0.62.3 h1:hR6UKjwzChW+MNG41yjfTKiVW9xet8jbJS59tsIY7bc=
+github.com/tektoncd/pipeline v0.62.3/go.mod h1:cYPH4n3X8t39arNMhgyU7swyv3hVeWToz1yYDRzTLT8=
 github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1 h1:9paprRIBXQgcvdhGq3wKiSspXP0JIFSY52ru3sIMjKM=
 github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1/go.mod h1:7eWs1XNkmReggow7ggRbRyRuHi7646B8b2XipCZ3VOw=
 github.com/tektoncd/triggers v0.29.0 h1:piRTJT1Sjq3xmGnR50V54oG0NlsszKETLxdCGhgSNQQ=

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--param_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--param_-f.golden
@@ -32,5 +32,4 @@ spec:
   - emptyDir: {}
     name: temporary
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--timeout_specified.golden
@@ -15,5 +15,4 @@ spec:
     name: task-1
   timeout: 1s
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_no_specified_params.golden
@@ -9,5 +9,4 @@ spec:
   taskRef:
     name: task-1
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_--use-param-defaults_and_specified_params.golden
@@ -12,5 +12,4 @@ spec:
   taskRef:
     name: task-1
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_-f.golden
@@ -32,5 +32,4 @@ spec:
   - emptyDir: {}
     name: temporary
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_PodTemplate.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_PodTemplate.golden
@@ -19,5 +19,4 @@ spec:
   taskRef:
     name: task-1
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_only_--dry-run_specified.golden
@@ -14,5 +14,4 @@ spec:
   taskRef:
     name: task-1
 status:
-  artifacts: {}
   podName: ""

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json.golden
@@ -23,7 +23,6 @@
 		}
 	},
 	"status": {
-		"podName": "",
-		"artifacts": {}
+		"podName": ""
 	}
 }

--- a/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json_-f.golden
+++ b/pkg/cmd/task/testdata/TestTaskStart_ExecuteCommand-Dry_Run_with_output=json_-f.golden
@@ -54,7 +54,6 @@
 		]
 	},
 	"status": {
-		"podName": "",
-		"artifacts": {}
+		"podName": ""
 	}
 }

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4214,7 +4214,6 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts are the list of artifacts written out by the task's containers",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
 						},
 					},
@@ -4366,7 +4365,6 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts are the list of artifacts written out by the task's containers",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
 						},
 					},

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/swagger.json
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/swagger.json
@@ -2125,7 +2125,6 @@
         },
         "artifacts": {
           "description": "Artifacts are the list of artifacts written out by the task's containers",
-          "default": {},
           "$ref": "#/definitions/v1.Artifacts",
           "x-kubernetes-list-type": "atomic"
         },
@@ -2220,7 +2219,6 @@
       "properties": {
         "artifacts": {
           "description": "Artifacts are the list of artifacts written out by the task's containers",
-          "default": {},
           "$ref": "#/definitions/v1.Artifacts",
           "x-kubernetes-list-type": "atomic"
         },

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/taskrun_types.go
@@ -282,7 +282,7 @@ type TaskRunStatusFields struct {
 	// Artifacts are the list of artifacts written out by the task's containers
 	// +optional
 	// +listType=atomic
-	Artifacts Artifacts `json:"artifacts,omitempty"`
+	Artifacts *Artifacts `json:"artifacts,omitempty"`
 
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1934,7 +1934,11 @@ func (in *TaskRunStatusFields) DeepCopyInto(out *TaskRunStatusFields) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Artifacts.DeepCopyInto(&out.Artifacts)
+	if in.Artifacts != nil {
+		in, out := &in.Artifacts, &out.Artifacts
+		*out = new(Artifacts)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]SidecarState, len(*in))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1420,7 +1420,7 @@ github.com/tektoncd/hub/api/v1/gen/http/catalog/client
 github.com/tektoncd/hub/api/v1/gen/http/resource/client
 github.com/tektoncd/hub/api/v1/gen/resource
 github.com/tektoncd/hub/api/v1/gen/resource/views
-# github.com/tektoncd/pipeline v0.62.2
+# github.com/tektoncd/pipeline v0.62.3
 ## explicit; go 1.22
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config


### PR DESCRIPTION
This will bump tektoncd/pipeline to v0.62.3 to make client compatible with old pipeline versions

Fix #2388

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Bump tektoncd/pipeline to v0.62.3
```
