### PR TITLE
fix(cve): CVE-2026-40938, CVE-2026-40161 - bump github.com/tektoncd/pipeline to v1.6.2 [release-v0.43.1]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/tektoncd/chains v0.26.0
 	github.com/tektoncd/hub v1.23.1
-	github.com/tektoncd/pipeline v1.6.1
+	github.com/tektoncd/pipeline v1.6.2
 	github.com/tektoncd/plumbing v0.0.0-20250430145243-3b7cd59879c1
 	github.com/tektoncd/triggers v0.34.0
 	github.com/theupdateframework/go-tuf v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1273,8 +1273,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tektoncd/chains v0.26.0 h1:TV4AyuMBb2/7TasVNePwLZLoZ8qKeju+j9RWpaPqkbw=
 github.com/tektoncd/chains v0.26.0/go.mod h1:0CmzkSfql6cltpKiiu6NHizPT+NPxHeGXHA+gV9Td9k=
-github.com/tektoncd/pipeline v1.6.1 h1:DLeA6gVQrDHw9hy7eI48rOp2MO+Fwawj1+AcgSpJysk=
-github.com/tektoncd/pipeline v1.6.1/go.mod h1:5SNoYgRYPQopkv7ApVq5GO3JqPk2AjV+VMMjwBsbJOg=
+github.com/tektoncd/pipeline v1.6.2 h1:lcpC4fuoc9Uy6uWjjNmtRJgYd+e6XIcFZKYitbVnORc=
+github.com/tektoncd/pipeline v1.6.2/go.mod h1:lnC/pCLLG37eZE3B5QPCumkWZyY0Lb2LZBpQlJCNaio=
 github.com/tektoncd/plumbing v0.0.0-20250430145243-3b7cd59879c1 h1:nv7BsOAZ1ifQX9Lw1hYFo1f7e62dTDyyVPJBuljgZKw=
 github.com/tektoncd/plumbing v0.0.0-20250430145243-3b7cd59879c1/go.mod h1:eDs4O8vTNkyKZ/+AEuo4nYDfpyn1AzbgIcQ1QMQaKJk=
 github.com/tektoncd/triggers v0.34.0 h1:CuhG1moThPGEMlxPUcoBDDplJ3FAczzF8MMAjGScRY0=

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -197,8 +198,9 @@ func (s *Step) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -434,8 +434,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/annotated_resource.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/annotated_resource.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"time"
-
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 )
@@ -46,23 +44,23 @@ type annotatedResource struct {
 	annotations map[string]string
 }
 
