### PR TITLE
Add CI summary job to the github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,3 +97,39 @@ jobs:
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml
+
+  ci-summary:
+    name: CI summary
+    if: always()
+    needs:
+      - build
+      - linting
+      - tests
+      - generated
+      - multi-arch-build
+      - e2e-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          echo "build: ${{ needs.build.result }}"
+          echo "linting: ${{ needs.linting.result }}"
+          echo "tests: ${{ needs.tests.result }}"
+          echo "generated: ${{ needs.generated.result }}"
+          echo "multi-arch-build: ${{ needs.multi-arch-build.result }}"
+          echo "e2e-tests: ${{ needs.e2e-tests.result }}"
+          results=(
+            "${{ needs.build.result }}"
+            "${{ needs.linting.result }}"
+            "${{ needs.tests.result }}"
+            "${{ needs.generated.result }}"
+            "${{ needs.multi-arch-build.result }}"
+            "${{ needs.e2e-tests.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "One or more jobs failed"
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This change adds CI summary job to release-v0.42.1  so that PRs are not blocked and can be merged.



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
