### PR TITLE
[release-v0.37.x] Security: Fix CVE-2026-42505 - update Go to 1.25.12 (crypto/tls ECH privacy leak)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
# Changes

Update Go directive from 1.25.11 to 1.25.12 to resolve CVE-2026-42505, a privacy leak in the `crypto/tls` package affecting Encrypted Client Hello (ECH) support.

**CVE Details:**
- **CVE ID:** CVE-2026-42505 (GO-2026-5856)
- **Severity:** High
- **Affected:** Go stdlib `crypto/tls` in versions < 1.25.12 (on 1.25.x line)
- **Fixed in:** Go 1.25.12
- **Advisory:** https://pkg.go.dev/vuln/GO-2026-5856

**Description:** When invoking Encrypted Client Hello (ECH), the TLS client may expose the cleartext server name (SNI) via the `crypto/tls` package, undermining the ECH privacy guarantee.

**Fix Summary:**
- Updated `go` directive in `go.mod` from `1.25.11` to `1.25.12`
- Ran `go mod tidy && go mod verify && go mod vendor` — all passed ✅

**Test Results:**
- `go mod verify`: ✅ PASS
- `go mod vendor`: ✅ PASS
- Pre-existing golden file failures in `pkg/cmd/hub/cmd/*` are unrelated to this change

**Breaking Changes:** None. Patch-level Go version bump.

**Risk Assessment:** Low — patch version bump (1.25.11 → 1.25.12) with no API changes.

# Submitter Checklist

- [x] Includes tests (no new tests needed — stdlib update, confirmed by govulncheck)
- [x] Run `go mod tidy && go mod verify && go mod vendor`
- [x] Commit messages follow best practices

# Release Notes

```release-note
Security: Update Go to 1.25.12 to fix CVE-2026-42505 (crypto/tls ECH privacy leak)
```

---
**Jira Reference:** CVE-2026-42505 / GO-2026-5856
**Corresponds to main fix:** https://github.com/tektoncd/cli/pull/3065
**Corresponds to v0.44.x fix:** https://github.com/tektoncd/cli/pull/3066