### PR TITLE
Do not print twice Cancelled when listing

### DIFF
--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -72,10 +72,19 @@ func Condition(c v1.Conditions) string {
 	} else if c[0].Reason != "" && c[0].Reason != status {
 		switch c[0].Reason {
 		case "PipelineRunCancelled", "TaskRunCancelled", "Cancelled":
+			if c[0].Reason == "Cancelled" {
+				return ColorStatus("Cancelled")
+			}
 			return ColorStatus("Cancelled") + "(" + c[0].Reason + ")"
 		case "PipelineRunStopping", "TaskRunStopping":
+			if c[0].Reason == "Failed" {
+				return ColorStatus("Failed")
+			}
 			return ColorStatus("Failed") + "(" + c[0].Reason + ")"
 		case "CreateContainerConfigError", "ExceededNodeResources", "ExceededResourceQuota":
+			if c[0].Reason == "Pending" {
+				return ColorStatus("Pending")
+			}
 			return ColorStatus("Pending") + "(" + c[0].Reason + ")"
 		default:
 			return ColorStatus(status) + "(" + c[0].Reason + ")"

--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -107,7 +107,7 @@ func TestCondition(t *testing.T) {
 				Status: corev1.ConditionFalse,
 				Reason: "Cancelled",
 			}},
-			want: "Cancelled(Cancelled)",
+			want: "Cancelled",
 		},
 		{
 			name: "PipelineRunTimeout status reason",


### PR DESCRIPTION
When listing the status of pipelinerun we would show something like this for cancelled PR:

```console
NAME            STARTED         DURATION   STATUS
pr-hmth-fmknk   5 minutes ago   1m8s       Succeeded
pr-hmth-7qzlb   5 minutes ago   11s        Cancelled(Cancelled)
pr-hmth-dtdrh   7 minutes ago   1m14s      Succeeded
pr-zrbj-f4kq8   7 minutes ago   1m24s      Succeeded
pr-zrbj-hxhw2   7 minutes ago   9s         Cancelled(Cancelled)
```

which makes no sense, the Cancelled(Cancelled) is redundant, so we fix this by checking the reasons is not the same as what we are going to set. which now show a nicer:

```console
NAME            STARTED          DURATION   STATUS
pr-hmth-fmknk   8 minutes ago    1m8s       Succeeded
pr-hmth-7qzlb   8 minutes ago    11s        Cancelled
pr-hmth-dtdrh   10 minutes ago   1m14s      Succeeded
pr-zrbj-f4kq8   10 minutes ago   1m24s      Succeeded
pr-zrbj-hxhw2   10 minutes ago   9s         Cancelled
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:


For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->


```release-note
Fix listing with `tkn pr list` as *Cancelled*
```
