### PR TITLE
[release-v0.45.x] CI: Use goinstall mode for golangci-lint action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,10 @@ jobs:
           fi
           echo "$gofmt_out"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.7.2
+          version: v2.12.2
+          install-mode: goinstall
           args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m
       - name: yamllint
         run: |


### PR DESCRIPTION
# Changes

Cherry-pick of #2984 to release-v0.45.x.

The prebuilt golangci-lint binary was built with Go 1.25, which is incompatible with our Go 1.26 toolchain. Switch to `install-mode: goinstall` so golangci-lint is compiled from source using the project's Go version, avoiding the mismatch.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```