### PR TITLE
fix panic when trying to read pod logs when pod is already deleted

### DIFF
--- a/pkg/log/task_reader.go
+++ b/pkg/log/task_reader.go
@@ -199,8 +199,13 @@ func (r *Reader) readPodLogs(podC <-chan string, podErrC <-chan error, follow, t
 			}
 			if err != nil {
 				errC <- fmt.Errorf("task %s failed: %s. Run tkn tr desc %s for more details", r.task, strings.TrimSpace(err.Error()), r.run)
+				continue
 			}
 			steps := filterSteps(pod, r.allSteps, r.steps)
+			if len(steps) == 0 {
+				errC <- fmt.Errorf("no steps found for task %s", r.task)
+				continue
+			}
 			r.readStepsLogs(logC, errC, steps, p, follow, timestamps)
 		}
 	}()
@@ -291,6 +296,7 @@ func (r *Reader) getTaskRunPodNames(run *v1.TaskRun) (<-chan string, <-chan erro
 func filterSteps(pod *corev1.Pod, allSteps bool, stepsGiven []string) []*step {
 	steps := []*step{}
 	if pod == nil {
+		fmt.Printf("pod not found")
 		return steps
 	}
 	stepsInPod := getSteps(pod)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fixed panic when trying to call log.NewReader(logType, opts) for a pipelineRun, but some of the task pod has been deleted.

Initial work is done in https://github.com/tektoncd/cli/pull/2411, due to inactivity taking up the follow up changes

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
fix panic when trying to read pod logs when pod is already deleted
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:


For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
