### PR TITLE
Add branch prefix to Dependabot PR titles for release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,8 @@ updates:
       target-branch: release-v0.45.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.45.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -98,6 +100,8 @@ updates:
       target-branch: release-v0.45.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.45.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -118,6 +122,8 @@ updates:
       target-branch: release-v0.45.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.45.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -139,6 +145,8 @@ updates:
       target-branch: release-v0.44.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.44.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -170,6 +178,8 @@ updates:
       target-branch: release-v0.44.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.44.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -190,6 +200,8 @@ updates:
       target-branch: release-v0.44.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.44.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -211,6 +223,8 @@ updates:
       target-branch: release-v0.43.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.43.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -242,6 +256,8 @@ updates:
       target-branch: release-v0.43.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.43.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -262,6 +278,8 @@ updates:
       target-branch: release-v0.43.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.43.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -283,6 +301,8 @@ updates:
       target-branch: release-v0.42.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.42.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -314,6 +334,8 @@ updates:
       target-branch: release-v0.42.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.42.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -334,6 +356,8 @@ updates:
       target-branch: release-v0.42.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.42.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -355,6 +379,8 @@ updates:
       target-branch: release-v0.37.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.37.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -386,6 +412,8 @@ updates:
       target-branch: release-v0.37.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.37.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -406,6 +434,8 @@ updates:
       target-branch: release-v0.37.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.37.x] '
       labels:
         - ok-to-test
         - dependencies

--- a/hack/generate-dependabot.go
+++ b/hack/generate-dependabot.go
@@ -56,12 +56,18 @@ type DependabotConfig struct {
 	Updates []Update `yaml:"updates"`
 }
 
+// CommitMessage configures the prefix for Dependabot commit messages and PR titles
+type CommitMessage struct {
+	Prefix string `yaml:"prefix"`
+}
+
 // Update represents a single dependabot update configuration
 type Update struct {
 	PackageEcosystem string                   `yaml:"package-ecosystem"`
 	Directory        string                   `yaml:"directory"`
 	TargetBranch     string                   `yaml:"target-branch,omitempty"`
 	Schedule         map[string]interface{}   `yaml:"schedule"`
+	CommitMessage    *CommitMessage           `yaml:"commit-message,omitempty"`
 	Labels           []string                 `yaml:"labels"`
 	Ignore           []map[string]interface{} `yaml:"ignore,omitempty"`
 	Groups           map[string]interface{}   `yaml:"groups,omitempty"`
@@ -164,16 +170,17 @@ func generateDependabotConfig(config Config) DependabotConfig {
 				},
 			})
 
-			update := Update{
-				PackageEcosystem: ecosystem.PackageEcosystem,
-				Directory:        ecosystem.Directory,
-				TargetBranch:     branch,
-				Schedule:         ecosystem.Schedule,
-				Labels:           ecosystem.Labels,
-				Ignore:           ignore,
-				Groups:           ecosystem.Groups,
-				Cooldown:         ecosystem.Cooldown,
-			}
+		update := Update{
+			PackageEcosystem: ecosystem.PackageEcosystem,
+			Directory:        ecosystem.Directory,
+			TargetBranch:     branch,
+			Schedule:         ecosystem.Schedule,
+			CommitMessage:    &CommitMessage{Prefix: "[" + branch + "] "},
+			Labels:           ecosystem.Labels,
+			Ignore:           ignore,
+			Groups:           ecosystem.Groups,
+			Cooldown:         ecosystem.Cooldown,
+		}
 			dependabotConfig.Updates = append(dependabotConfig.Updates, update)
 		}
 	}


### PR DESCRIPTION
## Changes

Updates the Dependabot configuration to add `[release-vX.Y.x]` prefix to commit messages (and PR titles) for all release branch entries.

### Modified files:
- `hack/generate-dependabot.go` — Added `CommitMessage` struct with `Prefix` field; set prefix for release branch update entries during generation.
- `.github/dependabot.yml` — Regenerated to include `commit-message.prefix` for all release branch blocks.

### Why

Dependabot PRs targeting release branches currently have generic titles that don't indicate which branch they target. Adding a `[release-vX.Y.x]` prefix makes it immediately clear which branch a Dependabot PR is for, improving triage and review workflows.

### Example

A Dependabot PR targeting `release-v0.45.x` will now have a title like:
```
[release-v0.45.x] Bump golang.org/x/net from 0.30.0 to 0.33.0
```

## Test plan

- [x] Ran `hack/generate-dependabot.sh` — regenerated `.github/dependabot.yml` successfully
- [x] Verified `main` branch entries do NOT have a prefix
- [x] Verified all release branch entries have the correct `[release-vX.Y.x]` prefix


Made with [Cursor](https://cursor.com)