### PR TITLE
add shorthand -a for --all flags

### DIFF
--- a/docs/cmd/tkn_clustertriggerbinding_delete.md
+++ b/docs/cmd/tkn_clustertriggerbinding_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all ClusterTriggerBindings (default: false)
+  -a, --all                           Delete all ClusterTriggerBindings (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_eventlistener_delete.md
+++ b/docs/cmd/tkn_eventlistener_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all EventListeners in a namespace (default: false)
+  -a, --all                           Delete all EventListeners in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_pipeline_delete.md
+++ b/docs/cmd/tkn_pipeline_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all Pipelines in a namespace (default: false)
+  -a, --all                           Delete all Pipelines in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_pipelinerun_delete.md
+++ b/docs/cmd/tkn_pipelinerun_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all PipelineRuns in a namespace (default: false)
+  -a, --all                           Delete all PipelineRuns in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_task_delete.md
+++ b/docs/cmd/tkn_task_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all Tasks in a namespace (default: false)
+  -a, --all                           Delete all Tasks in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_taskrun_delete.md
+++ b/docs/cmd/tkn_taskrun_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all TaskRuns in a namespace (default: false)
+  -a, --all                           Delete all TaskRuns in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
       --clustertask string            The name of a ClusterTask whose TaskRuns should be deleted (does not delete the ClusterTask)
   -f, --force                         Whether to force deletion (default: false)

--- a/docs/cmd/tkn_triggerbinding_delete.md
+++ b/docs/cmd/tkn_triggerbinding_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all TriggerBindings in a namespace (default: false)
+  -a, --all                           Delete all TriggerBindings in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/cmd/tkn_triggertemplate_delete.md
+++ b/docs/cmd/tkn_triggertemplate_delete.md
@@ -28,7 +28,7 @@ or
 ### Options
 
 ```
-      --all                           Delete all TriggerTemplates in a namespace (default: false)
+  -a, --all                           Delete all TriggerTemplates in a namespace (default: false)
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -f, --force                         Whether to force deletion (default: false)
   -h, --help                          help for delete

--- a/docs/man/man1/tkn-clustertriggerbinding-delete.1
+++ b/docs/man/man1/tkn-clustertriggerbinding-delete.1
@@ -20,7 +20,7 @@ Delete ClusterTriggerBindings
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all ClusterTriggerBindings (default: false)
 
 .PP

--- a/docs/man/man1/tkn-eventlistener-delete.1
+++ b/docs/man/man1/tkn-eventlistener-delete.1
@@ -20,7 +20,7 @@ Delete EventListeners in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all EventListeners in a namespace (default: false)
 
 .PP

--- a/docs/man/man1/tkn-pipeline-delete.1
+++ b/docs/man/man1/tkn-pipeline-delete.1
@@ -20,7 +20,7 @@ Delete Pipelines in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all Pipelines in a namespace (default: false)
 
 .PP

--- a/docs/man/man1/tkn-pipelinerun-delete.1
+++ b/docs/man/man1/tkn-pipelinerun-delete.1
@@ -20,7 +20,7 @@ Delete PipelineRuns in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all PipelineRuns in a namespace (default: false)
 
 .PP

--- a/docs/man/man1/tkn-task-delete.1
+++ b/docs/man/man1/tkn-task-delete.1
@@ -20,7 +20,7 @@ Delete Tasks in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all Tasks in a namespace (default: false)
 
 .PP

--- a/docs/man/man1/tkn-taskrun-delete.1
+++ b/docs/man/man1/tkn-taskrun-delete.1
@@ -20,7 +20,7 @@ Delete TaskRuns in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all TaskRuns in a namespace (default: false)
 
 .PP

--- a/docs/man/man1/tkn-triggerbinding-delete.1
+++ b/docs/man/man1/tkn-triggerbinding-delete.1
@@ -20,7 +20,7 @@ Delete TriggerBindings in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all TriggerBindings in a namespace (default: false)
 
 .PP

--- a/docs/man/man1/tkn-triggertemplate-delete.1
+++ b/docs/man/man1/tkn-triggertemplate-delete.1
@@ -20,7 +20,7 @@ Delete TriggerTemplates in a namespace
 
 .SH OPTIONS
 .PP
-\fB\-\-all\fP[=false]
+\fB\-a\fP, \fB\-\-all\fP[=false]
     Delete all TriggerTemplates in a namespace (default: false)
 
 .PP

--- a/pkg/cmd/clustertriggerbinding/delete.go
+++ b/pkg/cmd/clustertriggerbinding/delete.go
@@ -96,7 +96,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAll, "all", "", false, "Delete all ClusterTriggerBindings (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAll, "all", "a", false, "Delete all ClusterTriggerBindings (default: false)")
 
 	return c
 }

--- a/pkg/cmd/eventlistener/delete.go
+++ b/pkg/cmd/eventlistener/delete.go
@@ -97,7 +97,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all EventListeners in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all EventListeners in a namespace (default: false)")
 
 	return c
 }

--- a/pkg/cmd/pipeline/delete.go
+++ b/pkg/cmd/pipeline/delete.go
@@ -101,7 +101,7 @@ or
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().BoolVarP(&opts.DeleteRelated, "prs", "", false, "Whether to delete Pipeline(s) and related resources (PipelineRuns) (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all Pipelines in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all Pipelines in a namespace (default: false)")
 
 	return c
 }

--- a/pkg/cmd/pipelinerun/delete.go
+++ b/pkg/cmd/pipelinerun/delete.go
@@ -128,7 +128,7 @@ or
 	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of PipelineRuns")
 	c.Flags().IntVarP(&opts.KeepSince, "keep-since", "", 0, "When deleting all PipelineRuns keep the ones that has been completed since n minutes")
 	c.Flags().BoolVarP(&opts.IgnoreRunning, "ignore-running", "i", true, "ignore running PipelineRun")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all PipelineRuns in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all PipelineRuns in a namespace (default: false)")
 	c.Flags().StringVarP(&opts.LabelSelector, "label", "", opts.LabelSelector, "A selector (label query) to filter on when running with --all, supports '=', '==', and '!='")
 	return c
 }

--- a/pkg/cmd/task/delete.go
+++ b/pkg/cmd/task/delete.go
@@ -102,7 +102,7 @@ or
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().BoolVarP(&opts.DeleteRelated, "trs", "", false, "Whether to delete Task(s) and related resources (TaskRuns) (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all Tasks in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all Tasks in a namespace (default: false)")
 
 	return c
 }

--- a/pkg/cmd/taskrun/delete.go
+++ b/pkg/cmd/taskrun/delete.go
@@ -144,7 +144,7 @@ or
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
 	c.Flags().StringVarP(&deleteOpts.TaskName, "task", "t", "", "The name of a Task whose TaskRuns should be deleted (does not delete the task)")
 	c.Flags().StringVarP(&deleteOpts.ClusterTaskName, "clustertask", "", "", "The name of a ClusterTask whose TaskRuns should be deleted (does not delete the ClusterTask)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all TaskRuns in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all TaskRuns in a namespace (default: false)")
 	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of TaskRuns")
 	c.Flags().IntVarP(&opts.KeepSince, "keep-since", "", 0, "When deleting all TaskRuns keep the ones that has been completed since n minutes")
 	c.Flags().BoolVarP(&opts.IgnoreRunning, "ignore-running", "i", true, "ignore running TaskRun")

--- a/pkg/cmd/triggerbinding/delete.go
+++ b/pkg/cmd/triggerbinding/delete.go
@@ -97,7 +97,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all TriggerBindings in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all TriggerBindings in a namespace (default: false)")
 
 	return c
 }

--- a/pkg/cmd/triggertemplate/delete.go
+++ b/pkg/cmd/triggertemplate/delete.go
@@ -100,7 +100,7 @@ or
 	}
 	f.AddFlags(c)
 	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
-	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all TriggerTemplates in a namespace (default: false)")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "a", false, "Delete all TriggerTemplates in a namespace (default: false)")
 
 	return c
 }


### PR DESCRIPTION
Added shorthand 'a' for the --all flag in various delete commands which has a --all to improve usability and consistency across the CLI and with kubectl.

This change affects the following commands:

- ClusterTriggerBinding delete
- EventListener delete
- Pipeline delete
- PipelineRun delete
- Task delete
- TaskRun delete
- TriggerBinding delete
- TriggerTemplate delete

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
all command with -a 
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
 
```release-note
all commands with --all flag now has a a shorthand flag -a
```