### PR TITLE
Fix debbuild

### DIFF
--- a/tekton/debbuild/control/control
+++ b/tekton/debbuild/control/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 4.3.0
 Build-Depends: debhelper (>= 13),
-               dh-sequence-golang,
+               dh-golang,
                golang-any,
                curl,
                python3


### PR DESCRIPTION
This fix the debbuild which is breaking
after changing to dh-sequence-golang

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix debbuild
```