### PR TITLE
Nominate divyansh42 as cli approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
+- divyansh42
 - vdemeester
 - chmouel
 - piyush-garg


### PR DESCRIPTION
# Changes

Nominate **divyansh42** for promotion to cli approver. Already a reviewer on this repo.

Per the [contributor ladder](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#maintainer), the nominee must agree to all requirements by commenting on this PR.

## divyansh42 — Activity (last 12 months)

| Metric | CLI | Org-wide |
|--------|-----|----------|
| DevStats contributions | 76 | 340 |
| PRs authored | 7 (4 merged) | 42 |
| PR reviews | 6 | 188 |
| Comments | 82 | 210 |

Already a cli reviewer. Also a major contributor on **results** (239 devstats contributions). Strong cross-repo presence with 188 total reviews org-wide.

## Maintainer Requirements Checklist

- [x] Active reviewing for 3+ months
- [x] 30+ PRs authored/reviewed
- [x] Broad knowledge of the project
- [ ] **Nominee**: please comment confirming you agree to all maintainer responsibilities

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```