### PR TITLE
Remove create clusterrole in triggers test

### DIFF
--- a/test/resources/eventlistener/eventlistener_log.yaml
+++ b/test/resources/eventlistener/eventlistener_log.yaml
@@ -18,7 +18,7 @@ kind: EventListener
 metadata:
   name: github-listener-interceptor
 spec:
-  serviceAccountName: tekton-triggers-github-log-sa
+  serviceAccountName: tekton-triggers-github-sa
   triggers:
     - name: github-listener
       interceptors:
@@ -82,18 +82,13 @@ spec:
                   - name: url
                     value: $(tt.params.gitrepositoryurl)
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tekton-triggers-github-log-sa
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-triggers-github-binding
 subjects:
   - kind: ServiceAccount
-    name: tekton-triggers-github-log-sa
+    name: tekton-triggers-github-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/resources/eventlistener/eventlistener_v1beta1_log.yaml
+++ b/test/resources/eventlistener/eventlistener_v1beta1_log.yaml
@@ -18,7 +18,7 @@ kind: EventListener
 metadata:
   name: github-listener-interceptor
 spec:
-  serviceAccountName: tekton-triggers-github-log-sa
+  serviceAccountName: tekton-triggers-github-sa
   triggers:
     - name: github-listener
       interceptors:
@@ -89,18 +89,13 @@ spec:
                   - name: url
                     value: $(tt.params.gitrepositoryurl)
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tekton-triggers-github-log-sa
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-triggers-github-binding
 subjects:
   - kind: ServiceAccount
-    name: tekton-triggers-github-log-sa
+    name: tekton-triggers-github-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
This will remove creating clusterrole in triggers test as it is shipped by triggers now and an be used in clusterolebinding

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Remove create clusterrole in triggers test
```