### PR TITLE
[release-v0.45.x] chore: add rebase and cherry-pick slash command workflows

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -10,5 +10,5 @@ on:
 jobs:
   retest:
     name: Rerun Failed Actions
-    uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@8441d6ffad5bf64f631ed0e67e46192fdedaca47
+    uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@48c53b4e7f1e0bb206575b80eb9fcf07b5854907
     secrets: inherit

--- a/.github/workflows/rebase-command.yaml
+++ b/.github/workflows/rebase-command.yaml
@@ -1,0 +1,30 @@
+# Rebase Command Workflow
+#
+# This workflow is triggered by the /rebase slash command from the slash.yml workflow.
+# It automatically rebases a PR branch against its base branch and force pushes the result.
+#
+# Usage: Comment `/rebase` on an open pull request
+#
+# Security Notes:
+# - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Cannot rebase PRs from forks (branch must be in tektoncd/cli)
+# - Uses CHATOPS_TOKEN to push rebased branches
+# - Uses --force-with-lease for safe force pushing
+
+name: Rebase Command
+
+on:
+  repository_dispatch:
+    types: [rebase-command]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  rebase:
+    name: Rebase PR
+    uses: tektoncd/plumbing/.github/workflows/_rebase-command.yaml@4e60dd3785868521b0542134f5f57f2989c8883d
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -1,17 +1,38 @@
 name: Slash Command Routing
 
-permissions:
-  contents: read
-
 on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   check_comments:
-    if: ${{ github.event.issue.pull_request }}
-    permissions:
-      issues: write # for peter-evans/slash-command-dispatch to create issue reaction
-      pull-requests: write # for peter-evans/slash-command-dispatch to create PR reaction
-    uses: tektoncd/plumbing/.github/workflows/_slash.yml@8441d6ffad5bf64f631ed0e67e46192fdedaca47
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+    - name: route-land
+      uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        config: >
+          [
+            {
+              "command": "retest",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/cli"
+            },
+            {
+              "command": "cherry-pick",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/cli"
+            },
+            {
+              "command": "rebase",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/cli"
+            }
+          ]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cherry-pick of #3221 to this release branch.

- Update \`slash.yml\` to use \`peter-evans/slash-command-dispatch\` inline with \`retest\`, \`cherry-pick\`, and \`rebase\` commands scoped to \`tektoncd/cli\`
- Add \`rebase-command.yaml\` triggered by \`/rebase\` slash command, delegating to \`tektoncd/plumbing/_rebase-command.yaml\`
- Update \`chatops_retest.yaml\` plumbing SHA to match tektoncd/pipeline

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Run the code checkers with \`make check\`
- [x] Regenerate the manpages, docs and go formatting with \`make generated\`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```release-note
NONE
```