### PR TITLE
[release-v0.42.x] Security: Fix CVE-2026-27145 - update Go toolchain to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.25.9
+go 1.25.11
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-27145** by updating the Go toolchain requirement from `go 1.25.9` to `go 1.25.11` in `go.mod`.

### CVE Details
- **CVE-2026-27145** (GO-2026-5037, BIT-golang-2026-27145): golang crypto/x509 — Denial of Service via excessive processing of DNS SAN entries
  - Affected: Go stdlib versions < 1.25.11 and < 1.26.4
  - Fixed version: Go 1.25.11 (patch in same minor line)
  - Jira: SRVKP-12628

### Changes
- Updated `go` directive in `go.mod`: 1.25.9 → 1.25.11
- No vendor/ changes required (stdlib version bump only)

### Vulnerability Scan
- Tool: govulncheck v1.5.0 (go1.25.11)
- CVE identified via OSV advisory GO-2026-5037

### Test Results
**Status**: ✅ All tests passed
**Summary**: All unit test packages pass with go1.25.11 toolchain

### Jira References
SRVKP-12628

### Testing Checklist
- [x] Pre-PR automated tests executed (all packages pass)
- [x] go mod tidy && go mod verify && go mod vendor passed
- [ ] Verify CVE is resolved with security scan post-merge

### Risk Assessment
**Low** — minor patch version bump to the Go stdlib toolchain requirement; no API changes; all tests pass.

---
🤖 Generated by CVE Fixer Workflow

```release-note
Security fix: update Go toolchain from 1.25.9 to 1.25.11 to address CVE-2026-27145 (crypto/x509 DoS)
```