### PR TITLE
[release-v0.37.x] cherry-pick: OWNERS, CI summary, Dockerfile fix 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,3 +97,39 @@ jobs:
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml
+
+  ci-summary:
+    name: CI summary
+    if: always()
+    needs:
+      - build
+      - linting
+      - tests
+      - generated
+      - multi-arch-build
+      - e2e-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          echo "build: ${{ needs.build.result }}"
+          echo "linting: ${{ needs.linting.result }}"
+          echo "tests: ${{ needs.tests.result }}"
+          echo "generated: ${{ needs.generated.result }}"
+          echo "multi-arch-build: ${{ needs.multi-arch-build.result }}"
+          echo "e2e-tests: ${{ needs.e2e-tests.result }}"
+          results=(
+            "${{ needs.build.result }}"
+            "${{ needs.linting.result }}"
+            "${{ needs.tests.result }}"
+            "${{ needs.generated.result }}"
+            "${{ needs.multi-arch-build.result }}"
+            "${{ needs.e2e-tests.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "One or more jobs failed"
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped"

--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,19 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
+- divyansh42
 - vdemeester
 - chmouel
-- piyush-garg
-- pradeepitm12
 - vinamra28
+- pratap0007
+
+reviewers:
+- pratap0007
+- divyansh42
+- pradeepitm12
 
 # Alumni ❤️
 # danielhelfand
 # hrishin
 # sthaha
+# piyush-garg

--- a/contrib/tkn-image/Dockerfile
+++ b/contrib/tkn-image/Dockerfile
@@ -1,11 +1,11 @@
-ARG GOLANG_VERSION=1.17.13
-ARG DEBIAN_VERSION=10
+ARG GOLANG_VERSION=1.25.6
+ARG DEBIAN_VERSION=12
 
-FROM golang:${GOLANG_VERSION} as builder
+FROM golang:${GOLANG_VERSION} AS builder
 ARG RELEASE_VERSION=
 COPY . /go/src/github.com/tektoncd/cli
 WORKDIR /go/src/github.com/tektoncd/cli
 RUN make RELEASE_VERSION=${RELEASE_VERSION} bin/tkn
 
-FROM debian:${DEBIAN_VERSION} as tkn
+FROM debian:${DEBIAN_VERSION} AS tkn
 COPY --from=builder /go/src/github.com/tektoncd/cli/bin/tkn /usr/bin


### PR DESCRIPTION
## Changes

Cherry-pick 3 commits from `release-v0.37.6` that were missing from `release-v0.37.x`:

1. **Update OWNERS file** (`d6b0e56ef`) - sync OWNERS with release-v0.37.6 branch
2. **Add CI summary job** (`145f66dca`) - add CI summary job to GitHub workflows
3. **fix: CVE-2025-61729** (`5815a1389`) - update contrib Dockerfile to use Go 1.25.6

The remaining missing commit (Go 1.25.8 -> 1.25.9) is already superseded by
open PRs #2922 and #2923 which bump Go further.

/release-note-none

Made with [Cursor](https://cursor.com)