### PR TITLE
Fix lint errors

### DIFF
--- a/test/e2e/customrun/list_test.go
+++ b/test/e2e/customrun/list_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2024 The Tekton Authors.
 //

--- a/test/e2e/eventlistener/eventListener_test.go
+++ b/test/e2e/eventlistener/eventListener_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2020 The Tekton Authors.
 //

--- a/test/e2e/pipeline/pipeline_test.go
+++ b/test/e2e/pipeline/pipeline_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2020 The Tekton Authors.
 //

--- a/test/e2e/pipeline/start_test.go
+++ b/test/e2e/pipeline/start_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2020 The Tekton Authors.
 //

--- a/test/e2e/pipelinerun/pipelinerun_test.go
+++ b/test/e2e/pipelinerun/pipelinerun_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2020 The Tekton Authors.
 //

--- a/test/e2e/plugin/plugin_test.go
+++ b/test/e2e/plugin/plugin_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2020 The Tekton Authors.
 //

--- a/test/e2e/task/start_test.go
+++ b/test/e2e/task/start_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // Copyright © 2020 The Tekton Authors.
 //


### PR DESCRIPTION
This patch removes deprecated //+build e2e tag
to fix the lint errors

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```