### PR TITLE
Add CONTEXT.md for AI agent consumption

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,159 @@
+# tkn CLI Agent Context
+
+This file describes `tkn` conventions, output formats, and behavioral notes
+for automated and agent-driven workflows. For contributing to tkn itself,
+see `AGENTS.md`.
+
+---
+
+## Resource Types
+
+Tekton has two layers:
+
+- Definitions (`pipeline`, `task`): reusable templates
+- Runs (`pipelinerun`, `taskrun`): execution instances
+
+Supported verbs per resource type:
+
+| Resource | Verbs |
+|---|---|
+| `pipeline`, `task` | `list`, `describe`, `start`, `logs`, `delete`, `export` |
+| `pipelinerun`, `taskrun` | `list`, `describe`, `logs`, `cancel`, `delete`, `export` |
+
+---
+
+## Common Workflows
+
+List pipeline runs:
+
+```bash
+tkn pipelinerun list --output json
+```
+
+Inspect run status:
+
+```bash
+tkn pipelinerun describe <run-name> --output json
+tkn taskrun describe <run-name> --output json
+```
+
+Get logs for the most recent run:
+
+```bash
+tkn pipelinerun logs --last
+tkn taskrun logs --last
+```
+
+Start a pipeline non-interactively:
+
+```bash
+tkn pipeline start <pipeline-name> \
+  --param <key>=<value> \
+  --workspace name=<ws-name>,claimName=<pvc-name> \
+  --use-param-defaults \
+  --skip-optional-workspace \
+  --showlog
+```
+
+Re-run the most recent pipeline run:
+
+```bash
+tkn pipeline start <pipeline-name> --last --use-param-defaults
+```
+
+Delete a run:
+
+```bash
+tkn pipelinerun delete <run-name> --force
+tkn taskrun delete <run-name> --force
+```
+
+---
+
+## Output Formats
+
+| Command | JSON output | Notes |
+|---|---|---|
+| `list` | Yes | Supported on all resources |
+| `describe` | Yes | Supported on all resources |
+| `logs` | No | Plain text to stdout only |
+| `start` | No | Prints run name to stdout on success |
+| `delete` | No | Requires `--force` to skip confirmation |
+| `export` | No | Outputs YAML (Kubernetes manifest) |
+
+`--output yaml` is available wherever `--output json` is supported.
+
+---
+
+## Non-Interactive Usage
+
+`pipeline start` and `task start` prompt for missing parameters and workspaces
+by default. In non-TTY environments, this blocks execution.
+
+For non-interactive use, pass:
+
+```bash
+tkn pipeline start <pipeline-name> \
+  --param <key>=<value> \
+  --use-param-defaults \
+  --skip-optional-workspace
+```
+
+`--use-param-defaults` applies schema defaults for unspecified parameters. If
+a required parameter has no default and is not passed via `--param`, the
+command prompts regardless.
+
+---
+
+## Exit Codes
+
+`tkn pipelinerun logs` defines the following exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | PipelineRun succeeded |
+| 1 | PipelineRun failed |
+| 2 | No status conditions available |
+
+Exit code behavior is only documented for `pipelinerun logs`. Other commands
+do not define stable exit code semantics.
+
+---
+
+## Behavioral Notes
+
+**`taskrun logs` exit code does not reflect run outcome.** A failed TaskRun
+exits 0. To check TaskRun outcome, inspect `.status.conditions[0].status`:
+
+```bash
+tkn taskrun describe <run-name> --output json
+```
+
+**`delete` requires `--force` on all resources.** Without `-f`, the command
+prompts for confirmation.
+
+**`--last` targets the most recent run by creation time.** In concurrent
+environments, capture the run name from `pipeline start` stdout and pass it
+explicitly to subsequent commands.
+
+**`logs` does not support structured output.** Log content goes to stdout;
+errors go to stderr.
+
+**`export` outputs YAML only.** Use `describe --output json` for structured
+status inspection.
+
+---
+
+## Common Flags
+
+| Flag | Commands | Purpose |
+|---|---|---|
+| `--output json` | `list`, `describe` | Machine-readable output |
+| `--last` | `logs`, `start`, `describe` | Target most recent run |
+| `--use-param-defaults` | `start` | Use schema defaults for unspecified params |
+| `--skip-optional-workspace` | `start` | Skip prompts for optional workspaces |
+| `--force`, `-f` | `delete` | Skip confirmation prompt |
+| `--showlog` | `start` | Stream logs after starting |
+| `--namespace`, `-n` | all | Override kubeconfig namespace |
+| `--param`, `-p` | `start` | Pass parameter as `<key>=<value>` |
+| `--workspace`, `-w` | `start` | Pass workspace binding |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,13 @@ Supported verbs per resource type:
 
 | Resource | Verbs |
 |---|---|
