### PR TITLE
[release-v0.42.x] chore: sync OWNERS file with main

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,19 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
+- divyansh42
 - vdemeester
 - chmouel
-- piyush-garg
-- pradeepitm12
 - vinamra28
+- pratap0007
 
 reviewers:
 - pratap0007
 - divyansh42
+- pradeepitm12
 
 # Alumni ❤️
 # danielhelfand
 # hrishin
 # sthaha
+# piyush-garg


### PR DESCRIPTION
## Changes

Sync OWNERS file with `main` branch:
- Add `divyansh42` and `pratap0007` to approvers
- Add reviewers section with `pratap0007`, `divyansh42`, `pradeepitm12`
- Move `piyush-garg` to alumni

/release-note-none

Made with [Cursor](https://cursor.com)