### PR TITLE
fix: CVE-2025-61729 - update contrib Dockerfile to use Go 1.25.6

### DIFF
--- a/contrib/tkn-image/Dockerfile
+++ b/contrib/tkn-image/Dockerfile
@@ -1,11 +1,11 @@
-ARG GOLANG_VERSION=1.17.13
-ARG DEBIAN_VERSION=10
+ARG GOLANG_VERSION=1.25.6
+ARG DEBIAN_VERSION=12
 
-FROM golang:${GOLANG_VERSION} as builder
+FROM golang:${GOLANG_VERSION} AS builder
 ARG RELEASE_VERSION=
 COPY . /go/src/github.com/tektoncd/cli
 WORKDIR /go/src/github.com/tektoncd/cli
 RUN make RELEASE_VERSION=${RELEASE_VERSION} bin/tkn
 
-FROM debian:${DEBIAN_VERSION} as tkn
+FROM debian:${DEBIAN_VERSION} AS tkn
 COPY --from=builder /go/src/github.com/tektoncd/cli/bin/tkn /usr/bin


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
## Summary
- Bumps `contrib/tkn-image/Dockerfile` from Go 1.17.13 to 1.25.6 to pick up the fix for CVE-2025-61729 (DoS via crafted x509 certificate).
- Also bumps Debian from 10 (EOL) to 12.

The go.mod was already at 1.25.6 so the old Dockerfile couldn't even build the project anymore.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
/kind misc