-| `pipeline`, `task` | `list`, `describe`, `start`, `logs`, `delete`, `export` |
-| `pipelinerun`, `taskrun` | `list`, `describe`, `logs`, `cancel`, `delete`, `export` |
+| `pipeline` | `list`, `describe`, `start`, `logs`, `delete` |
+| `task` | `list`, `describe`, `start`, `logs`, `delete` |
+| `pipelinerun`, `taskrun` | `list`, `describe`, `logs`, `cancel`, `delete` |
+
+Other resource types (`customrun`, `eventlistener`, `triggerbinding`,
+`triggertemplate`, `clustertriggerbinding`, `bundle`, and `hub`) support
+subsets of `list`, `describe`, and `delete`.
 
 ---
 
@@ -76,10 +81,10 @@ tkn taskrun delete <run-name> --force
 |---|---|---|
 | `list` | Yes | Supported on all resources |
 | `describe` | Yes | Supported on all resources |
+| `start` | Yes | Supported by `pipeline start` and `task start` |
 | `logs` | No | Plain text to stdout only |
-| `start` | No | Prints run name to stdout on success |
 | `delete` | No | Requires `--force` to skip confirmation |
-| `export` | No | Outputs YAML (Kubernetes manifest) |
+| `export` | No | Outputs YAML instead of JSON |
 
 `--output yaml` is available wherever `--output json` is supported.
 
@@ -107,7 +112,10 @@ command prompts regardless.
 
 ## Exit Codes
 
-`tkn pipelinerun logs` defines the following exit codes:
+By default, `tkn pipelinerun logs` exits 0 after streaming logs, regardless
+of run outcome.
+
+With `--exit-with-pipelinerun-error` (`-E`), the exit code reflects run status:
 
 | Code | Meaning |
 |---|---|
@@ -115,15 +123,16 @@ command prompts regardless.
 | 1 | PipelineRun failed |
 | 2 | No status conditions available |
 
-Exit code behavior is only documented for `pipelinerun logs`. Other commands
-do not define stable exit code semantics.
+`-E` is also available on `pipeline start` when used with `--showlog`.
+
+`taskrun logs` does not support this flag — it always exits 0.
 
 ---
 
 ## Behavioral Notes
 
