### PR TITLE
Use io.ReadFull to read the bundle content

### DIFF
--- a/pkg/bundle/reader.go
+++ b/pkg/bundle/reader.go
@@ -116,7 +116,7 @@ func readTarLayer(l v1.Layer) ([]byte, error) {
 	}
 
 	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
+	if _, err := io.ReadFull(treader, contents); err != nil && err != io.EOF {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
 	}


### PR DESCRIPTION
The io.Reader documentation says:

> Read reads up to len(p) bytes into p. It returns the number of bytes
> read (0 <= n <= len(p)) and any error encountered. ... If some data is
> available but not len(p) bytes, Read conventionally returns what is
> available instead of waiting for more.

Read is not guaranteed to fill the data argument. Use io.ReadFull to
fill the buffer.

In some cases (a relatively big bundle), the bundle content was not
completely read and it would fail to parse. Using `io.ReadFull` fixes
the issue.

*Note:* because bundles are cached, one will need to clean their cache
bundle (`~/.tekton/bundles`) to make sure it re-fetches correct
content.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