-// newAnnotatedResource creates a new annotatedResource with cache annotations
-func newAnnotatedResource(resource resolutionframework.ResolvedResource, resolverType, operation string, clock Clock) *annotatedResource {
+func newAnnotatedResource(
+	resource resolutionframework.ResolvedResource,
+	resolverType,
+	operation string,
+	timestamp string,
+) *annotatedResource {
 	// Create a new map to avoid concurrent map writes when the same resource
 	// is being annotated from multiple goroutines
 	existingAnnotations := resource.Annotations()
 	annotations := make(map[string]string)
 
-	// Copy existing annotations to new map
-	if existingAnnotations != nil {
-		for k, v := range existingAnnotations {
-			annotations[k] = v
-		}
+	for k, v := range existingAnnotations {
+		annotations[k] = v
 	}
 
-	// Add cache annotations
 	annotations[cacheAnnotationKey] = cacheValueTrue
-	annotations[cacheTimestampKey] = clock.Now().Format(time.RFC3339)
+	annotations[cacheTimestampKey] = timestamp
 	annotations[cacheResolverTypeKey] = resolverType
 	annotations[cacheOperationKey] = operation
 

--- a/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/cache.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/cache.go
@@ -20,33 +20,44 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"sort"
+	"strings"
 	"time"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	utilcache "k8s.io/apimachinery/pkg/util/cache"
 )
+
+type resolveFn = func() (resolutionframework.ResolvedResource, error)
 
 var _ resolutionframework.ConfigWatcher = (*resolverCache)(nil)
 
 // resolverCache is a wrapper around utilcache.LRUExpireCache that provides
 // type-safe methods for caching resolver results.
 type resolverCache struct {
-	cache   *utilcache.LRUExpireCache
-	logger  *zap.SugaredLogger
-	ttl     time.Duration
-	maxSize int
-	clock   Clock
+	cache       *utilcache.LRUExpireCache
+	logger      *zap.SugaredLogger
+	ttl         time.Duration
+	maxSize     int
+	clock       utilcache.Clock
+	flightGroup *singleflight.Group
 }
 
 func newResolverCache(maxSize int, ttl time.Duration) *resolverCache {
+	return newResolverCacheWithClock(maxSize, ttl, realClock{})
+}
+
+func newResolverCacheWithClock(maxSize int, ttl time.Duration, clock utilcache.Clock) *resolverCache {
 	return &resolverCache{
-		cache:   utilcache.NewLRUExpireCache(maxSize),
-		ttl:     ttl,
-		maxSize: maxSize,
-		clock:   realClock{},
+		cache:       utilcache.NewLRUExpireCacheWithClock(maxSize, clock),
+		ttl:         ttl,
+		maxSize:     maxSize,
+		clock:       clock,
+		flightGroup: &singleflight.Group{},
 	}
 }
 
@@ -58,7 +69,7 @@ func (c *resolverCache) GetConfigName(_ context.Context) string {
 // withLogger returns a new ResolverCache instance with the provided logger.
 // This prevents state leak by not storing logger in the global singleton.
 func (c *resolverCache) withLogger(logger *zap.SugaredLogger) *resolverCache {
-	return &resolverCache{logger: logger, cache: c.cache, ttl: c.ttl, maxSize: c.maxSize, clock: c.clock}
+	return &resolverCache{logger: logger, cache: c.cache, ttl: c.ttl, maxSize: c.maxSize, clock: c.clock, flightGroup: c.flightGroup}
 }
 
 // TTL returns the time-to-live duration for cache entries.
@@ -71,55 +82,62 @@ func (c *resolverCache) MaxSize() int {
 	return c.maxSize
 }
 
-// Get retrieves a cached resource by resolver type and parameters, returning
-// the resource and whether it was found.
-func (c *resolverCache) Get(resolverType string, params []pipelinev1.Param) (resolutionframework.ResolvedResource, bool) {
+func (c *resolverCache) GetCachedOrResolveFromRemote(
+	params []pipelinev1.Param,
+	resolverType string,
+	resolveFromRemote resolveFn,
+) (resolutionframework.ResolvedResource, error) {
 	key := generateCacheKey(resolverType, params)
-	value, found := c.cache.Get(key)
-	if !found {
-		c.infow("Cache miss", "key", key)
-		return nil, found
+
+	if untyped, found := c.cache.Get(key); found {
+		cached, ok := untyped.(resolutionframework.ResolvedResource)
+		if !ok {
+			c.cache.Remove(key)
+			c.infow("Removed corrupted cache entry: type assertion failed", "key", key)
+			return nil, errors.New("failed casting cached resource")
+		}
+
+		c.infow("Cache hit", "key", key)
+
+		return c.annotate(cached, resolverType, cacheOperationRetrieve), nil
 	}
 
-	resource, ok := value.(resolutionframework.ResolvedResource)
-	if !ok {
-		c.infow("Failed casting cached resource", "key", key)
-		return nil, false
+	// If cache miss, resolve from remote using singleflight
+	untyped, err, shared := c.flightGroup.Do(key, func() (any, error) {
+		resolved, err := resolveFromRemote()
+		if err != nil {
+			return nil, err
+		}
+
+		annotated := c.annotate(resolved, resolverType, cacheOperationStore)
+
+		// Store annotated resource with store operation and return annotated resource
+		// to indicate it was stored in cache
+		c.infow("Adding to cache", "key", key, "expiration", c.ttl)
+		c.cache.Add(key, annotated, c.ttl)
+		return annotated, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	c.infow("Cache hit", "key", key)
-	return newAnnotatedResource(resource, resolverType, cacheOperationRetrieve, c.clock), true
+	if shared {
+		c.infow("Resolution deduplicated by singleflight", "resolverType", resolverType, "key", key)
+	}
+
+	return untyped.(resolutionframework.ResolvedResource), nil
+}
+
+func (c *resolverCache) annotate(resolvedResource resolutionframework.ResolvedResource, resolverType, operation string) *annotatedResource {
+	timestamp := c.clock.Now().Format(time.RFC3339)
+	result := newAnnotatedResource(resolvedResource, resolverType, operation, timestamp)
+	return result
 }
 
 func (c *resolverCache) infow(msg string, keysAndValues ...any) {
 	if c.logger != nil {
 		c.logger.Infow(msg, keysAndValues...)
 	}
-}
-
-// Add stores a resource in the cache with the configured TTL and returns an
-// annotated version of the resource.
-func (c *resolverCache) Add(
-	resolverType string,
-	params []pipelinev1.Param,
-	resource resolutionframework.ResolvedResource,
-) resolutionframework.ResolvedResource {
-	key := generateCacheKey(resolverType, params)
-	c.infow("Adding to cache", "key", key, "expiration", c.ttl)
-
-	annotatedResource := newAnnotatedResource(resource, resolverType, cacheOperationStore, c.clock)
-
-	c.cache.Add(key, annotatedResource, c.ttl)
-
-	return annotatedResource
-}
-
-// Remove deletes a cached resource identified by resolver type and parameters.
-func (c *resolverCache) Remove(resolverType string, params []pipelinev1.Param) {
-	key := generateCacheKey(resolverType, params)
-	c.infow("Removing from cache", "key", key)
-
-	c.cache.Remove(key)
 }
 
 // Clear removes all entries from the cache.
@@ -131,7 +149,9 @@ func (c *resolverCache) Clear() {
 
 func generateCacheKey(resolverType string, params []pipelinev1.Param) string {
 	// Create a deterministic string representation of the parameters
-	paramStr := resolverType + ":"
+	var sb strings.Builder
+	sb.WriteString(resolverType)
+	sb.WriteByte(':')
 
 	// Filter out the 'cache' parameter and sort remaining params by name for determinism
 	filteredParams := make([]pipelinev1.Param, 0, len(params))
@@ -147,11 +167,12 @@ func generateCacheKey(resolverType string, params []pipelinev1.Param) string {
 	})
 
 	for _, p := range filteredParams {
-		paramStr += p.Name + "="
+		sb.WriteString(p.Name)
+		sb.WriteByte('=')
 
 		switch p.Value.Type {
 		case pipelinev1.ParamTypeString:
-			paramStr += p.Value.StringVal
+			sb.WriteString(p.Value.StringVal)
 		case pipelinev1.ParamTypeArray:
 			// Sort array values for determinism
 			arrayVals := make([]string, len(p.Value.ArrayVal))
@@ -159,9 +180,9 @@ func generateCacheKey(resolverType string, params []pipelinev1.Param) string {
 			sort.Strings(arrayVals)
 			for i, val := range arrayVals {
 				if i > 0 {
-					paramStr += ","
+					sb.WriteByte(',')
 				}
-				paramStr += val
+				sb.WriteString(val)
 			}
 		case pipelinev1.ParamTypeObject:
 			// Sort object keys for determinism
@@ -172,18 +193,20 @@ func generateCacheKey(resolverType string, params []pipelinev1.Param) string {
 			sort.Strings(keys)
 			for i, key := range keys {
 				if i > 0 {
-					paramStr += ","
+					sb.WriteByte(',')
 				}
-				paramStr += key + ":" + p.Value.ObjectVal[key]
+				sb.WriteString(key)
+				sb.WriteByte(':')
+				sb.WriteString(p.Value.ObjectVal[key])
 			}
 		default:
 			// For unknown types, use StringVal as fallback
-			paramStr += p.Value.StringVal
+			sb.WriteString(p.Value.StringVal)
 		}
-		paramStr += ";"
+		sb.WriteByte(';')
 	}
 
 	// Generate a SHA-256 hash of the parameter string
-	hash := sha256.Sum256([]byte(paramStr))
+	hash := sha256.Sum256([]byte(sb.String()))
 	return hex.EncodeToString(hash[:])
 }

--- a/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/clock.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/clock.go
@@ -18,14 +18,6 @@ package cache
 
 import "time"
 
-// Clock is an interface for getting the current time.
-// This allows for testing without relying on actual time for timestamp generation.
-// Note: The underlying k8s LRUExpireCache uses real time for TTL expiration checks,
-// so we cannot use a fake clock to control cache expiration in tests.
-type Clock interface {
-	Now() time.Time
-}
-
 // realClock implements Clock using the actual system time.
 type realClock struct{}
 

--- a/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/operations.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache/operations.go
@@ -47,7 +47,6 @@ func ShouldUse(
 	ctx context.Context,
 	resolver ImmutabilityChecker,
 	params []v1.Param,
-	resolverType string,
 ) bool {
 	// Get cache mode from task parameter
 	cacheMode := ""
@@ -100,29 +99,4 @@ func Validate(cacheMode string) error {
 	}
 
 	return fmt.Errorf("invalid cache mode '%s', must be one of: %v (or empty for default)", cacheMode, validCacheModes)
-}
-
-type resolveFn = func() (resolutionframework.ResolvedResource, error)
-
-func GetFromCacheOrResolve(
-	ctx context.Context,
-	params []v1.Param,
-	resolverType string,
-	resolve resolveFn,
-) (resolutionframework.ResolvedResource, error) {
-	cacheInstance := Get(ctx)
-
-	if cached, ok := cacheInstance.Get(resolverType, params); ok {
-		return cached, nil
-	}
-
-	// If cache miss, resolve from params
-	resource, err := resolve()
-	if err != nil {
-		return nil, err
-	}
-
-	// Store annotated resource with store operation and return annotated resource
-	// to indicate it was stored in cache
-	return cacheInstance.Add(resolverType, params, resource), nil
 }

--- a/vendor/github.com/tektoncd/pipeline/test/README.md
+++ b/vendor/github.com/tektoncd/pipeline/test/README.md
@@ -3,6 +3,7 @@
 To run tests:
 
 [Unit tests](#unit-tests) and build tests (those run by [presubmits](#presubmit-tests)) run against your Pipelines clone:
+
 ```sh
 # Unit tests
 go test ./...
@@ -29,9 +30,10 @@ in local kubeconfig file (~/.kube/config by default) in you local machine.
 > Sometimes local tests pass but presubmit tests fail, one possible reason
 is the difference of running environments. The envs that our presubmit test
 uses are stored in ./*.env files. Specifically,
+>
 > - e2e-tests-kind-prow-alpha.env for [`pull-tekton-pipeline-alpha-integration-tests`](https://github.com/tektoncd/plumbing/blob/d2c8ccb63d02c6e72c62def788af32d63ff1981a/prow/config.yaml#L1304)
 > - e2e-tests-kind-prow-beta.env for [`pull-tekton-pipeline-beta-integration-tests`]
-(TODO: https://github.com/tektoncd/pipeline/issues/6048 Add permanent link after plumbing setup for prow)
+(TODO: <https://github.com/tektoncd/pipeline/issues/6048> Add permanent link after plumbing setup for prow)
 > - e2e-tests-kind-prow.env for [`pull-tekton-pipeline-integration-tests`](https://github.com/tektoncd/plumbing/blob/d2c8ccb63d02c6e72c62def788af32d63ff1981a/prow/config.yaml#L1249)
 
 ## Unit tests
@@ -194,7 +196,7 @@ To include tests for Windows, you need to specify the `windows_e2e` build tag. F
 go test -v -count=1 -tags=e2e,windows_e2e -timeout=20m ./test
 ```
 
-Please note that in order to run Windows tests there must be at least one Windows node available in the target Kubernetes cluster. 
+Please note that in order to run Windows tests there must be at least one Windows node available in the target Kubernetes cluster.
 
 ### Flags
 
@@ -255,8 +257,8 @@ There are two scenarios in upgrade tests. One is to install the previous release
 validate whether the Tekton pipeline works. The other is to install the previous release, create the pipelines and tasks,
 upgrade to the current release, and validate whether the Tekton pipeline works.
 
+#### Prerequisites for running upgrade tests locally
 
-#### Prerequisites for running upgrade tests locally:
 - Set up the cluster
   - Running against a fresh kind cluster
     - export SKIP_INITIALIZE=true
@@ -442,7 +444,7 @@ test/presubmit-tests.sh --integration-tests
 ## Per Feature flag tests
 
 Per-feature flag tests verify that the combinations of feature flags work together
-correctly, ensuring that individual flags don't interfere with each other's 
+correctly, ensuring that individual flags don't interfere with each other's
 functionality and that overall outcomes remain consistent.
 Per [TEP0138](https://github.com/tektoncd/community/blob/main/teps/0138-decouple-api-and-feature-versioning.md#additional-ci-tests),
 minimum end-to-end tests for stable features are utilized, mocking stable, beta,
@@ -458,3 +460,115 @@ go test -v -count=1 -tags=featureflags -timeout=60m ./test -run ^TestPerFeatureF
 
 Flags that could be set in featureflags tests are exactly the same as [flags in end to end tests](#flags).
 Just note that the build tags should be `-tags=featureflags`.
+
+## Test Categorization: Parallel vs Serial Execution
+
+The e2e test suite implements a categorization system that allows tests to run in parallel or serial mode,
+optimizing test execution time while ensuring safety for tests that modify shared cluster state.
+
+### Overview
+
+Tests are categorized using comment annotations in the source code:
+
+- **Parallel tests**: Safe to run concurrently, don't modify shared cluster state
+- **Serial tests**: Must run sequentially because they modify ConfigMaps in `system.Namespace()`
+
+The test runner (`TestMain` in `init_test.go`) parses these annotations and orchestrates test execution accordingly.
+
+### Annotation Format
+
+Tests use structured Go comments to declare their execution mode:
+
+```go
+// @test:execution=parallel
+func TestMyParallelTest(t *testing.T) {
+    // Test implementation
+}
+
+// @test:execution=serial
+// @test:reason=modifies results-from field in feature-flags ConfigMap
+// @test:tags=artifacts,featureflags,stateful
+func TestMySerialTest(t *testing.T) {
+    // Test implementation
+}
+```
+
+**Annotation fields:**
+
+- `@test:execution` - Required: either `parallel` or `serial`
+- `@test:reason` - Recommended for serial tests: explains why serial execution is needed
+- `@test:tags` - Optional: comma-separated tags for categorization and filtering
+
+### Running Tests by Category
+
+Use the `-category` flag to control which tests run:
+
+```shell
+# Run only parallel tests (fast, safe for concurrent execution)
+go test -tags=e2e -category=parallel -timeout=20m ./test
+
+# Run only serial tests (slower, sequential execution)
+go test -tags=e2e -category=serial -timeout=20m ./test
+
+# Run all tests with proper ordering (serial → parallel → unknown)
+go test -tags=e2e -category=all -timeout=30m ./test
+
+# Show test categorization without running tests
+go test -tags=e2e -show-tests ./test
+```
+
+**Note:** When the `-run` flag is provided, category filtering is automatically skipped and the
+user's test filter takes precedence. This allows running individual tests without category orchestration:
+
+```shell
+# Run a specific test (skips category filtering)
+go test -tags=e2e -run ^TestBundleResolverCache$ ./test
+```
+
+### Execution Order
+
+When running with `-category=all`, tests execute in this order:
+
+1. **Serial tests** run first, sequentially, with fail-fast behavior
+2. **Parallel tests** run next, concurrently
+3. **Unknown tests** (unannotated) run last
+
+This ensures that tests modifying shared state complete before parallel execution begins.
+
+### When to Mark Tests as Serial
+
+A test MUST be marked `serial` if it:
+
+- Modifies ConfigMaps in `system.Namespace()` (typically `tekton-pipelines`)
+- Changes feature flags in the `feature-flags` ConfigMap
+- Modifies any other shared cluster-wide configuration or resources
+
+Common examples:
+
+- Tests changing `enable-api-fields`, `results-from`, `coschedule` feature flags
+- Tests modifying `trusted-resources-verification-no-match-policy`
+- Any test calling `updateConfigMap(ctx, c.KubeClient, system.Namespace(), ...)`
+- Tests modifying controller replicas
+
+### When to Mark Tests as Parallel
+
+A test can be marked `parallel` if it:
+
+- Only creates/modifies resources in its own test namespace
+- Doesn't modify `system.Namespace()` ConfigMaps
+- Can safely run concurrently with other tests
+
+This includes most conformance tests, resolver tests, workspace tests, etc.
+
+### Implementation Details
+
+The categorization system is implemented via:
+
+1. **TestMain** (`init_test.go`): Parses annotations from source files using Go's AST parser,
+   categorizes tests, and routes execution based on the `-category` flag.
+
+2. **Annotation Parser**: Scans `*_test.go` files, extracts `@test:*` comments, and builds
+   a manifest of test metadata.
+
+3. **Test Filtering**: Uses `flag.Set("test.run", pattern)` to filter which tests execute
+   in each run.

--- a/vendor/github.com/tektoncd/pipeline/test/multiarch_utils.go
+++ b/vendor/github.com/tektoncd/pipeline/test/multiarch_utils.go
@@ -70,7 +70,7 @@ func initImageNames() map[int]string {
 	default:
 		return map[int]string{
 			busyboxImage:   "mirror.gcr.io/busybox@sha256:2f9af5cf39068ec3a9e124feceaa11910c511e23a1670dcfdff0bc16793545fb",
-			registryImage:  "mirror.gcr.io/library/registry",
+			registryImage:  "mirror.gcr.io/library/registry:3",
 			kanikoImage:    "gcr.io/kaniko-project/executor:v1.3.0",
 			dockerizeImage: "mirror.gcr.io/jwilder/dockerize",
 		}

--- a/vendor/github.com/tektoncd/pipeline/test/path_filtering.go
+++ b/vendor/github.com/tektoncd/pipeline/test/path_filtering.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 /*
 Copyright 2021 The Tekton Authors

--- a/vendor/github.com/tektoncd/pipeline/test/secret.go
+++ b/vendor/github.com/tektoncd/pipeline/test/secret.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/vendor/github.com/tektoncd/pipeline/test/util.go
+++ b/vendor/github.com/tektoncd/pipeline/test/util.go
@@ -1,5 +1,4 @@
 //go:build conformance || e2e || examples || featureflags
-// +build conformance e2e examples featureflags
 
 /*
 Copyright 2023 The Tekton Authors

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1550,8 +1550,8 @@ github.com/tektoncd/hub/api/v1/gen/http/catalog/client
 github.com/tektoncd/hub/api/v1/gen/http/resource/client
 github.com/tektoncd/hub/api/v1/gen/resource
 github.com/tektoncd/hub/api/v1/gen/resource/views
-# github.com/tektoncd/pipeline v1.6.1
-## explicit; go 1.24.0
+# github.com/tektoncd/pipeline v1.6.2
+## explicit; go 1.24.13
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config
 github.com/tektoncd/pipeline/pkg/apis/config/resolver


### PR DESCRIPTION
## CVE Details

### CVE-2026-40938 (Critical)
**Tekton Pipelines: Arbitrary code execution and secret exfiltration via malicious git commands**

The git resolver's `revision` parameter is passed directly to `git fetch` without validation. An attacker can inject arbitrary git fetch flags via the `--upload-pack=` flag.

- **Fixed in:** `github.com/tektoncd/pipeline v1.6.2`
- **Jira:** SRVKP-11739

### CVE-2026-40161 (High)
**Tekton Pipelines: Information disclosure of Git API token via user-controlled serverURL**

The git resolver in API mode sends the system-configured Git API token to a user-controlled `serverURL`.

- **Fixed in:** `github.com/tektoncd/pipeline v1.6.2`
- **Jira:** SRVKP-11669

## Fix Summary

Updated `github.com/tektoncd/pipeline` from `v1.6.1` to `v1.6.2` in `go.mod`, ran `go mod tidy` and `go mod vendor`.

| File | Change |
|------|--------|
| `go.mod` | `github.com/tektoncd/pipeline v1.6.1` → `v1.6.2` |
| `go.sum` | Updated checksums |
| `vendor/` | Regenerated via `go mod vendor` |

## Test Results

| Check | Status | Details |
|-------|--------|---------|
| `go get github.com/tektoncd/pipeline@v1.6.2` | ✅ PASS | Dependency resolved |
| `go mod tidy` | ✅ PASS | Clean |
| `go mod vendor` | ✅ PASS | Vendor synced |
| `go build ./...` | ✅ PASS | Build passes |

## Breaking Changes

None expected. Patch-level update from v1.6.1 to v1.6.2.

## Risk Assessment

**Low** — dependency version bump to address critical security vulnerabilities.

## Verification Steps

- [ ] CI passes
- [ ] `tkn` commands function correctly
- [ ] No regression in git resolver behavior

## Jira References

SRVKP-11739 (CVE-2026-40938, pipelines-1.21)
SRVKP-11669 (CVE-2026-40161, pipelines-1.21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)