### PR TITLE
fix(releaes): fix release script to fetch the correct previous tag

### DIFF
--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -104,7 +104,8 @@ spec:
         - name: github-token-secret-key
           value: $(params.github-token-secret-key)
         - name: image
-          value: goreleaser/goreleaser:v2.15.4
+          # TODO: update the goreleaser image to latest once go v1.25.6 is supported in latest goreleaser image
+          value: goreleaser/goreleaser:v2.18.0-ae4debbe-nightly
         - name: flags
           value: --timeout=60m
       workspaces:

--- a/tekton/release.sh
+++ b/tekton/release.sh
@@ -41,7 +41,8 @@ kubectl get pipeline 2>/dev/null >/dev/null || {
 RELEASE_BRANCH="release-${RELEASE_VERSION%.*}.x"
 
 git fetch -a --tags ${UPSTREAM_REMOTE} >/dev/null
-lasttag=$(git describe --tags `git rev-list --tags --max-count=1`)
+lasttag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${RELEASE_VERSION}$" | head -1)
+[[ -z ${lasttag} ]] && { echo "no previous release tag found for ${RELEASE_VERSION}"; exit 1; }
 
 git ls-remote --exit-code ${UPSTREAM_REMOTE} refs/heads/${RELEASE_BRANCH} >/dev/null 2>&1 && {
     echo "Patch release detected: ${RELEASE_BRANCH} exists on ${UPSTREAM_REMOTE}, previous tag ${lasttag}"
@@ -77,7 +78,9 @@ fi
 }
 
 if [[ -n ${patch_release} ]];then
-    prev_tag=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+    version_prefix="${RELEASE_VERSION%.*}"
+    prev_tag=$(git tag --sort=-v:refname -l "${version_prefix}.*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${RELEASE_VERSION}$" | head -1)
+    [[ -z ${prev_tag} ]] && { echo "no previous patch release tag found for ${version_prefix}"; exit 1; }
 else
     prev_tag=${lasttag}
 fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


  - The lasttag detection was using git describe --tags with git rev-list --tags --max-count=1, which can pick up pre-release or non-semver tags which was picking v0.44.2 as previous tag for v0.45.1 release
  It now uses git tag --sort=-v:refname filtered with a regex (^v[0-9]+\.[0-9]+\.[0-9]+$) to reliably get the      latest stable semver tag. 
   For patch releases, the previous tag lookup also changed: instead of git describe --tags --abbrev=0 HEAD, i t now extracts the version prefix (e.g. v0.45) and finds the latest tag matching v0.45.*,
  ensuring the correct previous tag within the same minor version.
  -  Bumped the goreleaser image from v2.15.4 to v2.18.0-ae4debbe-nightly.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
