### PR TITLE
cleanup: [work-in-progress-do-not-merge] replaced blang/semver with Masterminds/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.24
 	github.com/docker/cli v29.6.2+incompatible
@@ -68,6 +67,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -262,7 +262,7 @@ func checkRelease(client *Client) (string, error) {
 		return "", err
 	}
 
-	if current.LT(*latest) {
+	if current.LessThan(latest) {
 		return fmt.Sprintf("A newer version (v%s) of Tekton CLI is available, please check %s\n", latest, response.HTMLURL), nil
 	}
 
@@ -272,9 +272,9 @@ func checkRelease(client *Client) (string, error) {
 func parseVersion(version string) (*semver.Version, error) {
 	version = strings.TrimSpace(version)
 	// Strip the leading 'v' in the version strings
-	v, err := semver.Parse(strings.TrimLeft(version, "v"))
+	v, err := semver.NewVersion(strings.TrimLeft(version, "v"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse version")
 	}
-	return &v, nil
+	return v, nil
 }

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -185,13 +185,13 @@ func TestVersionBad(t *testing.T) {
 			name:          "bad-server-version",
 			clientVersion: "v0.0.1",
 			serverVersion: "BAD",
-			expectederr:   "failed to parse version: No Major.Minor.Patch elements found",
+			expectederr:   "failed to parse version: invalid semantic version",
 		},
 		{
 			name:          "bad-client-version",
 			clientVersion: "BAD",
 			serverVersion: "v0.0.1",
-			expectederr:   "failed to parse version: No Major.Minor.Patch elements found",
+			expectederr:   "failed to parse version: invalid semantic version",
 		},
 	}
 


### PR DESCRIPTION
# Changes

Part of: https://github.com/tektoncd/cli/issues/2751

This PR migrates all usages of `github.com/blang/semver` to `github.com/Masterminds/semver/v3`. 

The migration includes:
- Replacing Parse with NewVersion.
- Replacing ParseRange with NewConstraint.
- Adjusting unit tests for the different error messages returned by Masterminds/semver.

Since `Masterminds/semver` is already a project dependency, this removes the need to maintain two semantic versioning libraries and reduces the dependency footprint without changing functionality.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
NONE
```
