### PR TITLE
Fix(ci): Pin Tekton Pipelines to v1.12.0 in e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -135,13 +135,10 @@ function install_pipeline_crd() {
 	latestreleaseyaml=${RELEASE_YAML_PIPELINE}
   else
 
-    # First try to install latestreleaseyaml from nightly
-    # TODO: re-enable this curl command once we are confident about nightly releases
-    # curl -o/dev/null -s -LI -f https://infra.tekton.dev/tekton-releases-nightly/pipeline/latest/release.yaml &&
-    #     latestreleaseyaml=https://infra.tekton.dev/tekton-releases-nightly/pipeline/latest/release.yaml
-
-    # If for whatever reason the nightly release wasnt there (nightly ci failure?), try the released version
-    [[ -n ${latestreleaseyaml} ]] || latestreleaseyaml=https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
+    # Pin to v1.12.0 to avoid spurious termination message WARN in step logs (tektoncd/pipeline#10159).
+    # The fix (tektoncd/pipeline#10160) is merged but not yet in a released version.
+    # TODO: switch back to latest once a pipeline release includes the fix.
+    latestreleaseyaml=https://infra.tekton.dev/tekton-releases/pipeline/previous/v1.12.0/release.yaml
   fi
   [[ -z ${latestreleaseyaml} ]] && fail_test "Could not get latest released release.yaml"
   kubectl apply -f ${latestreleaseyaml} ||


### PR DESCRIPTION
Tekton Pipelines v1.13.0 emits spurious WARN messages in step logs (tektoncd/pipeline#10159) causing e2e log assertion failures. Pin to v1.12.0 until a release includes the fix (tektoncd/pipeline#10160)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
