### PR TITLE
fix(plugins): reject relative plugin dirs to prevent cwd fallback (CWE-426)

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -33,7 +33,14 @@ func getPluginDir() (string, error) {
 		return filepath.Join(xdgHome, "tkn", "plugins"), nil
 	}
 	// Fallback to default pluginDir (~/.config/tkn/plugins)
-	return homedir.Expand(pluginDir)
+	dir, err := homedir.Expand(pluginDir)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(dir) {
+		return "", fmt.Errorf("plugin dir %q is not an absolute path", dir)
+	}
+	return dir, nil
 }
 
 // Find a binary in plugin homedir directory or user paths.

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -20,10 +20,16 @@ func getPluginDir() (string, error) {
 	dir := os.Getenv(pluginDirEnv)
 	// if TKN_PLUGINS_DIR is set, follow it
 	if dir != "" {
+		if !filepath.IsAbs(dir) {
+			return "", fmt.Errorf("plugin dir %q is not an absolute path", dir)
+		}
 		return dir, nil
 	}
 	// Respect XDG_CONFIG_HOME if set
 	if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
+		if !filepath.IsAbs(xdgHome) {
+			return "", fmt.Errorf("XDG_CONFIG_HOME %q is not an absolute path", xdgHome)
+		}
 		return filepath.Join(xdgHome, "tkn", "plugins"), nil
 	}
 	// Fallback to default pluginDir (~/.config/tkn/plugins)
