### PR TITLE
feat(rpmbuild): update bash-completion handling

### DIFF
--- a/tekton/rpmbuild/tekton.spec
+++ b/tekton/rpmbuild/tekton.spec
@@ -10,6 +10,7 @@ License:        ASL 2.0
 URL:            https://%{repo}
 Source0:        https://%{repo}/archive/tkn_%{version}_Linux_x86_64.tar.gz
 Source1:        manpages.tar.gz
+Recommends:     bash-completion
 
 %description
 The Tekton Pipelines cli project provides a CLI for interacting with Tekton !
@@ -24,9 +25,6 @@ and not compiling from the sources.
 %install
 install -D -m 0755 tkn %{buildroot}%{_bindir}/tkn
 
-install -d %{buildroot}%{_datadir}/bash-completion/completions
-./tkn completion bash > %{buildroot}%{_datadir}/bash-completion/completions/_tkn
-
 install -d %{buildroot}%{_datadir}/zsh/site-functions
 ./tkn completion zsh > %{buildroot}%{_datadir}/zsh/site-functions/_tkn
 
@@ -37,10 +35,13 @@ mkdir -p %{buildroot}%{_mandir} && cp -a man1 %{buildroot}%{_mandir}
 %license LICENSE
 %{_bindir}/tkn
 %{_datadir}/zsh/site-functions/*
-%{_datadir}/bash-completion/completions/*
 %{_mandir}/*
 
 %changelog
+* Mon Jan 08 2022 Chmouel Boudjnah <chmouel@chmouel.com> 0.25.1
+- Don't generate bash completion since included by bash-completion package. Add
+  package as Recommends.
+
 * Mon Jun 13 2022 Chmouel Boudjnah <chmouel@chmouel.com> 0.24.0
 - Don't compile, use binary from releases.
 


### PR DESCRIPTION
Since bash-completion now include _tkn we can add it as recommended and remove the generation

- Add bash-completion as a recommended package.
- Remove manual generation of bash completion files.

Fixes #2464

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:


For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->


```release-note
The bash completions for the rpm package have been integrated into the bash-completion package and, consequently, removed from our package.
```