### PR TITLE
Set status to succeeded when the reason is Completed

### DIFF
--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -67,7 +67,9 @@ func Condition(c v1.Conditions) string {
 		status = "Running"
 	}
 
-	if c[0].Reason != "" && c[0].Reason != status {
+	if c[0].Reason == "Completed" && status == "Succeeded" {
+		return ColorStatus(status)
+	} else if c[0].Reason != "" && c[0].Reason != status {
 		switch c[0].Reason {
 		case "PipelineRunCancelled", "TaskRunCancelled", "Cancelled":
 			return ColorStatus("Cancelled") + "(" + c[0].Reason + ")"

--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -74,6 +74,15 @@ func TestCondition(t *testing.T) {
 			want: "Running",
 		},
 		{
+			name: "PipelineRunCompleted status reason",
+			condition: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+				Reason: "Completed",
+			}},
+			want: "Succeeded",
+		},
+		{
 			name: "PipelineRunCanceled status reason",
 			condition: []apis.Condition{{
 				Type:   apis.ConditionSucceeded,


### PR DESCRIPTION
When a task is skipped in a when expression, the reason becomes Completed, which shows as succeeded (Completed). This can be confusing compared to other tasks that are succeeded but not completed.

Users would not be able to tell the difference when they essentially mean the same thing.

Therefore, set the status to succeeded when the reason is Completed without displaying the reason.

This was how the pipelinerun would show when it's completed:

![image](https://github.com/user-attachments/assets/eaa2b2e1-384c-4757-a850-4c37e46b5e52)

which makes it confusing since we don't know what happen, why some pr are completed and not completed but successfull? this pr fix this since they are successfull we don't need to know more than that.

This is how it looks like now:

![image](https://github.com/user-attachments/assets/0893d1e8-0fa5-465e-b48b-b68df1d4a07d)


Further improvement perhaps would be to add support for when expression in `tkn pr show`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:



For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
when a pipelinerun is succeeded and have a reason of completed (due of a when condition) we don't show the completed reason to avoid confusion
```