@@ -33,15 +39,14 @@ func getPluginDir() (string, error) {
 // Find a binary in plugin homedir directory or user paths.
 func FindPlugin(pluginame string) (string, error) {
 	cmd := tknPrefix + pluginame
-	dir, _ := getPluginDir()
-	path := filepath.Join(dir, cmd)
-	_, err := os.Stat(path)
-	if err == nil {
-		// Found in dir
-		return path, nil
+	if dir, err := getPluginDir(); err == nil {
+		path := filepath.Join(dir, cmd)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
 	}
 
-	path, err = exec.LookPath(cmd)
+	path, err := exec.LookPath(cmd)
 	if err == nil {
 		return path, nil
 	}

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -74,9 +74,10 @@ func TestFindPluginDoesNotFallBackToCwd(t *testing.T) {
 	defer os.Chdir(orig) //nolint:errcheck
 	assert.NilError(t, os.Chdir(nd.Path()))
 
-	// Force getPluginDir() to fail via a relative TKN_PLUGINS_DIR.
+	// Use "." as TKN_PLUGINS_DIR: the old code would resolve filepath.Join(".", "tkn-evil")
+	// against cwd and find the binary; the fixed code rejects "." as non-absolute.
 	// Keep nd off PATH so LookPath cannot find the binary either.
-	t.Setenv(pluginDirEnv, "relative/bad/path")
+	t.Setenv(pluginDirEnv, ".")
 	t.Setenv("PATH", "")
 
 	// The binary is only reachable via cwd — FindPlugin must not find it.

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -3,7 +3,6 @@ package plugins
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -63,20 +62,26 @@ func TestGetPluginDirRelativeXDGConfigHome(t *testing.T) {
 	assert.ErrorContains(t, err, "not an absolute path")
 }
 
-func TestFindPluginSkipsCwdWhenPluginDirFails(t *testing.T) {
+func TestFindPluginDoesNotFallBackToCwd(t *testing.T) {
 	nd := fs.NewDir(t, "TestFindPluginCwd")
 	defer nd.Remove()
 	err := os.WriteFile(nd.Join("tkn-evil"), []byte("evil"), 0o700)
 	assert.NilError(t, err)
 
-	// Simulate relative TKN_PLUGINS_DIR so getPluginDir() returns error
-	t.Setenv(pluginDirEnv, "relative/bad/path")
-	t.Setenv("PATH", nd.Path())
-
-	// Plugin is in PATH so it should still be found via LookPath
-	path, err := FindPlugin("evil")
+	// Change into the directory that contains the malicious binary.
+	orig, err := os.Getwd()
 	assert.NilError(t, err)
-	assert.Assert(t, filepath.IsAbs(path), "expected absolute path, got %q", path)
+	defer os.Chdir(orig) //nolint:errcheck
+	assert.NilError(t, os.Chdir(nd.Path()))
+
+	// Force getPluginDir() to fail via a relative TKN_PLUGINS_DIR.
+	// Keep nd off PATH so LookPath cannot find the binary either.
+	t.Setenv(pluginDirEnv, "relative/bad/path")
+	t.Setenv("PATH", "")
+
+	// The binary is only reachable via cwd — FindPlugin must not find it.
+	_, err = FindPlugin("evil")
+	assert.ErrorContains(t, err, "cannot find plugin")
 }
 
 // as well tested differently in root_test.go

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -47,6 +48,35 @@ func TestGetAllTknPluginFromPathPlugindir(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(paths), 1)
 	assert.Equal(t, paths[0], "fromplugindir")
+}
+
+func TestGetPluginDirRelativeTKNPluginsDir(t *testing.T) {
+	t.Setenv(pluginDirEnv, "relative/path")
+	_, err := getPluginDir()
+	assert.ErrorContains(t, err, "not an absolute path")
+}
+
+func TestGetPluginDirRelativeXDGConfigHome(t *testing.T) {
+	t.Setenv(pluginDirEnv, "")
+	t.Setenv("XDG_CONFIG_HOME", "relative/xdg")
+	_, err := getPluginDir()
+	assert.ErrorContains(t, err, "not an absolute path")
+}
+
+func TestFindPluginSkipsCwdWhenPluginDirFails(t *testing.T) {
+	nd := fs.NewDir(t, "TestFindPluginCwd")
+	defer nd.Remove()
+	err := os.WriteFile(nd.Join("tkn-evil"), []byte("evil"), 0o700)
+	assert.NilError(t, err)
+
+	// Simulate relative TKN_PLUGINS_DIR so getPluginDir() returns error
+	t.Setenv(pluginDirEnv, "relative/bad/path")
+	t.Setenv("PATH", nd.Path())
+
+	// Plugin is in PATH so it should still be found via LookPath
+	path, err := FindPlugin("evil")
+	assert.NilError(t, err)
+	assert.Assert(t, filepath.IsAbs(path), "expected absolute path, got %q", path)
 }
 
 // as well tested differently in root_test.go


### PR DESCRIPTION
# Changes

`FindPlugin()` in `pkg/plugins/plugins.go` silently discarded the error from `getPluginDir()`. In minimal environments (scratch/distroless containers, Kubernetes pods running as arbitrary UIDs without `/etc/passwd` entries), all home-dir resolution fallbacks (`dscl`, `getent`, `sh -c "cd && pwd"`) can fail, causing `getPluginDir()` to return `("", err)`. The discarded error left `dir` as an empty string, so `filepath.Join("", "tkn-<arg>")` produced a relative path. `syscall.Exec` then resolved it against the current working directory — a classic untrusted search path (CWE-426).

Additionally, `TKN_PLUGINS_DIR` and `XDG_CONFIG_HOME` were accepted even when set to relative paths, creating the same cwd-resolution risk without any home-dir failure at all.

**Fix:**
- `getPluginDir()` now returns an error if `TKN_PLUGINS_DIR` or `XDG_CONFIG_HOME` is not an absolute path.
- `FindPlugin()` properly handles the error from `getPluginDir()` and skips the dir lookup (falling through to `exec.LookPath`) instead of silently using an empty string.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
Fix untrusted search path (CWE-426): plugin discovery no longer falls back to the current working directory when home-dir resolution fails or when TKN_PLUGINS_DIR/XDG_CONFIG_HOME is set to a relative path.
```