### PR TITLE
Deprecate the chain command

### DIFF
--- a/docs/cmd/tkn.md
+++ b/docs/cmd/tkn.md
@@ -21,7 +21,6 @@ CLI for tekton pipelines
 ### SEE ALSO
 
 * [tkn bundle](tkn_bundle.md)	 - Manage Tekton Bundles
-* [tkn chain](tkn_chain.md)	 - Manage Chains
 * [tkn clustertriggerbinding](tkn_clustertriggerbinding.md)	 - Manage ClusterTriggerBindings
 * [tkn completion](tkn_completion.md)	 - Prints shell completion scripts
 * [tkn customrun](tkn_customrun.md)	 - Manage CustomRuns

--- a/docs/man/man1/tkn.1
+++ b/docs/man/man1/tkn.1
@@ -26,4 +26,4 @@ CLI for tekton pipelines
 
 .SH SEE ALSO
 .PP
-\fBtkn\-bundle(1)\fP, \fBtkn\-chain(1)\fP, \fBtkn\-clustertriggerbinding(1)\fP, \fBtkn\-completion(1)\fP, \fBtkn\-customrun(1)\fP, \fBtkn\-eventlistener(1)\fP, \fBtkn\-hub(1)\fP, \fBtkn\-pipeline(1)\fP, \fBtkn\-pipelinerun(1)\fP, \fBtkn\-task(1)\fP, \fBtkn\-taskrun(1)\fP, \fBtkn\-triggerbinding(1)\fP, \fBtkn\-triggertemplate(1)\fP, \fBtkn\-version(1)\fP
+\fBtkn\-bundle(1)\fP, \fBtkn\-clustertriggerbinding(1)\fP, \fBtkn\-completion(1)\fP, \fBtkn\-customrun(1)\fP, \fBtkn\-eventlistener(1)\fP, \fBtkn\-hub(1)\fP, \fBtkn\-pipeline(1)\fP, \fBtkn\-pipelinerun(1)\fP, \fBtkn\-task(1)\fP, \fBtkn\-taskrun(1)\fP, \fBtkn\-triggerbinding(1)\fP, \fBtkn\-triggertemplate(1)\fP, \fBtkn\-version(1)\fP

--- a/pkg/cmd/chain/chain.go
+++ b/pkg/cmd/chain/chain.go
@@ -47,5 +47,6 @@ func Command(p cli.Params) *cobra.Command {
 		payloadCommand(p),
 		signatureCommand(p),
 	)
+	cmd.Deprecated = "The Chain command is deprecated and will be removed in future releases."
 	return cmd
 }

--- a/pkg/cmd/chain/payload.go
+++ b/pkg/cmd/chain/payload.go
@@ -69,6 +69,7 @@ func payloadCommand(p cli.Params) *cobra.Command {
 		},
 	}
 	c.Flags().BoolVarP(&opts.SkipVerify, "skip-verify", "S", opts.SkipVerify, "Skip verifying the payload'signature")
+	c.Deprecated = "The Chain command is deprecated and will be removed in future releases."
 
 	return c
 }

--- a/pkg/cmd/chain/signature.go
+++ b/pkg/cmd/chain/signature.go
@@ -58,6 +58,7 @@ func signatureCommand(p cli.Params) *cobra.Command {
 			return printSignatures(cs, chainsNamespace, taskrun)
 		},
 	}
+	c.Deprecated = "The Chain command is deprecated and will be removed in future releases."
 
 	return c
 }


### PR DESCRIPTION
This patch deprecate the chain command and
it's sub commands payload and signature.

Part of: #2534 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
