### PR TITLE
Fix e2e test for eventlistener

### DIFF
--- a/test/e2e/eventlistener/eventListener_test.go
+++ b/test/e2e/eventlistener/eventListener_test.go
@@ -46,7 +46,7 @@ func TestEventListenerE2E(t *testing.T) {
 	createResources(t, c, namespace)
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("eventlistener/eventlistener.yaml"))
 	// Wait for pods to become available for next test
-	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=2m", "--all")
+	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=5m", "--all")
 
 	t.Run("Assert if EventListener AVAILABLE status is true", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "eventlistener", "list")
@@ -57,7 +57,7 @@ func TestEventListenerE2E(t *testing.T) {
 	t.Logf("Scaling EventListener %s to 3 replicas in namespace %s", elName, namespace)
 	kubectl.MustSucceed(t, "apply", "-f", helper.GetResourcePath("eventlistener/eventlistener-multi-replica.yaml"))
 	// Wait for pods to become available for next test
-	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=2m", "--all")
+	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=5m", "--all")
 }
 
 func TestEventListenerLogsE2E(t *testing.T) {
@@ -74,7 +74,7 @@ func TestEventListenerLogsE2E(t *testing.T) {
 	createResources(t, c, namespace)
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("eventlistener/eventlistener_log.yaml"))
 	// Wait for pods to run and crash for next test
-	kubectl.MustSucceed(t, "wait", "--for=jsonpath=.status.phase=Running", "pod", "-n", namespace, "--timeout=2m", "--all")
+	kubectl.MustSucceed(t, "wait", "--for=jsonpath=.status.phase=Running", "pod", "-n", namespace, "--timeout=5m", "--all")
 
 	t.Run("Get logs of EventListener", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "eventlistener", "logs", elName, "-t", "1")
@@ -109,7 +109,7 @@ func TestEventListener_v1beta1LogsE2E(t *testing.T) {
 	createResources(t, c, namespace)
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("eventlistener/eventlistener_v1beta1_log.yaml"))
 	// Wait for pods to run and crash for next test
-	kubectl.MustSucceed(t, "wait", "--for=jsonpath=.status.phase=Running", "pod", "-n", namespace, "--timeout=2m", "--all")
+	kubectl.MustSucceed(t, "wait", "--for=jsonpath=.status.phase=Running", "pod", "-n", namespace, "--timeout=5m", "--all")
 
 	t.Run("Get logs of EventListener", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "eventlistener", "logs", elName, "-t", "1")
@@ -144,7 +144,7 @@ func TestEventListener_v1beta1E2E(t *testing.T) {
 	createResources(t, c, namespace)
 	kubectl.MustSucceed(t, "create", "-f", helper.GetResourcePath("eventlistener/eventlistener_v1beta1.yaml"))
 	// Wait for pods to become available for next test
-	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=2m", "--all")
+	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=5m", "--all")
 
 	t.Run("Assert if EventListener AVAILABLE status is true", func(t *testing.T) {
 		res := tkn.MustSucceed(t, "eventlistener", "list")
@@ -155,7 +155,7 @@ func TestEventListener_v1beta1E2E(t *testing.T) {
 	t.Logf("Scaling EventListener %s to 3 replicas in namespace %s", elName, namespace)
 	kubectl.MustSucceed(t, "apply", "-f", helper.GetResourcePath("eventlistener/eventlistener_v1beta1-multi-replica.yaml"))
 	// Wait for pods to become available for next test
-	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=2m", "--all")
+	kubectl.MustSucceed(t, "wait", "--for=condition=Ready", "pod", "-n", namespace, "--timeout=5m", "--all")
 }
 
 func createResources(t *testing.T, c *framework.Clients, namespace string) {


### PR DESCRIPTION
This patch increase wait timeout to 5 minutes as
earliar e2e test was failing due to timeout

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
