### PR TITLE
feat: add cherry-pick command workflow

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -1,0 +1,32 @@
+# Cherry Pick Command Workflow
+#
+# This workflow is triggered by the /cherry-pick slash command from the slash.yml workflow.
+# It automatically cherry-picks merged PRs to the specified target branches.
+#
+# Usage: Comment `/cherry-pick <target-branch> [<target-branch> ...]` on a merged pull request
+# Example: `/cherry-pick release-v0.42.x`
+# Example: `/cherry-pick release-v0.42.x release-v0.43.x`
+#
+# Security Notes:
+# - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Works safely with PRs from forks because it only cherry-picks already-merged commits
+# - Uses CHATOPS_TOKEN to create PRs and push to branches
+# - The action creates a new branch from the target branch, not from the fork
+
+name: Cherry Pick Command
+
+on:
+  repository_dispatch:
+    types: [cherry-pick-command]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick Actions
+    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@4b57443b85569e5bb7d9ee440bf5cae99cb642cb
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}


### PR DESCRIPTION
# Changes

This PR adds the cherry-pick command workflow to cli (addresses tektoncd/plumbing#3004).

**What's included:**
- New `cherry-pick-command.yaml` workflow using the centralized plumbing reusable workflow
- Enables `/cherry-pick <branch>` command for easier backports to release branches
- CLI already has `slash.yml` configured to use plumbing's slash routing, so no changes needed there

**Benefits:**
- Streamlines cherry-picking to release branches with simple slash command
- Uses centralized, well-tested logic from tektoncd/plumbing
- Consistent behavior with other tektoncd repositories
- Reduces manual cherry-pick errors

**Usage:**
Comment `/cherry-pick release-v0.42.x` on a merged PR to automatically create a cherry-pick PR to that branch.

# Submitter Checklist

- [x] Includes tests (N/A - workflow file only)
- [x] Includes docs (comprehensive inline documentation in workflow file)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```