### PR TITLE
fix: add execute-bit check in FindPlugin

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -48,7 +48,7 @@ func FindPlugin(pluginame string) (string, error) {
 	cmd := tknPrefix + pluginame
 	if dir, err := getPluginDir(); err == nil {
 		path := filepath.Join(dir, cmd)
-		if _, err := os.Stat(path); err == nil {
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
 			return path, nil
 		}
 	}

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -33,6 +33,36 @@ func TestFindPluginInPath(t *testing.T) {
 	assert.Equal(t, path, nd.Join("tkn-testp"))
 }
 
+func TestFindPluginNonExecutable(t *testing.T) {
+	nd := fs.NewDir(t, "TestFindPluginNonExecutable")
+	defer nd.Remove()
+	err := os.WriteFile(nd.Join("tkn-test"), []byte("test"), 0o600)
+	assert.NilError(t, err)
+	t.Setenv(pluginDirEnv, nd.Path())
+	t.Setenv("PATH", "/non/existing/path")
+	_, err = FindPlugin("test")
+	assert.ErrorContains(t, err, "cannot find plugin")
+}
+
+func TestFindPluginNonExecutableFallsBackToPath(t *testing.T) {
+	pluginDir := fs.NewDir(t, "TestFindPluginNonExecPluginDir")
+	defer pluginDir.Remove()
+	err := os.WriteFile(pluginDir.Join("tkn-test"), []byte("nonexec"), 0o600)
+	assert.NilError(t, err)
+
+	pathDir := fs.NewDir(t, "TestFindPluginNonExecPath")
+	defer pathDir.Remove()
+	// nolint: gosec
+	err = os.WriteFile(pathDir.Join("tkn-test"), []byte("exec"), 0o700)
+	assert.NilError(t, err)
+
+	t.Setenv(pluginDirEnv, pluginDir.Path())
+	t.Setenv("PATH", pathDir.Path())
+	path, err := FindPlugin("test")
+	assert.NilError(t, err)
+	assert.Equal(t, path, pathDir.Join("tkn-test"))
+}
+
 func TestGetAllTknPluginFromPathPlugindir(t *testing.T) {
 	nd := fs.NewDir(t, "TestGetAllTknPluginFromPluginPath")
 	defer nd.Remove()


### PR DESCRIPTION
# **Changes**

Included `execute-bit` check in `FindPlugin` to only allow executable files. Earlier, `FindPlugin` uses `os.Stat` to check file existence in the plugin directory but did not verify the execute bit (Mode()&0o111). A non-executable file matching` tkn-<name> `was being returned as a valid plugin path. 

Added tests to verify this execute-bit check in FindPlugin.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```
