### PR TITLE
ci: enforce gofmt and docs freshness checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,9 @@ jobs:
         run: |
           gofmt_out=$(gofmt -d $(find * -name '*.go' ! -path 'vendor/*' ! -path 'third_party/*'))
           if [[ -n "$gofmt_out" ]]; then
-              failed=1
+              echo "$gofmt_out"
+              exit 1
           fi
-          echo "$gofmt_out"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -83,6 +83,10 @@ jobs:
         run: |
           go install github.com/google/go-licenses@v1.0.0 # Not sure why it is needed here
           ./hack/verify-codegen.sh
+      - name: docs
+        run: |
+          ./hack/verify-generated.sh
+
   multi-arch-build:
     needs: [build]
     name: Multi-arch build

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that docs and golden files are up to date.
+# Run `make generated` and commit the result if this fails.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+echo "Regenerating docs..."
+make docs
+
+echo "Checking for uncommitted changes in docs..."
+git_status=$(git status --porcelain -- docs/)
+if [[ -n "$git_status" ]]; then
+  echo "$git_status"
+  echo ""
+  echo "ERROR: docs are out of date."
+  echo "Run 'make docs' and commit the result."
+  exit 1
+fi
+
+echo "All generated docs are up to date."


### PR DESCRIPTION
# Changes

Fix a long-standing bug where the `gofmt` CI step set `failed=1` on
formatting violations but never exited with it — this check has been
passing vacuously since the workflow was first introduced.

Add `hack/verify-generated.sh` which runs `make docs` and uses
`git status --porcelain` to detect both modified and newly generated
files in `docs/`. Wire it as a second step inside the existing
`generated` CI job so docs staleness is caught without adding a
separate job.

# Submitter Checklist

- [x] Includes tests (if functionality changed/added)
- [x] Run the code checkers with `make check`
- [x] Regenerate the manpages, docs and go formatting with `make generated`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```