-**`taskrun logs` exit code does not reflect run outcome.** A failed TaskRun
-exits 0. To check TaskRun outcome, inspect `.status.conditions[0].status`:
+**`taskrun logs` has no equivalent of `-E`.** To check TaskRun outcome,
+inspect `.status.conditions[0].status`:
 
 ```bash
 tkn taskrun describe <run-name> --output json
@@ -148,12 +157,13 @@ status inspection.
 
 | Flag | Commands | Purpose |
 |---|---|---|
-| `--output json` | `list`, `describe` | Machine-readable output |
-| `--last` | `logs`, `start`, `describe` | Target most recent run |
-| `--use-param-defaults` | `start` | Use schema defaults for unspecified params |
+| `--output json` | `list`, `describe`, `pipeline start` | Machine-readable output |
+| `--last` | `logs`, `start`, `pipelinerun describe`, `taskrun describe` | Target the most recent run |
+| `--use-param-defaults` | `start` | Use schema defaults for unspecified parameters |
 | `--skip-optional-workspace` | `start` | Skip prompts for optional workspaces |
 | `--force`, `-f` | `delete` | Skip confirmation prompt |
 | `--showlog` | `start` | Stream logs after starting |
-| `--namespace`, `-n` | all | Override kubeconfig namespace |
+| `--exit-with-pipelinerun-error`, `-E` | `pipelinerun logs`, `pipeline start` | Exit with PipelineRun status (0=success, 1=failed, 2=unknown) |
+| `--namespace`, `-n` | all | Override the kubeconfig namespace |
 | `--param`, `-p` | `start` | Pass parameter as `<key>=<value>` |
 | `--workspace`, `-w` | `start` | Pass workspace binding |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,184 @@
+# tkn CLI Agent Context
+
+This file describes `tkn` conventions, output formats, and behavioral notes
+for automated and agent-driven workflows. For contributing to tkn itself,
+see `AGENTS.md`.
+
+---
+
+## Resource Types
+
+Tekton has two layers:
+
+- Definitions (`pipeline`, `task`): reusable templates
+- Runs (`pipelinerun`, `taskrun`): execution instances
+
+Supported verbs per resource type:
+
+| Resource | Verbs |
+|---|---|
+| `pipeline` | `list`, `describe`, `start`, `logs`, `delete`, `export` |
+| `task` | `list`, `describe`, `start`, `logs`, `delete` |
+| `pipelinerun`, `taskrun` | `list`, `describe`, `logs`, `cancel`, `delete`, `export` |
+
+Other resource types (`customrun`, `eventlistener`, `triggerbinding`,
+`triggertemplate`, `clustertriggerbinding`, `bundle`, and `hub`) support
+subsets of `list`, `describe`, and `delete`.
+
+---
+
+## Common Workflows
+
+List pipeline runs:
+
+```bash
+tkn pipelinerun list --output json
+```
+
+Inspect run status:
+
+```bash
+tkn pipelinerun describe <run-name> --output json
+tkn taskrun describe <run-name> --output json
+```
+
+Get logs for the most recent run:
+
+```bash
+tkn pipelinerun logs --last
+tkn taskrun logs --last
+```
+
+Start a pipeline non-interactively:
+
+```bash
+tkn pipeline start <pipeline-name> \
+  --param <key>=<value> \
+  --workspace name=<ws-name>,claimName=<pvc-name> \
+  --use-param-defaults \
+  --skip-optional-workspace \
+  --showlog
+```
+
+Re-run the most recent pipeline run:
+
+```bash
+tkn pipeline start <pipeline-name> --last --use-param-defaults
+```
+
+Delete a run:
+
+```bash
+tkn pipelinerun delete <run-name> --force
+tkn taskrun delete <run-name> --force
+```
+
+---
+
+## Output Formats
+
+| Command | JSON output | Notes |
+|---|---|---|
+| `list` | Yes | Supported on all resources |
+| `describe` | Yes | Supported on all resources |
+| `start` | Yes | Supported by `pipeline start` and `task start` |
+| `logs` | No | Plain text to stdout only |
+| `delete` | No | Requires `--force` to skip confirmation |
+| `export` | No | Outputs YAML instead of JSON |
+
+`--output yaml` is available wherever `--output json` is supported.
+
+---
+
+## Non-Interactive Usage
+
+`pipeline start` and `task start` prompt for missing parameters and workspaces
+by default. In non-TTY environments, this blocks execution.
+
+For non-interactive use, pass:
+
+```bash
+tkn pipeline start <pipeline-name> \
+  --param <key>=<value> \
+  --use-param-defaults \
+  --skip-optional-workspace
+```
+
+`--use-param-defaults` applies schema defaults for unspecified parameters. If
+a required parameter has no default and is not passed via `--param`, the
+command prompts regardless.
+
+## Structured JSON Input
+
+`pipeline start` and `task start` support structured JSON input through the
+`--json` flag. The input can be provided inline, from stdin using `-`, or from
+a file using `@path`.
+
+Examples:
+
+```bash
+tkn pipeline start <pipeline-name> --json '<PipelineRunSpec JSON>'
+tkn task start <task-name> --json '<TaskRunSpec JSON>'
+echo '<PipelineRunSpec JSON>' | tkn pipeline start <pipeline-name> --json -
+tkn pipeline start <pipeline-name> --json @run.json
+```
+---
+
+## Exit Codes
+
+By default, `tkn pipelinerun logs` exits 0 after streaming logs, regardless
+of run outcome.
+
+With `--exit-with-pipelinerun-error` (`-E`), the exit code reflects run status:
+
+| Code | Meaning |
+|---|---|
+| 0 | PipelineRun succeeded |
+| 1 | PipelineRun failed |
+| 2 | No status conditions available |
+
+`-E` is also available on `pipeline start` when used with `--showlog`.
+
+`taskrun logs` does not support this flag — it always exits 0.
+
+---
+
+## Behavioral Notes
+
+**`taskrun logs` has no equivalent of `-E`.** To check TaskRun outcome,
+inspect `.status.conditions[0].status`:
+
+```bash
+tkn taskrun describe <run-name> --output json
+```
+
+**`delete` requires `--force` on all resources.** Without `-f`, the command
+prompts for confirmation.
+
+**`--last` targets the most recent run by creation time.** In concurrent
+environments, capture the run name from `pipeline start` stdout and pass it
+explicitly to subsequent commands.
+
+**`logs` does not support structured output.** Log content goes to stdout;
+errors go to stderr.
+
+**`export` outputs YAML only.** Use `describe --output json` for structured
+status inspection.
+
+---
+
+## Common Flags
+
+| Flag | Commands | Purpose |
+|---|---|---|
+| `--output json` | `list`, `describe`, `pipeline start`, `task start` | Machine-readable output |
+| `--json` | `pipeline start`, `task start` | Provide structured RunSpec JSON via inline input, stdin (`-`), or file (`@path`) |
+| `--last` | `logs`, `start`, `pipelinerun describe`, `taskrun describe` | Target the most recent run |
+| `--use-param-defaults` | `start` | Use schema defaults for unspecified parameters |
+| `--skip-optional-workspace` | `start` | Skip prompts for optional workspaces |
+| `--force`, `-f` | `delete` | Skip confirmation prompt |
+| `--showlog` | `start` | Stream logs after starting |
+| `--exit-with-pipelinerun-error`, `-E` | `pipelinerun logs`, `pipeline start` | Exit with PipelineRun status (0=success, 1=failed, 2=unknown) |
+| `--namespace`, `-n` | all | Override the kubeconfig namespace |
+| `--param`, `-p` | `start` | Pass parameter as `<key>=<value>` |
+| `--workspace`, `-w` | `start` | Pass workspace binding |


### PR DESCRIPTION
Add a concise CONTEXT.md describing common tkn workflows,

conventions, output formats, and behavioral notes for AI agents.

Fixes #2856

Assisted-by: Claude Sonnet 4.6

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Add a new `CONTEXT.md` file documenting common tkn workflows, conventions, output formats, and behavioral guidance for AI agents.

- Ran `make check` locally. The command fails because of existing lint issues in unrelated files, no new issues were introduced by this documentation only change.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
