### PR TITLE
Update tekton hub to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/tektoncd/chains v0.26.3
-	github.com/tektoncd/hub v1.23.6
+	github.com/tektoncd/hub v1.24.0
 	github.com/tektoncd/pipeline v1.12.0
 	github.com/tektoncd/plumbing v0.0.0-20250430145243-3b7cd59879c1
 	github.com/tektoncd/triggers v0.35.1-0.20260401091813-1aad8a1898ec
@@ -54,7 +54,7 @@ require (
 
 replace github.com/alibabacloud-go/cr-20160607 => github.com/vdemeester/cr-20160607 v1.0.1
 
-replace github.com/tektoncd/hub => github.com/openshift-pipelines/hub v1.23.7
+replace github.com/tektoncd/hub => github.com/openshift-pipelines/hub v1.24.0
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openshift-pipelines/hub v1.23.7 h1:HvWfTlDCIqdjl8jNfMExN38aicjfsIqoLZ2TJYG4TmU=
-github.com/openshift-pipelines/hub v1.23.7/go.mod h1:avuMaqxKD3ihAOT6ttocG6DvHC3HxSWSalBm7p1dXKc=
+github.com/openshift-pipelines/hub v1.24.0 h1:MHqB+SIrxh3CVA04qkkYFLUywxMDWrA0NELqcDdFj5I=
+github.com/openshift-pipelines/hub v1.24.0/go.mod h1:yjfR+KhIpZBaQBxlauVA4dHE/YNcfG3PhgT5oqwQC4A=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/check_upgrade/check_uprade.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/check_upgrade/check_uprade.go
@@ -110,9 +110,10 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:   "check-upgrade",
-		Short: "Check for upgrades of resources if present",
-		Long:  ``,
+		Use:        "check-upgrade",
+		Short:      "Check for upgrades of resources if present",
+		Long:       ``,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/downgrade/downgrade.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/downgrade/downgrade.go
@@ -66,9 +66,10 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:   "downgrade",
-		Short: "Downgrade an installed resource",
-		Long:  ``,
+		Use:        "downgrade",
+		Short:      "Downgrade an installed resource",
+		Long:       ``,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/get/get.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/get/get.go
@@ -54,9 +54,10 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: "Get resource manifest by its name, kind, catalog, and version",
-		Long:  ``,
+		Use:        "get",
+		Short:      "Get resource manifest by its name, kind, catalog, and version",
+		Long:       ``,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/info/info.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/info/info.go
@@ -112,9 +112,10 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:   "info",
-		Short: "Display info of resource by its name, kind, catalog, and version",
-		Long:  ``,
+		Use:        "info",
+		Short:      "Display info of resource by its name, kind, catalog, and version",
+		Long:       ``,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/install/install.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/install/install.go
@@ -49,18 +49,18 @@ type options struct {
 }
 
 var cmdExamples string = `
-Install a %S of name 'foo':
+Install a %S of name 'foo' from Artifact Hub:
 
-    tkn hub install %s foo
+    tkn hub install %s foo --type artifact --from tekton-catalog-tasks --version 0.3.0
 
 or
 
-Install a %S of name 'foo' of version '0.3' from Catalog 'Tekton':
+Install a %S of name 'foo' from Tekton Hub (DEPRECATED):
 
     tkn hub install %s foo --version 0.3 --from tekton
 
-Note that the resources in Artifact Hub follow full SemVer - <major>.<minor>.<patch> (e.g. 0.3.0),
-please double check the version used
+Note: Tekton Hub is deprecated. Use '--type artifact' with Artifact Hub instead.
+Resources in Artifact Hub follow full SemVer - <major>.<minor>.<patch> (e.g. 0.3.0).
 `
 
 func Command(cli app.CLI) *cobra.Command {

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/reinstall/reinstall.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/reinstall/reinstall.go
@@ -65,9 +65,10 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:   "reinstall",
-		Short: "Reinstall a resource by its kind and name",
-		Long:  ``,
+		Use:        "reinstall",
+		Short:      "Reinstall a resource by its kind and name",
+		Long:       ``,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/root.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/root.go
@@ -40,12 +40,35 @@ func Root(cli app.CLI) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		Short:        "Interact with tekton hub",
-		Long:         ``,
+		Short: "Interact with tekton hub",
+		Long: `Interact with tekton hub
+
+Deprecation Notice: Tekton Hub support in CLI is being deprecated in favor of Artifact Hub.
+The following commands currently only work with Tekton Hub and may support Artifact Hub in a future release:
+  - check-upgrade
+  - downgrade
+  - get
+  - info
+  - reinstall
+  - search
+  - upgrade
+
+Action Required: Users should migrate to Artifact Hub by using the '--type artifact' flag
+with the install command. For example:
+    tkn hub install task foo --type artifact --from tekton-catalog-tasks
+
+When using '--type tekton', a deprecation warning will now be displayed.
+Artifact Hub (https://artifacthub.io) will become the only supported hub in future releases.`,
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if hubType != hub.ArtifactHubType && hubType != hub.TektonHubType {
 				return fmt.Errorf("invalid hub type: %s, expecting artifact or tekton", hubType)
+			}
+			if hubType == hub.TektonHubType {
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"WARNING: Tekton Hub support is deprecated and will be removed in a future release. "+
+						"Artifact Hub (https://artifacthub.io) will become the only supported hub. "+
+						"Use '--type artifact' to switch now.")
 			}
 			if err := cli.SetHub(hubType); err != nil {
 				return err
@@ -67,8 +90,12 @@ func Root(cli app.CLI) *cobra.Command {
 		check_upgrade.Command(cli),
 	)
 
-	cmd.PersistentFlags().StringVar(&apiURL, "api-server", "", "Hub API Server URL (default 'https://api.hub.tekton.dev' for 'tekton' type; default 'https://artifacthub.io' for 'artifact' type).\nURL can also be defined in a file '$HOME/.tekton/hub-config' with a variable 'TEKTON_HUB_API_SERVER'/'ARTIFACT_HUB_API_SERVER'.")
-	cmd.PersistentFlags().StringVar(&hubType, "type", "tekton", "The type of Hub from where to pull the resource. Either 'artifact' or 'tekton'")
+	cmd.PersistentFlags().StringVar(&apiURL, "api-server", "", "Hub API Server URL.\n"+
+		"For artifact type: default 'https://artifacthub.io' (env: ARTIFACT_HUB_API_SERVER)\n"+
+		"For tekton type (DEPRECATED): default 'https://api.hub.tekton.dev' (env: TEKTON_HUB_API_SERVER)\n"+
+		"Can also be set in '$HOME/.tekton/hub-config'.")
+	cmd.PersistentFlags().StringVar(&hubType, "type", "tekton", "The type of Hub from where to pull the resource. Either 'artifact' or 'tekton' "+
+		"(DEPRECATED: tekton type will be removed in a future release)")
 
 	return cmd
 }

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/search/search.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/search/search.go
@@ -90,10 +90,11 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:     "search",
-		Short:   "Search resource by a combination of name, kind, categories, platforms, and tags",
-		Long:    ``,
-		Example: examples,
+		Use:   "search",
+		Short: "Search resource by a combination of name, kind, categories, platforms, and tags",
+		Long: ``,
+		Example:    examples,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/upgrade/upgrade.go
+++ b/vendor/github.com/tektoncd/hub/api/pkg/cli/cmd/upgrade/upgrade.go
@@ -64,9 +64,10 @@ func Command(cli app.CLI) *cobra.Command {
 	opts := &options{cli: cli}
 
 	cmd := &cobra.Command{
-		Use:   "upgrade",
-		Short: "Upgrade an installed resource",
-		Long:  ``,
+		Use:        "upgrade",
+		Short:      "Upgrade an installed resource",
+		Long:       ``,
+		Deprecated: "this command currently only works with Tekton Hub which is deprecated. It may support Artifact Hub in a future release.",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1305,8 +1305,8 @@ github.com/tektoncd/chains/pkg/chains/storage/pubsub
 github.com/tektoncd/chains/pkg/chains/storage/tekton
 github.com/tektoncd/chains/pkg/config
 github.com/tektoncd/chains/pkg/patch
-# github.com/tektoncd/hub v1.23.6 => github.com/openshift-pipelines/hub v1.23.7
-## explicit; go 1.24.0
+# github.com/tektoncd/hub v1.24.0 => github.com/openshift-pipelines/hub v1.24.0
+## explicit; go 1.25.8
 github.com/tektoncd/hub/api/pkg/cli/app
 github.com/tektoncd/hub/api/pkg/cli/cmd
 github.com/tektoncd/hub/api/pkg/cli/cmd/check_upgrade
@@ -2910,4 +2910,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/alibabacloud-go/cr-20160607 => github.com/vdemeester/cr-20160607 v1.0.1
-# github.com/tektoncd/hub => github.com/openshift-pipelines/hub v1.23.7
+# github.com/tektoncd/hub => github.com/openshift-pipelines/hub v1.24.0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update tekton hub to 1.24.0

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
**Deprecation Notice**: Tekton Hub support in CLI is being deprecated in favor of Artifact Hub. The following commands currently only work with Tekton Hub and may support Artifact Hub in a future release:
  - check-upgrade
  - downgrade
  - get
  - info
  - reinstall
  - search
  - upgrade

**Action Required**: Users should migrate to Artifact Hub by using the '--type artifact' flag with the install command. For example:
    tkn hub install task foo --type artifact --from tekton-catalog-tasks

When using '--type tekton', a deprecation warning will now be displayed. Artifact Hub (https://artifacthub.io) will become the only supported hub in future releases.
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
**Deprecation Notice**: Tekton Hub support in CLI is being deprecated in favor of Artifact Hub. The following commands currently only work with Tekton Hub and may support Artifact Hub in a future release:
  - check-upgrade
  - downgrade
  - get
  - info
  - reinstall
  - search
  - upgrade

**Action Required**: Users should migrate to Artifact Hub by using the '--type artifact' flag with the install command. For example:
    tkn hub install task foo --type artifact --from tekton-catalog-tasks

When using '--type tekton', a deprecation warning will now be displayed. Artifact Hub (https://artifacthub.io) will become the only supported hub in future releases.
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
