### PR TITLE
Security: Fix CVE-2026-32282 (Go stdlib os.Root.Chmod) SRVKP-11615

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-32282** by upgrading Go from **1.25.8** to **1.25.9**.

### CVE Details
- **CVE ID**: CVE-2026-32282
- **Package**: Go stdlib (`os.Root.Chmod`, `internal/syscall/unix.Fchmodat`)
- **Severity**: Moderate
- **Impact**: TOCTOU race in `os.Root.Chmod` allows symlink traversal and unauthorized permission changes outside a restricted directory on Linux. The Linux `fchmodat` syscall silently ignores `AT_SYMLINK_NOFOLLOW`.
- **Vulnerable versions**: Go < 1.25.9
- **Fixed version**: Go 1.25.9
- **Advisory**: https://github.com/golang/go/issues/78293
- **Jira Issue**: SRVKP-11615

### Additional CVEs Fixed by Go 1.25.9
This Go version bump also resolves:
- **CVE-2026-32283**: crypto/tls DoS via multiple TLS 1.3 key update messages
- **CVE-2026-32281**: crypto/x509 DoS via inefficient certificate chain validation

### Changes
- `go.mod`: Updated `go 1.25.8` → `go 1.25.9`
- Ran `go mod tidy && go mod verify && go mod vendor`

### Test Results

**Status**: ✅ All tests passed

**Test command**: `go test ./...`
**Result**: PASSED
**Duration**: ~3 minutes

All packages passed, including:
- `github.com/tektoncd/cli/pkg/pods` (8s)
- `github.com/tektoncd/cli/pkg/pipelinerun` (4s)
- `github.com/tektoncd/cli/pkg/trustedresources` (1s)

### Breaking Changes
None. This is a Go patch-level update within the same minor line (1.25.x).

### Testing Checklist

- [x] Pre-PR `go test ./...` passed
- [x] `go mod tidy` passed
- [x] `go mod verify` passed
- [x] `go mod vendor` passed
- [ ] Verify CVE is resolved with security scan
- [ ] Test affected functionality manually

### Risk Assessment
| Category | Risk | Notes |
|----------|------|-------|
| Breaking changes | Low | Patch-level Go update |
| Dependency compatibility | Low | Same minor line |
| Runtime behavior | Low | Security fix only |

---

```release-note
Security fix: update Go from 1.25.8 to 1.25.9 to address CVE-2026-32282 (os.Root.Chmod symlink traversal), CVE-2026-32283 (crypto/tls DoS), and CVE-2026-32281 (crypto/x509 DoS)
```

🤖 Generated by CVE Fixer Workflow