### PR TITLE
refactor export function and add finalizers to be removed

### DIFF
--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -1,0 +1,72 @@
+package export
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRemoveFieldForExport(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *unstructured.Unstructured
+		expected map[string]interface{}
+	}{
+		{
+			name: "Remove status and metadata fields",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": "some-status",
+					"metadata": map[string]interface{}{
+						"managedFields":     "some-managed-fields",
+						"resourceVersion":   "some-resource-version",
+						"uid":               "some-uid",
+						"finalizers":        "some-finalizers",
+						"generation":        "some-generation",
+						"namespace":         "some-namespace",
+						"creationTimestamp": "some-timestamp",
+						"ownerReferences":   "some-owner-references",
+						"annotations": map[string]interface{}{
+							"kubectl.kubernetes.io/last-applied-configuration": "some-configuration",
+						},
+					},
+					"spec": map[string]interface{}{
+						"status":        "some-spec-status",
+						"statusMessage": "some-status-message",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{},
+				},
+				"spec": map[string]interface{}{},
+			},
+		},
+		{
+			name: "Remove name if generateName exists",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"generateName": "some-generate-name",
+						"name":         "some-name",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"generateName": "some-generate-name",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RemoveFieldForExport(tt.input)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, tt.expected, tt.input.Object)
+		})
+	}
+}


### PR DESCRIPTION
Refactor the RemoveFieldForExport function to improve readability and maintainability.

add finalizers to be removed from the metadata and spec fields

Grouped metadata and spec fields into slices and used loops to remove them. Added unit tests to verify the functionality.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
