### PR TITLE
chore(deps): add release-v0.46.x to dependabot config

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -6,6 +6,7 @@
 # by parsing the active LTS entries from releases.md.
 
 release-branches:
+  - release-v0.46.x
   - release-v0.45.x
   - release-v0.44.x
   - release-v0.43.x

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,84 @@ updates:
         default-days: 7
     - package-ecosystem: gomod
       directory: /
+      target-branch: release-v0.46.x
+      schedule:
+        interval: weekly
+      commit-message:
+        prefix: '[release-v0.46.x] '
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: k8s.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        go-docker-dependencies:
+            patterns:
+                - github.com/docker/*
+        go-k8s-dependencies:
+            patterns:
+                - k8s.io/*
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
+    - package-ecosystem: gomod
+      directory: /tools
+      target-branch: release-v0.46.x
+      schedule:
+        interval: weekly
+      commit-message:
+        prefix: '[release-v0.46.x] '
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
+    - package-ecosystem: github-actions
+      directory: /
+      target-branch: release-v0.46.x
+      schedule:
+        interval: weekly
+      commit-message:
+        prefix: '[release-v0.46.x] '
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
+    - package-ecosystem: gomod
+      directory: /
       target-branch: release-v0.45.x
       schedule:
         interval: weekly

--- a/releases.md
+++ b/releases.md
@@ -36,6 +36,12 @@ Further documentation available:
 
 ## Release
 
+### v0.46 (LTS)
+
+- **Latest Release**: [v0.46.0][v0-46-0] (2026-08-05) ([docs][v0-46-0-docs])
+- **Initial Release**: [v0.46.0][v0-46-0] (2026-08-05) ([docs][v0-46-0-docs])
+- **End of Life**: 2027-08-04
+
 ### v0.45 (LTS)
 
 - **Latest Release**: [v0.45.0][v0-45-0] (2026-05-12) ([docs][v0-45-0-docs])
@@ -177,6 +183,7 @@ Older releases are EOL and available on [GitHub][tekton-cli-releases].
 [tekton-releases-docs]: tekton/README.md
 [release-notes-standards]: https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 [tekton-release-process]: RELEASE_PROCESS.md
+[v0-46-0]: https://github.com/tektoncd/cli/releases/tag/v0.46.0
 [v0-45-0]: https://github.com/tektoncd/cli/releases/tag/v0.45.0
 [v0-44-0]: https://github.com/tektoncd/cli/releases/tag/v0.44.0
 [v0-43-0]: https://github.com/tektoncd/cli/releases/tag/v0.43.0
@@ -208,6 +215,7 @@ Older releases are EOL and available on [GitHub][tekton-cli-releases].
 [v0-27-0]: https://github.com/tektoncd/cli/releases/tag/v0.27.0
 [v0-26-0]: https://github.com/tektoncd/cli/releases/tag/v0.26.0
 [v0-25-0]: https://github.com/tektoncd/cli/releases/tag/v0.25.0
+[v0-46-0-docs]: https://github.com/tektoncd/cli/tree/v0.46.0/docs
 [v0-45-0-docs]: https://github.com/tektoncd/cli/tree/v0.45.0/docs
 [v0-44-0-docs]: https://github.com/tektoncd/cli/tree/v0.44.0/docs
 [v0-43-0-docs]: https://github.com/tektoncd/cli/tree/v0.43.0/docs


### PR DESCRIPTION
# Changes

- Registers `v0.46.0` as a new active LTS release in `releases.md` (release date 2026-08-05, EOL 2027-08-04).
- Regenerates `.github/dependabot.config.yml` and `.github/dependabot.yml` via `./hack/generate-dependabot.sh` so `release-v0.46.x` receives weekly dependency updates alongside the other active LTS branches (`release-v0.45.x`, `release-v0.44.x`, `release-v0.43.x`, `release-v0.42.x`, `release-v0.37.x`).

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)