### PR TITLE
Security: Fix CVE-2026-42505 - update Go to 1.26.5 (crypto/tls ECH privacy leak)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/ActiveState/vt10x v1.3.1


### PR DESCRIPTION
# Changes

Update Go directive from 1.26.4 to 1.26.5 to resolve CVE-2026-42505, a privacy leak in the `crypto/tls` package affecting Encrypted Client Hello (ECH) support.

**CVE Details:**
- **CVE ID:** CVE-2026-42505 (GO-2026-5856)
- **Severity:** High
- **CVSS:** crypto/tls privacy leak in ECH handshake
- **Affected:** Go stdlib `crypto/tls` in versions < 1.26.5
- **Fixed in:** Go 1.26.5
- **Advisory:** https://pkg.go.dev/vuln/GO-2026-5856

**Description:** When invoking Encrypted Client Hello (ECH), the TLS client may expose the cleartext server name (SNI) via the `crypto/tls` package, undermining the ECH privacy guarantee.

**Fix Summary:**
- Updated `go` directive in `go.mod` from `1.26.4` to `1.26.5`
- Ran `go mod tidy && go mod verify && go mod vendor` — all passed

**Test Results:**
- Core packages (`pkg/`, `pkg/cmd/`, etc.): ✅ PASS
- `pkg/cmd/hub/cmd/*`: ⚠️ Pre-existing golden file failures unrelated to this change (root cause: `user: unknown userid 1009320000` in CI container environment; failing tests existed before this change)

**Breaking Changes:** None. This is a patch-level Go version bump.

**Risk Assessment:** Low — patch version bump (1.26.4 → 1.26.5) with no API changes.

# Submitter Checklist

- [x] Includes tests (no new tests needed — stdlib update, confirmed by govulncheck)
- [x] Run `go mod tidy && go mod verify && go mod vendor`
- [x] Commit messages follow best practices

# Release Notes

```release-note
Security: Update Go to 1.26.5 to fix CVE-2026-42505 (crypto/tls ECH privacy leak)
```

---
**Jira Reference:** CVE-2026-42505 / GO-2026-5856