### PR TITLE
Add CI summary fan-in job to presubmit CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,3 +108,39 @@ jobs:
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml
+
+  ci-summary:
+    name: CI summary
+    if: always()
+    needs:
+      - build
+      - linting
+      - tests
+      - generated
+      - multi-arch-build
+      - e2e-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          echo "build: ${{ needs.build.result }}"
+          echo "linting: ${{ needs.linting.result }}"
+          echo "tests: ${{ needs.tests.result }}"
+          echo "generated: ${{ needs.generated.result }}"
+          echo "multi-arch-build: ${{ needs.multi-arch-build.result }}"
+          echo "e2e-tests: ${{ needs.e2e-tests.result }}"
+          results=(
+            "${{ needs.build.result }}"
+            "${{ needs.linting.result }}"
+            "${{ needs.tests.result }}"
+            "${{ needs.generated.result }}"
+            "${{ needs.multi-arch-build.result }}"
+            "${{ needs.e2e-tests.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "One or more jobs failed"
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped"


### PR DESCRIPTION
# Changes

Add a `ci-summary` fan-in job that depends on all CI jobs and acts as a
single required check for branch protection. This replaces having
to configure individual job names as required checks.

The job treats both `success` and `skipped` as passing states,
only failing when a job returns `failure` or `cancelled`.

This follows the same pattern used in tektoncd/pipeline and tektoncd/triggers.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```