### PR TITLE
fix panic when trying to read pod logs when pod is already deleted

### DIFF
--- a/pkg/log/task_reader.go
+++ b/pkg/log/task_reader.go
@@ -290,6 +290,9 @@ func (r *Reader) getTaskRunPodNames(run *v1.TaskRun) (<-chan string, <-chan erro
 
 func filterSteps(pod *corev1.Pod, allSteps bool, stepsGiven []string) []*step {
 	steps := []*step{}
+	if pod == nil {
+		return steps
+	}
 	stepsInPod := getSteps(pod)
 
 	if allSteps {


### PR DESCRIPTION
# Changes

fixed panic when trying to call log.NewReader(logType, opts) for a pipelineRun, but some of the task pod has been deleted. 

# Release Notes

```release-note
fix panic when trying to read pod logs when pod is already deleted
```
