### PR TITLE
Feat: enhance tkn version command to display openshift pipelines product version 

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -74,6 +74,10 @@ func Command(p cli.Params) *cobra.Command {
 			if err == nil {
 				switch component {
 				case "":
+					productVersion, _ := version.GetRedHatOpenShiftPipelinesVersion(cs, namespace)
+					if productVersion != "" {
+						fmt.Fprintf(cmd.OutOrStdout(), "Red Hat OpenShift Pipelines: %s\n", productVersion)
+					}
 					fmt.Fprintf(cmd.OutOrStdout(), "Client version: %s\n", clientVersion)
 					chainsVersion, _ := version.GetChainsVersion(cs, namespace)
 					if chainsVersion != "" {
@@ -140,6 +144,12 @@ func Command(p cli.Params) *cobra.Command {
 						hubVersion = "unknown"
 					}
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", hubVersion)
+				case "openshift":
+					productVersion, _ := version.GetRedHatOpenShiftPipelinesVersion(cs, namespace)
+					if productVersion == "" {
+						productVersion = "unknown"
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", productVersion)
 				default:
 					fmt.Fprintf(cmd.OutOrStdout(), "Invalid component value\n")
 				}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
It extends the existing tkn version command to include the OpenShift product version information. This helps users quickly identify the OpenShift Tekton product version alongside the CLI version.
Fixes jira: [SRVKP-2124](https://issues.redhat.com/browse/SRVKP-2124)

Changes:
- Added logic to detect OpenShift environment and fetch OpenShift product version
- Display OpenShift product version in tkn version output
- Added tests to verify OpenShift product version inclusion

Sample output:

> $ ./tkn version
> Red Hat OpenShift Pipelines version: 1.7.0
> Client version: dev
> Chains version: v0.24.0
> Pipeline version: v0.69.0
> Triggers version: v0.31.0
> Operator version: devel

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note: -->

```release-note
Added OpenShift product version display to `tkn version` command output.
```
<!--
For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here 
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
