### PR TITLE
Use io.ReadFull to read the bundle content

### DIFF
--- a/pkg/bundle/reader.go
+++ b/pkg/bundle/reader.go
@@ -116,7 +116,7 @@ func readTarLayer(l v1.Layer) ([]byte, error) {
 	}
 
 	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
+	if _, err := io.ReadFull(treader, contents); err != nil && err != io.EOF {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The io.Reader documentation says:

> Read reads up to len(p) bytes into p. It returns the number of bytes
> read (0 <= n <= len(p)) and any error encountered. ... If some data is
> available but not len(p) bytes, Read conventionally returns what is
> available instead of waiting for more.

Read is not guaranteed to fill the data argument. Use io.ReadFull to
fill the buffer.

In some cases (a relatively big bundle), the bundle content was not
completely read and it would fail to parse. Using `io.ReadFull` fixes
the issue.

*Note:* because bundles are cached, one will need to clean their cache
bundle (`~/.tekton/bundles`) to make sure it re-fetches correct
content.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix an issue on `bundle list` command with relatively big bundles that couldn't be parsed (truncated data)
```

