### PR TITLE
fix: update Pending color of PipelineRunPending

### DIFF
--- a/pkg/cmd/pipelinerun/delete_test.go
+++ b/pkg/cmd/pipelinerun/delete_test.go
@@ -635,7 +635,7 @@ func TestPipelineRunDelete_v1beta1(t *testing.T) {
 			input:       seeds[15].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "NAME             STARTED         DURATION   STATUS\npipeline-run-4   ---             ---        ---\npipeline-run-5   ---             ---        Succeeded(PipelineRunPending)\npipeline-run-6   0 seconds ago   ---        Succeeded(Running)\npipeline-run-7   0 seconds ago   ---        Running(PipelineRunPending)\n",
+			want:        "NAME             STARTED         DURATION   STATUS\npipeline-run-4   ---             ---        ---\npipeline-run-5   ---             ---        Pending\npipeline-run-6   0 seconds ago   ---        Succeeded(Running)\npipeline-run-7   0 seconds ago   ---        Pending\n",
 		},
 	}
 
@@ -1267,7 +1267,7 @@ func TestPipelineRunDelete(t *testing.T) {
 			input:       seeds[15].pipelineClient,
 			inputStream: nil,
 			wantError:   false,
-			want:        "NAME             STARTED         DURATION   STATUS\npipeline-run-4   ---             ---        ---\npipeline-run-5   ---             ---        Succeeded(PipelineRunPending)\npipeline-run-6   0 seconds ago   ---        Succeeded(Running)\npipeline-run-7   0 seconds ago   ---        Running(PipelineRunPending)\n",
+			want:        "NAME             STARTED         DURATION   STATUS\npipeline-run-4   ---             ---        ---\npipeline-run-5   ---             ---        Pending\npipeline-run-6   0 seconds ago   ---        Succeeded(Running)\npipeline-run-7   0 seconds ago   ---        Pending\n",
 		},
 	}
 

--- a/pkg/formatted/k8s.go
+++ b/pkg/formatted/k8s.go
@@ -29,7 +29,7 @@ var ConditionColor = map[string]color.Attribute{
 	"Running":   color.FgHiBlue,
 	"Cancelled": color.FgHiYellow,
 	"Completed": color.FgHiMagenta,
-	"Pending":   color.FgHiBlue,
+	"Pending":   color.FgHiYellow,
 	"Started":   color.FgHiCyan,
 }
 
@@ -86,6 +86,8 @@ func Condition(c v1.Conditions) string {
 				return ColorStatus("Pending")
 			}
 			return ColorStatus("Pending") + "(" + c[0].Reason + ")"
+		case "PipelineRunPending":
+			return ColorStatus("Pending")
 		default:
 			return ColorStatus(status) + "(" + c[0].Reason + ")"
 		}

--- a/pkg/formatted/k8s_test.go
+++ b/pkg/formatted/k8s_test.go
@@ -83,6 +83,15 @@ func TestCondition(t *testing.T) {
 			want: "Succeeded",
 		},
 		{
+			name: "PipelineRunPending status reason",
+			condition: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+				Reason: "PipelineRunPending",
+			}},
+			want: "Pending",
+		},
+		{
 			name: "PipelineRunCanceled status reason",
 			condition: []apis.Condition{{
 				Type:   apis.ConditionSucceeded,


### PR DESCRIPTION
- Changed Pending status color from blue to yellow for better clarity
- Added explicit handling for PipelineRunPending status to display as Pending
- Updated tests to cover PipelineRunPending condition

Before:

![image](https://github.com/user-attachments/assets/7d3a6b87-8069-4dc1-8c56-51c5a67585ba)

After:

![image](https://github.com/user-attachments/assets/9f1ac8c2-de53-464c-80e8-fa2d159f09fa)


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
