### PR TITLE
Move piyush-garg to alumni

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@
 approvers:
 - vdemeester
 - chmouel
-- piyush-garg
 - vinamra28
 - pratap0007
 
@@ -16,3 +15,4 @@ reviewers:
 # danielhelfand
 # hrishin
 # sthaha
+# piyush-garg


### PR DESCRIPTION
# Changes

Move piyush-garg to alumni in OWNERS. Near-zero CLI activity in the last 12 months (0 PRs authored, only 10 issue comments). DevStats shows only 17 CLI contributions vs a previous 976 org-wide in the last 2 years — activity dropped off completely.

Per the [contributor ladder inactivity policy](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#inactivity), >4 months of no contributions warrants moving to emeritus.

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`.
- [x] Release notes block below has been updated with any user facing changes

# Release Notes

```release-note
NONE
```