### PR TITLE
Add --resolvertype flag to rerun a resolver based pipelinerun

### DIFF
--- a/docs/cmd/tkn_pipeline_start.md
+++ b/docs/cmd/tkn_pipeline_start.md
@@ -74,6 +74,7 @@ my-csi-template and my-volume-claim-template)
       --pipeline-timeout string       timeout for PipelineRun
       --pod-template string           local or remote file containing a PodTemplate definition
       --prefix-name string            specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)
+      --resolvertype string           resolver type for remote pipelines (hub, git, http, cluster, bundle, remote)
   -s, --serviceaccount string         pass the serviceaccount name
       --showlog                       show logs right after starting the Pipeline
       --skip-optional-workspace       skips the prompt for optional workspaces

--- a/docs/man/man1/tkn-pipeline-start.1
+++ b/docs/man/man1/tkn-pipeline-start.1
@@ -76,6 +76,10 @@ Parameters, at least those that have no default value
     specify a prefix for the PipelineRun name (must be lowercase alphanumeric characters)
 
 .PP
+\fB\-\-resolvertype\fP=""
+    resolver type for remote pipelines (hub, git, http, cluster, bundle, remote)
+
+.PP
 \fB\-s\fP, \fB\-\-serviceaccount\fP=""
     pass the serviceaccount name
 


### PR DESCRIPTION
Previously, the `tkn p start <pipeline_name> --last` command was used to rerun a pipeline by referencing the last successful PipelineRun. This worked well for pipelines that were defined and available on the cluster (i.e., when the Pipeline resource existed in the cluster).
However, with resolver-based pipelines, the pipeline definition is not stored as a cluster-scoped resource. Instead, it is dynamically fetched from an external source, such as:

**Git resolver** – when the pipeline is defined in a Git repository
**HTTP resolver** – when the pipeline is fetched from a remote HTTP endpoint
**Hub resolver** – when the pipeline comes from Tekton or Artifact Hub
**Bundle resolver** – when the pipeline is packaged and retrieved from an OCI bundle
**Cluster resolver** – when it references a resource within the cluster using the resolver mechanism

Because of this, the existing `--last` flag did not work for resolver-based pipelines — the CLI had no direct reference to the original resolver configuration (e.g., URL, repository, bundle reference, etc.) used in the previous run.

To address this limitation, this PR introduces a new flag called `--resolvertype`.
This flag allows users to specify the resolver type (such as `git`, `http`, `hub`, `cluster`, `bundle`, and a special type `remote` resolvers (whan user doesn't know about resolver type they can specify `--resolvertype=remote` which would be any supported type resolver)) when re-running a resolver-based pipeline.

When provided, the CLI uses the metadata from the last `PipelineRun` — including the resolver type and its parameters — to reconstruct and trigger a new `PipelineRun` using the same remote source.

This PR supports these following combinations of flag `--last` and `--resolvertype`

- tkn p <pipeline_name> start –last (existing one)
- tkn p start <pipeline_name> --last –remotetype=remote 
  - pipeline_name is optional and 
  - If provides pipeline_name is provided then it searches pipeline on the cluster
- tkn p start <pipeline_name> –resolvertype=git/http/bundle/cluster/hub
  -  pipeline_name is required
- tkn p start <pipeline_name> –last –remotetype=git/htttp/cluster/bundle/hub
   - pipeline_name is optional
   - if pipeline_name is provided then it searches pipeline on the cluster

closes: #2422


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes



```release-note
This introduces a new flag called `--resolvertype`. This flag allows users to specify the resolver type (such as `git`, `http`, `hub`, `cluster`, `bundle`, and a special type `remote` resolvers (which would be any supported type resolver)) when re-running a resolver-based pipeline.

```
