### PR TITLE
refactor(release): use .x branches for releases

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -23,6 +23,11 @@
 
 The steps below are meant to be followed in order. Some steps can be done in a different order, but it is generally recommended to follow the process outlined below without skipping steps.
 
+- Release branches use the `release-vX.Y.x` naming convention (e.g.,
+  `release-v0.43.x`). For new minor releases the script creates the `.x` branch
+  from `main`. For patch releases, merge your fixes into the existing `.x` branch
+  via pull requests before running the release script.
+
 - Start reading this [README](tekton/README.md), and you can start a new release
   with the [release.sh](tekton/release.sh) script.
 

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -20,13 +20,15 @@ that needs to be done for the release.
 The first argument to `release.sh` is the release version. It
 needs to be in a format like `v1.2.3`, which is basically SEMVER.
 
-If it detects that you are doing a minor release, it will ask you for some
-commits to be cherry-picked in this release. Alternatively, you can provide the
-commits separated by a space to the second argument of the script. You do need to
-make sure to provide them in order from the oldest to the newest.
+Release branches use the `release-vX.Y.x` naming convention (e.g.,
+`release-v0.43.x`). The script automatically determines the branch name from
+the release version.
 
-If you give the `*` argument for the commits to pick up, it would apply all the new
-commits.
+- **New minor release** (e.g., `v0.46.0`): The script creates a new
+  `release-v0.46.x` branch from `main`.
+- **Patch release** (e.g., `v0.43.3`): The script checks out the existing
+  `release-v0.43.x` branch. All patch fixes should already be merged into
+  the `.x` branch via pull requests before running the release.
 
 The release script will ask you to provide a GitHub token with appropriate priviledges as 
 documented under the [release process prerequisites](../RELEASE_PROCESS.md#Prerequisites).

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 RELEASE_VERSION="${1}"
-COMMITS="${2}"
 
 UPSTREAM_REMOTE=upstream
 DEFAULT_BRANCH="main"
@@ -38,12 +37,17 @@ kubectl get pipeline 2>/dev/null >/dev/null || {
 }
 
 [[ ${RELEASE_VERSION} =~ v[0-9]+\.[0-9]*\.[0-9]+ ]] || { echo "invalid version provided, need to match v\d+\.\d+\.\d+"; exit 1 ;}
+
+RELEASE_BRANCH="release-${RELEASE_VERSION%.*}.x"
+
 git fetch -a --tags ${UPSTREAM_REMOTE} >/dev/null
 lasttag=$(git describe --tags `git rev-list --tags --max-count=1`)
-echo ${lasttag}|sed 's/\.[0-9]*$//'|grep -q ${RELEASE_VERSION%.*} && {
-    echo "Minor version of ${RELEASE_VERSION%.*} detected, previous ${lasttag}"; minor_version=true ;
+
+git ls-remote --exit-code ${UPSTREAM_REMOTE} refs/heads/${RELEASE_BRANCH} >/dev/null 2>&1 && {
+    echo "Patch release detected: ${RELEASE_BRANCH} exists on ${UPSTREAM_REMOTE}, previous tag ${lasttag}"
+    patch_release=true
 } || {
-    echo "Major version for ${RELEASE_VERSION%.*} detected, previous ${lasttag}";
+    echo "New release detected: creating ${RELEASE_BRANCH} from ${DEFAULT_BRANCH}, previous tag ${lasttag}"
 }
 
 cd ${GOPATH}/src/github.com/tektoncd/cli
@@ -54,33 +58,14 @@ cd ${GOPATH}/src/github.com/tektoncd/cli
     exit 1
 }
 
-git checkout ${DEFAULT_BRANCH}
-git reset --hard ${UPSTREAM_REMOTE}/${DEFAULT_BRANCH}
-git checkout -B release-${RELEASE_VERSION}  ${DEFAULT_BRANCH} >/dev/null
-
-if [[ -n ${minor_version} ]];then
-    git reset --hard ${lasttag} >/dev/null
-
-    if [[ -z ${COMMITS} ]];then
-        echo "Showing commit between last minor tag '${lasttag} to '${DEFAULT_BRANCH}'"
-        echo
-        git log --reverse --no-merges --pretty=format:"%C(bold cyan)%h%Creset | %cd | %s | %ae" ${DEFAULT_BRANCH} --since "$(git log --pretty=format:%cd -1 ${lasttag})"
-        echo
-        read -e -p "Pick a list of ordered commits to cherry-pick space separated (* mean all of them): " COMMITS
-    fi
-    [[ -z ${COMMITS} ]] && { echo "no commits picked"; exit 1;}
-    if [[ ${COMMITS} == "*" ]];then
-        COMMITS=$(git log --reverse --no-merges --pretty=format:"%h" ${DEFAULT_BRANCH} \
-                      --since "$(git log --pretty=format:%cd -1 ${lasttag})")
-    fi
-    for commit in ${COMMITS};do
-        git branch --contains ${commit} >/dev/null || { echo "Invalid commit ${commit}" ; exit 1;}
-        echo "Cherry-picking commit: ${commit}"
-        git cherry-pick ${commit} >/dev/null
-    done
+if [[ -n ${patch_release} ]];then
+    echo "Checking out existing ${RELEASE_BRANCH} from ${UPSTREAM_REMOTE}"
+    git checkout -B ${RELEASE_BRANCH} ${UPSTREAM_REMOTE}/${RELEASE_BRANCH} >/dev/null
 else
-    echo "Major release ${RELEASE_VERSION%.*} detected: picking up ${UPSTREAM_REMOTE}/${DEFAULT_BRANCH}"
+    echo "New release ${RELEASE_VERSION%.*} detected: creating ${RELEASE_BRANCH} from ${UPSTREAM_REMOTE}/${DEFAULT_BRANCH}"
+    git checkout ${DEFAULT_BRANCH}
     git reset --hard ${UPSTREAM_REMOTE}/${DEFAULT_BRANCH}
+    git checkout -B ${RELEASE_BRANCH} ${DEFAULT_BRANCH} >/dev/null
 fi
 
 # HACK:! this is temporary to disable the upload to homebrew when we do our testing
@@ -91,9 +76,14 @@ fi
     git cherry-pick 052b0b4ce989fe9aee01027e67e61538b48e1179 >/dev/null
 }
 
+if [[ -n ${patch_release} ]];then
+    prev_tag=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+else
+    prev_tag=${lasttag}
+fi
 COMMITS=$(git log --reverse --no-merges \
-              --pretty=format:'%H' ${DEFAULT_BRANCH} \
-              --since "$(git log --pretty=format:%cd -1 ${lasttag})")
+              --pretty=format:'%H' HEAD \
+              --since "$(git log --pretty=format:%cd -1 ${prev_tag})")
 
 changelog=""
 for c in ${COMMITS};do
@@ -112,7 +102,7 @@ git tag --sign -m \
     -m "${changelog}" --force ${RELEASE_VERSION}
 
 git push --force ${PUSH_REMOTE} ${RELEASE_VERSION}
-git push --force ${PUSH_REMOTE} release-${RELEASE_VERSION}
+git push --force ${PUSH_REMOTE} ${RELEASE_BRANCH}
 
 kubectl create namespace ${TARGET_NAMESPACE} 2>/dev/null || true
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update release script to use release-vX.Y.x branches instead of per-release branches. Patch releases check out the existing .x branch; new releases create one from main. Remove the cherry-pick workflow as fixes are now merged via PRs.


Assisted-by: Claude Opus 4 (via Cursor)


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```release-note
NONE
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:


-->
