### PR TITLE
fix(cve): CVE-2026-42499, CVE-2026-39820 - update Go 1.25.9 to 1.25.10 [release-v0.42.2]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## CVE Details

| Field | CVE-2026-42499 | CVE-2026-39820 |
|-------|----------------|----------------|
| **CVE ID** | CVE-2026-42499 | CVE-2026-39820 |
| **Go ID** | GO-2026-4977 | GO-2026-4986 |
| **Severity** | TBD (DoS) | TBD (DoS) |
| **Component** | `net/mail` (stdlib) | `net/mail` (stdlib) |
| **Affected** | Go < 1.25.10 | Go < 1.25.10 |
| **Fixed** | Go 1.25.10 | Go 1.25.10 |

### Description
- **CVE-2026-42499**: Quadratic string concatenation in `consumePhrase` in `net/mail`. Pathological inputs could cause DoS when parsing email addresses according to RFC 5322.
- **CVE-2026-39820**: Quadratic string concatenation in `consumeComment` in `net/mail`. Well-crafted inputs reaching `ParseAddress`, `ParseAddressList`, and `ParseDate` could trigger excessive CPU exhaustion and memory allocations.

## Fix Summary

Updated `go` directive in `go.mod` from `1.25.9` to `1.25.10`. This is a Go stdlib patch release that includes the security fixes for both CVEs. No vendor directory changes were required (stdlib fix only).

## Test Results

**Status: ✅ PASSED**

```
Command: GOTOOLCHAIN=go1.25.10 go test -mod=vendor -count=1 ./...
Result: All packages PASSED
```

All unit tests passed with the updated Go version.

## Breaking Changes

None. This is a patch-level stdlib update (1.25.9 → 1.25.10) with no API changes.

## Jira References

SRVKP-12511
SRVKP-12514

## Verification Steps

- [ ] `go version` in the build environment matches `1.25.10` or higher
- [ ] `govulncheck -scan package ./...` no longer reports GO-2026-4977 or GO-2026-4986
- [ ] All unit tests pass: `go test -mod=vendor ./...`

## Risk Assessment

**Low** — Patch-level Go version bump. Fixes two DoS vulnerabilities in `net/mail`. The `tkn` CLI does not directly call `net/mail` functions but benefits from the updated stdlib in case of transitive use. All tests pass.