### PR TITLE
CI: Group all GitHub Actions dependabot updates together

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -61,5 +61,9 @@ ecosystems:
       - dependencies
       - release-note-none
       - kind/misc
+    groups:
+      all:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,10 @@ updates:
         - dependencies
         - release-note-none
         - kind/misc
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -124,6 +128,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -192,6 +200,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -260,6 +272,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -328,6 +344,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -396,5 +416,9 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7


### PR DESCRIPTION
# Changes

Group all GitHub Actions dependency updates into a single PR per branch. This prevents version mismatches between related actions (e.g. `github/codeql-action/init` and `github/codeql-action/analyze`) that must be bumped together to work correctly.

Without grouping, dependabot creates separate PRs for init and analyze, and merging one without the other causes CI failures:

```
Loaded a configuration file for version '3.32.4', but running version '3.32.6'
```

This affects PRs on multiple release branches (e.g. #2983 + #2967 on release-v0.37.x, #2981 + #2980 on release-v0.44.x, #2982 + #2952 on release-v0.45.x).

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```