### PR TITLE
[cherry-pick: release-v0.37.x] fix: prevent unbounded tar layer allocation

### DIFF
--- a/pkg/bundle/builder_test.go
+++ b/pkg/bundle/builder_test.go
@@ -131,14 +131,13 @@ func TestBuildTektonBundle(t *testing.T) {
 
 	// If the user bundled this up as a tar file then we need to untar it.
 	treader := tar.NewReader(rc)
-	header, err := treader.Next()
-	if err != nil {
+	if _, err := treader.Next(); err != nil {
 		t.Errorf("layer is not a tarball")
 	}
 
-	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
-		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
+	limited := io.LimitReader(treader, MaxLayerSize+1)
+	contents, err := io.ReadAll(limited)
+	if err != nil && err != io.EOF {
 		t.Errorf("failed to read tar bundle: %v", err)
 	}
 

--- a/pkg/bundle/reader.go
+++ b/pkg/bundle/reader.go
@@ -15,6 +15,9 @@ import (
 // Tekton bundle. The `version`, `kind`, and `name` fields map 1:1 with the same named fields in the Tekton Bundle spec.
 type ObjectVisitor func(version, kind, name string, element runtime.Object, raw []byte)
 
+// setting a limit reader to avoid reading more than 1.5 MiB from the layer
+const MaxLayerSize = 15 << 20 / 10
+
 // List will call visitor for every single layer in the img.
 func List(img v1.Image, visitor ObjectVisitor) error {
 	manifest, err := img.Manifest()
@@ -110,15 +113,16 @@ func readTarLayer(l v1.Layer) ([]byte, error) {
 
 	// If the user bundled this up as a tar file then we need to untar it.
 	treader := tar.NewReader(rc)
-	header, err := treader.Next()
-	if err != nil {
+	if _, err := treader.Next(); err != nil {
 		return nil, fmt.Errorf("layer is not a tarball")
 	}
-
-	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
-		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
+	limited := io.LimitReader(treader, MaxLayerSize+1)
+	contents, err := io.ReadAll(limited)
+	if err != nil {
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
+	}
+	if int64(len(contents)) > MaxLayerSize {
+		return nil, fmt.Errorf("layer exceeds maximum allowed size of %d bytes", MaxLayerSize)
 	}
 	return contents, nil
 }

--- a/pkg/bundle/reader_test.go
+++ b/pkg/bundle/reader_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -123,5 +124,35 @@ func TestReader(t *testing.T) {
 		test.Contains(t, []runtime.Object{&task1}, element)
 	}); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestReadTarLayerExceedsMaxSize(t *testing.T) {
+	oversized := make([]byte, MaxLayerSize+1)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{
+		Name: "oversizedtask.yaml",
+		Size: int64(len(oversized)),
+	})
+	_, _ = tw.Write(oversized)
+	_ = tw.Close()
+
+	// Wrap as a fake v1.Layer via tarball.FromOpener
+	opener := func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	}
+	layer, err := tarball.LayerFromOpener(opener)
+	if err != nil {
+		t.Fatalf("failed to create layer: %v", err)
+	}
+
+	_, err = readTarLayer(layer)
+	if err == nil {
+		t.Fatal("expected error for oversized layer, got nil")
+	}
+	if !strings.Contains(err.Error(), "layer exceeds maximum allowed size") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/pkg/cmd/bundle/push_test.go
+++ b/pkg/cmd/bundle/push_test.go
@@ -245,15 +245,13 @@ func readTarLayer(t *testing.T, layer v1.Layer) string {
 
 	// If the user bundled this up as a tar file then we need to untar it.
 	treader := tar.NewReader(rc)
-	header, err := treader.Next()
-	if err != nil {
+	if _, err := treader.Next(); err != nil {
 		t.Errorf("layer is not a tarball")
-
 	}
 
-	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
-		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
+	limited := io.LimitReader(treader, bundle.MaxLayerSize+1)
+	contents, err := io.ReadAll(limited)
+	if err != nil && err != io.EOF {
 		t.Errorf("failed to read tar bundle: %v", err)
 	}
 	return string(contents)


### PR DESCRIPTION
Previously, `readTarLayer` used the tar header's declared size directly in `make([]byte, header.Size)`, allowing a malicious bundle to specify an arbitrarily large size and potentially cause the CLI to exhaust available memory and crash.

Updated `readTarLayer` to use a bounded reader with a 10 MiB maximum layer size, preventing attacker-controlled tar metadata or oversized layer contents from causing excessive memory allocation. Added regression coverage to verify that layers exceeding the maximum size are rejected.

Signed-off-by: Anwesha Palit [apalit@redhat.com]

Assisted-by: Claude Opus 4.6

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
