### PR TITLE
[release-v0.44.x] Security: Fix stdlib CVEs (go1.25.13)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/cli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
# Changes

Bump Go stdlib from `go 1.25.12` to `go 1.25.13` to fix four vulnerabilities confirmed by govulncheck on the release-v0.44.x branch.

**Vulnerabilities fixed:**
| Advisory | Package | Description | Severity |
|----------|---------|-------------|----------|
| GO-2026-6218 | `net/url` | Quadratic complexity in `resolvePath` | Important (CVSS 7.5) |
| GO-2026-6090 | `crypto/tls` | Unbounded post-handshake messages | Important (CVSS 7.5) |
| GO-2026-5972 | `encoding/asn1` | Missing max recursion depth | Important (CVSS 7.5) |
| GO-2026-5026 | `net/http` | Punycode-encoded label rejection in idna | Important (CVSS 7.5) |

**Related Jira:** SRVKP-13176 (FedRAMP ConMon scan — pipelines-cli-tkn-rhel9, Pipelines 1.22)

**Note:** grpc fix (GHSA-hrxh-6v49-42gf) covered by PR #3132 on this branch.

## Changes Applied
- `go.mod`: `go 1.25.12` → `go 1.25.13`
- `go mod tidy` ✅
- `go mod verify` ✅ (all modules verified)
- `go mod vendor` ✅

# Submitter Checklist

- [x] Includes tests (dependency-only update, no logic changes)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```

---
🤖 Generated by CVE Fixer Workflow