### PR TITLE
[release-v0.43.x] CI: Use goinstall mode for golangci-lint action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.7.2
+          version: v2.12.2
+          install-mode: goinstall
           args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m
       - name: yamllint
         run: |


### PR DESCRIPTION
# Changes

Cherry-pick of #2984 to release-v0.43.x.

The prebuilt golangci-lint binary was built with Go 1.25, which is incompatible with our Go 1.26 toolchain. Switch to `install-mode: goinstall` so golangci-lint is compiled from source using the project's Go version, avoiding the mismatch.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```