### PR TITLE
[release-v0.38.2] fix: bump Go to 1.25.8 to fix CVE-2025-61728, CVE-2025-61726, CVE-2025-61729

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.22.5
+go 1.25.8
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Bump Go version to 1.25.8 to fix three CVEs:

- **CVE-2025-61728**: Excessive CPU consumption when building archive index in `archive/zip`
- **CVE-2025-61726**: Memory exhaustion in `net/url` query parameter parsing
- **CVE-2025-61729**: Resource exhaustion in `crypto/x509` certificate validation

/kind bug

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Bump Go to 1.25.8 to fix CVE-2025-61728 (archive/zip DoS), CVE-2025-61726 (net/url memory exhaustion), CVE-2025-61729 (crypto/x509 resource exhaustion).
```