### PR TITLE
Strip Go symbol table from release binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
   - s390x
   - ppc64le
   ldflags:
-  - -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}
+  - -s -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}
 archives:
 - name_template: >-
     {{- .Binary }}_


### PR DESCRIPTION
# Changes

Add `-s` to the goreleaser ldflags alongside the existing `-w`.

Per maintainer testing in #2109, building `tkn` with `-s -w` shrinks the binary from ~207MB to ~147MB (~30%) compared to the current `-w`-only default. The release pipeline already strips DWARF debug info via `-w`; adding `-s` additionally strips the Go symbol table, which is purely a size optimization for release artifacts.

Fixes part of #2109.

# Submitter Checklist

- [x] Includes tests (n/a — release-config-only change)
- [x] Run the code checkers with `make check` (n/a — no Go code touched)
- [x] Regenerate the manpages, docs and go formatting with `make generated` (n/a)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Release binaries are now built with `-s` in addition to `-w`, reducing the `tkn` binary size by ~30%.
```