### PR TITLE
[release-v0.43.x] fix(cve): bump Go stdlib to 1.25.11 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Changes

Update go directive from 1.25.8 to 1.25.11 to resolve Go stdlib CVEs:
GO-2026-5039, GO-2026-5038, GO-2026-5037, GO-2026-4986, GO-2026-4982,
GO-2026-4981, GO-2026-4980, GO-2026-4977, GO-2026-4976, GO-2026-4971,
GO-2026-4947, GO-2026-4946, GO-2026-4870, GO-2026-4869, GO-2026-4865.

The `golang.org/x/net v0.55.0` bump is already present on the `.x` branch
via dependabot. Only the Go directive itself was missing.

/release-note-none

Made with [Cursor](https://cursor.com)