### PR TITLE
Change all occurences of GCS buckets with OCI buckets

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -137,11 +137,11 @@ function install_pipeline_crd() {
 
     # First try to install latestreleaseyaml from nightly
     # TODO: re-enable this curl command once we are confident about nightly releases
-    # curl -o/dev/null -s -LI -f https://storage.googleapis.com/tekton-releases-nightly/pipeline/latest/release.yaml &&
-    #     latestreleaseyaml=https://storage.googleapis.com/tekton-releases-nightly/pipeline/latest/release.yaml
+    # curl -o/dev/null -s -LI -f https://infra.tekton.dev/tekton-releases-nightly/pipeline/latest/release.yaml &&
+    #     latestreleaseyaml=https://infra.tekton.dev/tekton-releases-nightly/pipeline/latest/release.yaml
 
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
-    [[ -n ${latestreleaseyaml} ]] || latestreleaseyaml=https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+    [[ -n ${latestreleaseyaml} ]] || latestreleaseyaml=https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
   fi
   [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
   kubectl apply -f ${latestreleaseyaml} ||
@@ -164,21 +164,21 @@ function install_triggers_crd() {
 	latestreleaseyaml=${RELEASE_YAML_TRIGGERS}
   else
     # First try to install latestreleaseyaml from nightly
-    curl -o/dev/null -s -LI -f https://storage.googleapis.com/tekton-releases-nightly/triggers/latest/release.yaml &&
-        latestreleaseyaml=https://storage.googleapis.com/tekton-releases-nightly/triggers/latest/release.yaml
+    curl -o/dev/null -s -LI -f https://infra.tekton.dev/tekton-releases-nightly/triggers/latest/release.yaml &&
+        latestreleaseyaml=https://infra.tekton.dev/tekton-releases-nightly/triggers/latest/release.yaml
 
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
-    [[ -z ${latestreleaseyaml} ]] && latestreleaseyaml="https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml"
+    [[ -z ${latestreleaseyaml} ]] && latestreleaseyaml="https://infra.tekton.dev/tekton-releases/triggers/latest/release.yaml"
   fi
   if [[ -n ${RELEASE_YAML_TRIGGERS_INTERCEPTORS} ]];then
 	latestinterceptorsyaml=${RELEASE_YAML_TRIGGERS_INTERCEPTORS}
   else
     # First try to install latest interceptors from nightly
-    curl -o/dev/null -s -LI -f https://storage.googleapis.com/tekton-releases-nightly/triggers/latest/interceptors.yaml &&
-        latestinterceptorsyaml=https://storage.googleapis.com/tekton-releases-nightly/triggers/latest/interceptors.yaml
+    curl -o/dev/null -s -LI -f https://infra.tekton.dev/tekton-releases-nightly/triggers/latest/interceptors.yaml &&
+        latestinterceptorsyaml=https://infra.tekton.dev/tekton-releases-nightly/triggers/latest/interceptors.yaml
 
     # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
-    [[ -z ${latestinterceptorsyaml} ]] && latestinterceptorsyaml="https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml"
+    [[ -z ${latestinterceptorsyaml} ]] && latestinterceptorsyaml="https://infra.tekton.dev/tekton-releases/triggers/latest/interceptors.yaml"
   fi
   [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
   [[ -z ${latestinterceptorsyaml} ]] && fail_test "Could not get latest released interceptors.yaml"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes:  https://github.com/tektoncd/cli/issues/2767

This pull request updates Tekton release URLs throughout the documentation and scripts to use the new `infra.tekton.dev` domain instead of the previous `storage.googleapis.com` URLs.

### Migration to new Tekton release URL domain:

Updated all references to Tekton release YAMLs in `test/e2e-common.sh` to use https://infra.tekton.dev/tekton-releases/ instead of https://storage.googleapis.com/tekton-releases/.

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

/kind documentation