### PR TITLE
fix(bundle): gate name.Insecure behind --remote-skip-tls (CWE-319)

### DIFF
--- a/docs/cmd/tkn_bundle_list.md
+++ b/docs/cmd/tkn_bundle_list.md
@@ -42,7 +42,7 @@ Caching:
   -o, --output string                 Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file).
       --remote-bearer string          A Bearer token to authenticate against the repository
       --remote-password string        A password to pass to the registry for basic auth. Must be used with --remote-username
-      --remote-skip-tls               If set to true, skips TLS check when connecting to the registry
+      --remote-skip-tls               Skip TLS certificate verification and allow plain-HTTP connections to the registry (opt-in insecure mode)
       --remote-username string        A username to pass to the registry for basic auth. Must be used with --remote-password
       --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

--- a/docs/cmd/tkn_bundle_push.md
+++ b/docs/cmd/tkn_bundle_push.md
@@ -39,7 +39,7 @@ Created time:
       --label strings            OCI Config labels in the form of key=value to be added to the OCI image. Can be provided multiple times to add multiple labels.
       --remote-bearer string     A Bearer token to authenticate against the repository
       --remote-password string   A password to pass to the registry for basic auth. Must be used with --remote-username
-      --remote-skip-tls          If set to true, skips TLS check when connecting to the registry
+      --remote-skip-tls          Skip TLS certificate verification and allow plain-HTTP connections to the registry (opt-in insecure mode)
       --remote-username string   A username to pass to the registry for basic auth. Must be used with --remote-password
 ```
 

--- a/docs/cmd/tkn_task_start.md
+++ b/docs/cmd/tkn_task_start.md
@@ -69,7 +69,7 @@ For passing the workspaces via flags:
       --prefix-name string        specify a prefix for the TaskRun name (must be lowercase alphanumeric characters)
       --remote-bearer string      A Bearer token to authenticate against the repository
       --remote-password string    A password to pass to the registry for basic auth. Must be used with --remote-username
-      --remote-skip-tls           If set to true, skips TLS check when connecting to the registry
+      --remote-skip-tls           Skip TLS certificate verification and allow plain-HTTP connections to the registry (opt-in insecure mode)
       --remote-username string    A username to pass to the registry for basic auth. Must be used with --remote-password
   -s, --serviceaccount string     pass the serviceaccount name
       --showlog                   show logs right after starting the Task

--- a/docs/man/man1/tkn-bundle-list.1
+++ b/docs/man/man1/tkn-bundle-list.1
@@ -78,7 +78,7 @@ Caching:
 
 .PP
 \fB\-\-remote\-skip\-tls\fP[=false]
-    If set to true, skips TLS check when connecting to the registry
+    Skip TLS certificate verification and allow plain\-HTTP connections to the registry (opt\-in insecure mode)
 
 .PP
 \fB\-\-remote\-username\fP=""

--- a/docs/man/man1/tkn-bundle-push.1
+++ b/docs/man/man1/tkn-bundle-push.1
@@ -75,7 +75,7 @@ Created time:
 
 .PP
 \fB\-\-remote\-skip\-tls\fP[=false]
-    If set to true, skips TLS check when connecting to the registry
+    Skip TLS certificate verification and allow plain\-HTTP connections to the registry (opt\-in insecure mode)
 
 .PP
 \fB\-\-remote\-username\fP=""

--- a/docs/man/man1/tkn-task-start.1
+++ b/docs/man/man1/tkn-task-start.1
@@ -73,7 +73,7 @@ Start Tasks
 
 .PP
 \fB\-\-remote\-skip\-tls\fP[=false]
-    If set to true, skips TLS check when connecting to the registry
+    Skip TLS certificate verification and allow plain\-HTTP connections to the registry (opt\-in insecure mode)
 
 .PP
 \fB\-\-remote\-username\fP=""

--- a/pkg/bundle/flags.go
+++ b/pkg/bundle/flags.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/pflag"
 )
@@ -39,13 +40,24 @@ func (r *RemoteOptions) ToOptions() []remoteimg.Option {
 		opts = []remoteimg.Option{remoteimg.WithAuthFromKeychain(keychains)}
 	}
 
-	transport := http.DefaultTransport.(*http.Transport)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if r.skipTLS {
 		transport.TLSClientConfig.InsecureSkipVerify = r.skipTLS
 	}
 	// TODO: consider adding CA overrides for self-signed or private registries.
 	opts = append(opts, remoteimg.WithTransport(transport))
 	return opts
+}
+
+// NameOptions returns name-parsing options that reflect the current remote settings.
+// name.Insecure is only included when --remote-skip-tls is set, to prevent
+// unintentional plain-HTTP registry connections (CWE-319).
+// Callers that require strict reference validation should add name.StrictValidation themselves.
+func (r *RemoteOptions) NameOptions() []name.Option {
+	if r.skipTLS {
+		return []name.Option{name.Insecure}
+	}
+	return nil
 }
 
 // AddRemoteFlags will define a common set of flags that can be used to change how images are pushed/fetched from remote
@@ -56,7 +68,7 @@ func AddRemoteFlags(flags *pflag.FlagSet, opts *RemoteOptions) {
 	flags.StringVar(&opts.basicPassword, "remote-password", "", "A password to pass to the registry for basic auth. Must be used with --remote-username")
 
 	// TLS related flags.
-	flags.BoolVar(&opts.skipTLS, "remote-skip-tls", false, "If set to true, skips TLS check when connecting to the registry")
+	flags.BoolVar(&opts.skipTLS, "remote-skip-tls", false, "Skip TLS certificate verification and allow plain-HTTP connections to the registry (opt-in insecure mode)")
 }
 
 // PullOptions configure how an image is cached once it is fetched from the remote.

--- a/pkg/cmd/bundle/list.go
+++ b/pkg/cmd/bundle/list.go
@@ -84,7 +84,7 @@ Caching:
 				return errInvalidRef
 			}
 
-			ref, err := name.ParseReference(args[0], name.StrictValidation, name.Insecure)
+			ref, err := name.ParseReference(args[0], append([]name.Option{name.StrictValidation}, opts.remoteOptions.NameOptions()...)...)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/bundle/push.go
+++ b/pkg/cmd/bundle/push.go
@@ -84,7 +84,7 @@ Created time:
 				return errInvalidRef
 			}
 
-			if _, err := name.ParseReference(args[0], name.StrictValidation, name.Insecure); err != nil {
+			if _, err := name.ParseReference(args[0], append([]name.Option{name.StrictValidation}, opts.remoteOptions.NameOptions()...)...); err != nil {
 				return err
 			}
 
@@ -112,7 +112,7 @@ Created time:
 // Reads the positional arguments and the `-f` flag to fill in the `bunldeContents` parameter with all of the raw Tekton
 // contents.
 func (p *pushOptions) parseArgsAndFlags(args []string) (err error) {
-	p.ref, _ = name.ParseReference(args[0], name.StrictValidation, name.Insecure)
+	p.ref, _ = name.ParseReference(args[0], append([]name.Option{name.StrictValidation}, p.remoteOptions.NameOptions()...)...)
 
 	// If there are file paths specified, then read them and include their contents.
 	for _, path := range p.bundleContentPaths {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`tkn bundle push` and `tkn bundle list` unconditionally passed `name.Insecure` to every `name.ParseReference` call, enabling plain-HTTP registry connections without user consent (CWE-319 / ASVS V9.1.1). This creates a MitM risk on untrusted networks.

This PR fixes the issue by:

- Adding `RemoteOptions.NameOptions() []name.Option` in `pkg/bundle/flags.go` — returns `[]name.Option{name.Insecure}` only when `--remote-skip-tls` is explicitly set, `nil` otherwise. Validation mode is left to the caller; `bundle push/list` prepend `name.StrictValidation` explicitly to preserve existing strict-reference behaviour. `task start` is unchanged.
- Replacing the hardcoded `name.Insecure` arguments in `push.go` (PreRunE + parseArgsAndFlags) and `list.go` (PreRunE) with `NameOptions()` calls.
- Fixing a secondary bug: `ToOptions()` was mutating `http.DefaultTransport` in-place. Now uses `.Clone()` so the global transport is never modified. Uses `r.skipTLS` instead of literal `true` for `InsecureSkipVerify`.
- Updating the `--remote-skip-tls` flag description to clarify it also enables plain-HTTP connections, not just cert-check bypass.
- Regenerating docs and man pages for `bundle push` and `bundle list`.

Fixes: https://redhat.atlassian.net/browse/SRVKP-13805

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
action required: tkn bundle push/list no longer allow plain-HTTP registry connections by default. Pass --remote-skip-tls to opt in to insecure (HTTP) registry access.
```